### PR TITLE
Fix time-series scripts use time bounds properly

### DIFF
--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -11,12 +11,14 @@ from ..shared.plot.plotting import timeseries_analysis_plot
 
 from ..shared.io import NameList, StreamsFile
 
+from ..shared.timekeeping.Date import Date
+
 def ohc_timeseries(config):
     """
     Performs analysis of ocean heat content (OHC) from time-series output.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 11/25/2016
+    Last Modified: 11/28/2016
     """
 
     # read parameters from config file
@@ -50,8 +52,6 @@ def ohc_timeseries(config):
     plots_dir = config.get('paths','plots_dir')
 
     yr_offset = config.getint('time','yr_offset')
-    timeseries_yr1 = yr_offset + config.getint('time', 'timeseries_yr1')
-    timeseries_yr2 = yr_offset + config.getint('time', 'timeseries_yr2')
 
     N_movavg = config.getint('ohc_timeseries','N_movavg')
 
@@ -90,14 +90,17 @@ def ohc_timeseries(config):
 
     ds = remove_repeated_time_index(ds)
 
+    # convert the start and end dates to datetime objects using
+    # the Date class, which ensures the results are within the
+    # supported range
+    time_start = Date(startDate).to_datetime(yr_offset)
+    time_end = Date(endDate).to_datetime(yr_offset)
     # select only the data in the specified range of years
-    # time_start = datetime.datetime(timeseries_yr1, 1, 1)
-    # time_end = datetime.datetime(timeseries_yr2, 12, 31)
-    # ds = ds.sel(Time=slice(time_start, time_end))
+    ds = ds.sel(Time=slice(time_start, time_end))
 
     # Select year-1 data and average it (for later computing anomalies)
-    time_start = datetime.datetime(timeseries_yr1, 1, 1)
-    time_end = datetime.datetime(timeseries_yr1, 12, 31)
+    time_start = datetime.datetime(time_start.year, 1, 1)
+    time_end = datetime.datetime(time_start.year, 12, 31)
     ds_yr1 = ds.sel(Time=slice(time_start,time_end))
     mean_yr1 = ds_yr1.mean('Time')
 

--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -9,13 +9,15 @@ from ..shared.plot.plotting import timeseries_analysis_plot
 
 from ..shared.io import StreamsFile
 
+from ..shared.timekeeping.Date import Date
+
 def sst_timeseries(config):
     """
     Performs analysis of the time-series output of sea-surface temperature
     (SST).
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 10/27/2016
+    Last Modified: 11/28/2016
     """
     # Define/read in general variables
     print "  Load SST data..."
@@ -54,6 +56,14 @@ def sst_timeseries(config):
                                            timestr=['xtime_start', 'xtime_end'],
                                            onlyvars=['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']))
     ds = remove_repeated_time_index(ds)
+
+    # convert the start and end dates to datetime objects using
+    # the Date class, which ensures the results are within the
+    # supported range
+    time_start = Date(startDate).to_datetime(yr_offset)
+    time_end = Date(endDate).to_datetime(yr_offset)
+    # select only the data in the specified range of years
+    ds = ds.sel(Time=slice(time_start, time_end))
 
     SSTregions = ds.time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature
 

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -11,12 +11,14 @@ from ..shared.plot.plotting  import timeseries_analysis_plot
 from ..shared.io import StreamsFile
 from ..shared.io.utility import paths
 
+from ..shared.timekeeping.Date import Date
+
 def seaice_timeseries(config):
     """
     Performs analysis of time series of sea-ice properties.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 10/27/2016
+    Last Modified: 11/28/2016
     """
 
     # read parameters from config file
@@ -78,6 +80,14 @@ def seaice_timeseries(config):
                                            onlyvars=['timeSeriesStatsMonthly_avg_iceAreaCell_1',
                                                      'timeSeriesStatsMonthly_avg_iceVolumeCell_1']))
     ds = remove_repeated_time_index(ds)
+
+    # convert the start and end dates to datetime objects using
+    # the Date class, which ensures the results are within the
+    # supported range
+    time_start = Date(startDate).to_datetime(yr_offset)
+    time_end = Date(endDate).to_datetime(yr_offset)
+    # select only the data in the specified range of years
+    ds = ds.sel(Time=slice(time_start, time_end))
 
     ds = ds.merge(dsmesh)
 

--- a/mpas_analysis/test/test_date.py
+++ b/mpas_analysis/test/test_date.py
@@ -6,6 +6,7 @@ Xylar Asay-Davis
 """
 
 import pytest
+import datetime
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.timekeeping.Date import Date
 
@@ -118,5 +119,37 @@ class TestDate(TestCase):
         diff = date1-date2
         self.assertEqual(diff, Date(dateString='1995-12-26', isInterval=False))
 
+        date = Date(dateString='1996-01-15', isInterval=False)
+        datetime1 = date.to_datetime(yearOffset=0)
+        datetime2 = datetime.datetime(year=1996, month=1, day=15)
+        self.assertEqual(datetime1, datetime2)
+
+        date = Date(dateString='0000-00-20', isInterval=True)
+        timedelta1 = date.to_timedelta()
+        timedelta2 = datetime.timedelta(days=20)
+        self.assertEqual(timedelta1, timedelta2)
+
+        # since pandas and xarray use the numpy type 'datetime[ns]`, which
+        # has a limited range of dates, the date 0001-01-01 gets increased to
+        # the minimum allowed year boundary, 1678-01-01 to avoid invalid
+        # dates.
+        date = Date(dateString='0001-01-01', isInterval=False)
+        datetime1 = date.to_datetime(yearOffset=0)
+        datetime2 = datetime.datetime(year=1678, month=1, day=1)
+        self.assertEqual(datetime1, datetime2)
+
+        date = Date(dateString='0001-01-01', isInterval=False)
+        datetime1 = date.to_datetime(yearOffset=1849)
+        datetime2 = datetime.datetime(year=1850, month=1, day=1)
+        self.assertEqual(datetime1, datetime2)
+
+        # since pandas and xarray use the numpy type 'datetime[ns]`, which
+        # has a limited range of dates, the date 9999-01-01 gets decreased to
+        # the maximum allowed year boundary, 2262-01-01 to avoid invalid
+        # dates.
+        date = Date(dateString='9999-01-01', isInterval=False)
+        datetime1 = date.to_datetime(yearOffset=0)
+        datetime2 = datetime.datetime(year=2262, month=1, day=1)
+        self.assertEqual(datetime1, datetime2)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
This merge updates the 3 time-series analysis scripts to make use
of the time series start and end dates, computed via `timeseries_yr1`
and `timeseries_yr2`, allowing analysis of a subset of the output
data.

To accomplish this, this merge adds the method `to_datetime` to 
the `Date` class. This method can be used (optionally with an offset
year) to convert a Date to a datetime object.  The date is
clamped to  the valid range supported by numpy's datetime64[ns], 
used by xarray and pandas.