### PR TITLE
Fix getWithDefault in MPASAnalysisConfigParser

### DIFF
--- a/mpas_analysis/configuration/MpasAnalysisConfigParser.py
+++ b/mpas_analysis/configuration/MpasAnalysisConfigParser.py
@@ -26,7 +26,7 @@ class MpasAnalysisConfigParser(ConfigParser):
         if isinstance(default, list):
             self.setlist(section, option, default)
         else:
-            return self.get(section, option, str(default))
+            self.set(section, option, str(default))
         return default
 
     def getlist(self, section, option, listType=str):


### PR DESCRIPTION
If a default is provided, the getWithDefault method now correctly
sets the value of the option to the default, rather than trying
to get the value.