### PR TITLE
Adds namelist and streams file interface

### DIFF
--- a/mpas_analysis/shared/containers.py
+++ b/mpas_analysis/shared/containers.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""
+    Module of custom container data types
+
+    Phillip J. Wolfram
+    10/22/2016
+"""
+
+import collections
+class ReadOnlyDict(collections.Mapping): #{{{
+    """ Read only-dictionary
+    http://stackoverflow.com/questions/19022868/how-to-make-dictionary-read-only-in-python
+    310/22/2016
+    """
+
+    def __init__(self, data):
+        self._data = data
+
+    # overloads [] operator
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __len__(self):
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+#}}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/io/__init__.py
+++ b/mpas_analysis/shared/io/__init__.py
@@ -1,0 +1,1 @@
+from .namelist_streams_interface import NameList, StreamsFile

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python
+"""
+    Module of classes / routines to manipulate fortran namelist and streams
+    files.
+
+    Phillip Wolfram
+    LANL
+    04/24/2014
+"""
+
+from subprocess import check_output, call
+from lxml import etree
+import re
+from ..containers import ReadOnlyDict
+
+def convert_namelist_to_dict(fname, readonly=True):
+    """
+    Converts a namelist file to key-value pairs in dictionary.
+
+    Phillip J Wolfram
+    10/22/2016
+    """
+    # form dictionary
+    nml = dict()
+
+    regex = re.compile(r"^\s*(.*?)\s*=\s*['\"]*(.*?)['\"]*\s*\n")
+    with open(fname) as f:
+        for line in f:
+            match = regex.findall(line)
+            if len(match) > 0:
+                # assumes that there is only one match per line
+                nml[match[0][0]] = match[0][1]
+    if readonly:
+        nml = ReadOnlyDict(nml)
+
+    return nml
+
+
+class NameList:
+    """
+    Class for fortran manipulation of namelist files, provides
+    read and write functionality
+    """
+
+    # constructor
+    def __init__(self, fname):
+        # input file name
+        self.fname = fname
+        # get values
+        self.nml = convert_namelist_to_dict(fname)
+
+    # note following accessors do not do type casting
+    def __getattr__(self, key):
+        """ Accessor for dot noation, e.g., nml.field, returns string """
+        return self.nml[key]
+
+    # provide accessor for dictionary notation (returns string)
+    def __getitem__(self, key):
+        """ Accessor for bracket noation, e.g., nml['field'], returns string """
+        return self.nml[key]
+
+    # provide accessors for get, getint, getfloat, getbool with appropriate
+    # casting for comparable behavior with config files #{{{
+    def get(self, key):
+        return self.nml[key]
+
+    def getint(self, key):
+        return int(self.nml[key])
+
+    def getfloat(self, key):
+        return float(self.nml[key])
+
+    def getbool(self, key):
+        if 'True' in self.nml[key] or 'true' in self.nml[key]:
+            return True
+        else:
+            return False
+    #}}}
+
+
+class StreamsFile:
+    """
+    Class to read in streams configuration file, provdies
+    read and write functionality
+    """
+
+    def __init__(self, fname):
+        self.fname = fname
+        self.xmlfile = etree.parse(fname)
+        self.root = self.xmlfile.getroot()
+
+    def read(self, streamname, attribname):
+        """ name is a list of name entries terminanting in some value
+        """
+        for stream in self.root:
+            # assumes streamname is unique in XML
+            if stream.get('name') == streamname:
+                return stream.get(attribname)
+
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/__init__.py
+++ b/mpas_analysis/test/__init__.py
@@ -1,0 +1,72 @@
+"""
+Unit test infrastructure, adapted from approach of xarray.
+
+Phillip J. Wolfram
+10/07/2016
+"""
+
+import warnings
+from contextlib import contextmanager
+
+import os
+from distutils import dir_util
+from pytest import fixture
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+try:
+    import lxml
+    has_lxml = True
+except ImportError:
+    has_lxml = False
+
+try:
+    import numpy as np
+    has_numpy = True
+except ImportError:
+    has_numpy = False
+
+def requires_lxml(test):
+    return test if has_lxml else unittest.skip('requires lxml')(test)
+
+def requires_numpy(test):
+    return test if has_numpy else unittest.skip('requires numpy')(test)
+
+# Adapted from
+# http://stackoverflow.com/questions/29627341/pytest-where-to-store-expected-data
+@fixture
+def loaddatadir(request, tmpdir):
+    '''
+    Fixture responsible for searching a folder with the same name of test
+    module and, if available, moving all contents to a temporary directory so
+    tests can use them freely.
+    '''
+    filename = request.module.__file__
+    test_dir, _ = os.path.splitext(filename)
+
+    if os.path.isdir(test_dir):
+        dir_util.copy_tree(test_dir, bytes(tmpdir))
+
+    request.cls.datadir = tmpdir
+
+
+class TestCase(unittest.TestCase):
+    def assertEqual(self, a1, a2):
+        assert a1 == a2 or (a1 != a1 and a2 != a2)
+
+    @requires_numpy
+    def assertApproxEqual(self, a1, a2, rtol=1e-5, atol=1e-8):
+        assert np.isclose(a1, a2, rtol=rtol, atol=atol)
+
+    @contextmanager
+    def assertWarns(self, message):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('always', message)
+            yield
+            assert len(w) > 0
+            assert all(message in str(wi.message) for wi in w)
+
+

--- a/mpas_analysis/test/test_namelist_streams_interface.py
+++ b/mpas_analysis/test/test_namelist_streams_interface.py
@@ -1,0 +1,50 @@
+"""
+Unit test infrastructure, adapted from approach of xarray.
+
+Phillip J. Wolfram
+10/07/2016
+"""
+
+import pytest
+from mpas_analysis.test import (TestCase, requires_lxml, loaddatadir)
+from mpas_analysis.shared.io import NameList, StreamsFile
+
+@pytest.mark.usefixtures("loaddatadir")
+class TestNamelist(TestCase):
+    def setup_namelist(self):
+        nlpath = self.datadir.join('namelist.ocean')
+        self.nl = NameList(bytes(nlpath))
+
+    def setup_streams(self):
+        sfpath = self.datadir.join('streams.ocean')
+        self.sf = StreamsFile(bytes(sfpath))
+
+    def test_open_files(self):
+        self.setup_namelist()
+        self.setup_streams()
+
+    def test_read_namelist(self):
+        self.setup_namelist()
+
+        # check accessing generalized function techniques
+        self.assertEqual(self.nl.config_dt, '00:10:00')
+        self.assertEqual(self.nl['config_dt'], '00:10:00')
+
+        # check cast accessors
+        self.assertEqual(self.nl.getint('config_num_halos'), 3)
+        self.assertApproxEqual(self.nl.getfloat('config_min_thickness'), 1.0)
+        self.assertEqual(self.nl.getbool('config_do_restart'), False)
+
+        # tests for use of ' and " for string selections
+        self.assertEqual(self.nl.config_test_extra_equals1, 'a = b')
+        self.assertEqual(self.nl.config_test_extra_equals2, 'a = b')
+
+    def test_read_streamsfile(self):
+        self.setup_streams()
+
+        # check
+        self.assertEqual(self.sf.read('output', 'type'), 'output')
+        self.assertEqual(self.sf.read('restart', 'output_interval'),
+                         '0100_00:00:00')
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_namelist_streams_interface/namelist.ocean
+++ b/mpas_analysis/test/test_namelist_streams_interface/namelist.ocean
@@ -1,0 +1,34 @@
+# note, some entires are not for illustration and not used in MPAS
+&run_modes
+    config_ocean_run_mode = 'forward'
+/
+&time_management
+    config_do_restart = .false.
+    config_restart_timestamp_name = 'Restart_timestamp'
+    config_start_time = '0000-01-01_00:00:00'
+    config_stop_time = 'none'
+    config_run_duration = '1000_00:00:00'
+    config_calendar_type = 'gregorian_noleap'
+/
+&time_integration
+    config_dt = '00:10:00'
+    config_time_integrator = 'split_explicit'
+/
+&decomposition
+    config_num_halos = 3
+    config_block_decomp_file_prefix = 'graph.info.part.'
+    config_number_of_blocks = 0
+    config_explicit_proc_decomp = .false.
+    config_proc_decomp_file_prefix = 'graph.info.part.'
+/
+&ALE_vertical_grid
+    config_vert_coord_movement = 'uniform_stretching'
+    config_use_min_max_thickness = .false.
+    config_min_thickness = 1.0
+    config_max_thickness_factor = 6.0
+    config_set_restingThickness_to_IC = .true.
+    config_dzdk_positive = .false.
+/
+&debug_checking_NOT_REAL
+    config_test_extra_equals1 = 'a = b'
+    config_test_extra_equals2 = "a = b"

--- a/mpas_analysis/test/test_namelist_streams_interface/streams.ocean
+++ b/mpas_analysis/test/test_namelist_streams_interface/streams.ocean
@@ -1,0 +1,72 @@
+<streams>
+<immutable_stream name="mesh"
+                  type="input"
+                  filename_template="mesh.nc"
+                  input_interval="initial_only" />
+
+<immutable_stream name="input"
+                  type="input"
+                  filename_template="init.nc"
+                  input_interval="initial_only" />
+
+<immutable_stream name="restart"
+                  type="input;output"
+                  filename_template="restarts/restart.$Y-$M-$D_$h.$m.$s.nc"
+                  filename_interval="output_interval"
+                  reference_time="0000-01-01_00:00:00"
+                  clobber_mode="truncate"
+                  input_interval="initial_only"
+                  output_interval="0100_00:00:00" />
+
+<stream name="output"
+        type="output"
+        filename_template="output/output.$Y-$M-$D_$h.$m.$s.nc"
+        filename_interval="01-00-00_00:00:00"
+        reference_time="0000-01-01_00:00:00"
+        clobber_mode="truncate"
+        output_interval="0001_00:00:00" >
+
+	<stream name="mesh"/>
+	<var_struct name="tracers"/>
+	<var name="velocityZonal"/>
+	<var name="velocityMeridional"/>
+	<var name="density"/>
+	<var name="divergence"/>
+	<var name="displacedDensity"/>
+	<var name="potentialDensity"/>
+	<var name="boundaryLayerDepth"/>
+	<var name="boundaryLayerDepthEdge"/>
+	<var name="indexBoundaryLayerDepth"/>
+	<var name="indexSurfaceLayerDepth"/>
+	<var name="surfaceFrictionVelocity"/>
+	<var name="windStressZonalDiag"/>
+	<var name="windStressMeridionalDiag"/>
+	<var name="surfaceBuoyancyForcing"/>
+	<var name="seaSurfacePressure"/>
+	<var name="layerThickness"/>
+	<var name="ssh"/>
+	<var name="maxLevelEdgeTop"/>
+	<var name="vertCoordMovementWeights"/>
+	<var name="edgeMask"/>
+	<var name="vertexMask"/>
+	<var name="cellMask"/>
+	<var name="refZMid"/>
+	<var name="refLayerThickness"/>
+	<var name="xtime"/>
+	<var name="zMid"/>
+	<var name="zTop"/>
+	<var name="kineticEnergyCell"/>
+	<var name="relativeVorticityCell"/>
+	<var name="areaCellGlobal"/>
+	<var name="areaEdgeGlobal"/>
+	<var name="areaTriangleGlobal"/>
+	<var name="volumeCellGlobal"/>
+	<var name="volumeEdgeGlobal"/>
+	<var name="CFLNumberGlobal"/>
+	<var name="windStressZonal"/>
+	<var name="windStressMeridional"/>
+	<var_struct name="tracersSurfaceRestoringFields"/>
+	<var_struct name="tracersInteriorRestoringFields"/>
+</stream>
+
+</streams>


### PR DESCRIPTION
This is a prototype reader / writer for interfacing with namelist and streams and this will ultimately be needed to support generalization identified in #20. 

A list of preliminary features (included or could be included):
- [X] Read-only status for the classes which build the reader/writer namelist and streams objects
- [x] Pure-python implementation that does not require use of command line tools, e.g., awk or sed and calls to the shell.
- [x] Type conversion, especially for things like numbers, times, and logic
