### PR TITLE
Map variables and streams from MPAS dycore names to MPAS-Analysis names

### DIFF
--- a/mpas_analysis/ocean/ocean_modelvsobs.py
+++ b/mpas_analysis/ocean/ocean_modelvsobs.py
@@ -29,6 +29,12 @@ def ocn_modelvsobs(config, field, streamMap=None, variableMap=None):
     """
     Plots a comparison of ACME/MPAS output to SST or MLD observations
 
+    config is an instance of MpasAnalysisConfigParser containing configuration
+    options.
+
+    field is the name of a field to be analyize (currently one of 'mld' or
+    'sst')
+
     If present, streamMap is a dictionary of MPAS-O stream names that map to
     their mpas_analysis counterparts.
 
@@ -36,10 +42,8 @@ def ocn_modelvsobs(config, field, streamMap=None, variableMap=None):
     to their mpas_analysis counterparts.
 
     Authors: Luke Van Roekel, Milena Veneziani, Xylar Asay-Davis
-    Modified: 12/07/2016
+    Modified: 12/08/2016
     """
-
-    field = field.lower()
 
     # read parameters from config file
     indir = config.get('paths', 'archive_dir_ocn')
@@ -57,14 +61,14 @@ def ocn_modelvsobs(config, field, streamMap=None, variableMap=None):
     print 'Reading files {} through {}'.format(infiles[0], infiles[-1])
 
     plots_dir = config.get('paths', 'plots_dir')
-    obsdir = config.get('paths', 'obs_' + field.lower() + 'dir')
+    obsdir = config.get('paths', 'obs_' + field + 'dir')
     casename = config.get('case', 'casename')
     meshfile = config.get('data', 'mpas_meshfile')
     climo_yr1 = config.getint('time', 'climo_yr1')
     climo_yr2 = config.getint('time', 'climo_yr2')
     yr_offset = config.getint('time', 'yr_offset')
 
-    outputTimes = config.getExpression(field.lower() + '_modelvsobs',
+    outputTimes = config.getExpression(field + '_modelvsobs',
                                        'comparisonTimes')
 
     f = netcdf_dataset(meshfile, mode='r')
@@ -187,14 +191,14 @@ def ocn_modelvsobs(config, field, streamMap=None, variableMap=None):
             obsdata = dsData.sel(month=monthsvalue)[obsFieldName].values
         else:
 
-            modeldata = np.sum(
+            modeldata = (np.sum(
                 constants.dinmonth[monthsvalue-1] *
-                monthly_clim.sel(month=monthsvalue)[field].values.T,
-                axis=1) / np.sum(constants.dinmonth[monthsvalue-1])
-            obsdata = np.nansum(
+                monthly_clim.sel(month=monthsvalue)[field].values.T, axis=1) /
+                np.sum(constants.dinmonth[monthsvalue-1]))
+            obsdata = (np.nansum(
                 daysarray[monthsvalue-1, :, :] *
-                dsData.sel(month=monthsvalue)[obsFieldName].values,
-                axis=0) / np.nansum(daysarray[monthsvalue-1, :, :], axis=0)
+                dsData.sel(month=monthsvalue)[obsFieldName].values, axis=0) /
+                np.nansum(daysarray[monthsvalue-1, :, :], axis=0))
 
         modelOutput[i, :, :] = interp_fields(modeldata, d2, inds2, lonTarg)
         observations[i, :, :] = interp_fields(obsdata.flatten(), d, inds,

--- a/mpas_analysis/ocean/ocean_modelvsobs.py
+++ b/mpas_analysis/ocean/ocean_modelvsobs.py
@@ -139,7 +139,7 @@ def ocn_modelvsobs(config, field, streamMap=None, variableMap=None):
                                              timestr='Time',
                                              onlyvars=varList,
                                              selvals=selvals,
-                                             variable_map=variableMap))
+                                             varmap=variableMap))
     ds = remove_repeated_time_index(ds)
 
     time_start = datetime.datetime(yr_offset+climo_yr1, 1, 1)

--- a/mpas_analysis/ocean/ocean_modelvsobs.py
+++ b/mpas_analysis/ocean/ocean_modelvsobs.py
@@ -3,8 +3,8 @@
 General comparison of 2-d model fields against data.  Currently only supports
 mixed layer depths (mld) and sea surface temperature (sst)
 
-Author: Luke Van Roekel, Milena Veneziani
-Last Modified: 10/24/2016
+Author: Luke Van Roekel, Milena Veneziani, Xylar Asay-Davis
+Last Modified: 12/06/2016
 """
 
 import matplotlib.pyplot as plt
@@ -14,23 +14,32 @@ import numpy as np
 import xarray as xr
 import datetime
 from netCDF4 import Dataset as netcdf_dataset
-import os.path
 
-from ..shared.mpas_xarray.mpas_xarray import preprocess_mpas, remove_repeated_time_index
+from ..shared.mpas_xarray.mpas_xarray import preprocess_mpas, \
+    remove_repeated_time_index
 from ..shared.plot.plotting import plot_global_comparison
 from ..shared.interpolation.interpolate import interp_fields, init_tree
 from ..shared.constants import constants
 
 from ..shared.io import StreamsFile
 
-def ocn_modelvsobs(config, field):
+
+def ocn_modelvsobs(config, field, streamMap=None, variableMap=None):
 
     """
     Plots a comparison of ACME/MPAS output to SST or MLD observations
 
+    If present, streamMap is a dictionary of MPAS-O stream names that map to
+    their mpas_analysis counterparts.
+
+    If present, variableMap is a dictionary of MPAS-O variable names that map
+    to their mpas_analysis counterparts.
+
     Authors: Luke Van Roekel, Milena Veneziani, Xylar Asay-Davis
-    Modified: 10/27/2016
+    Modified: 12/07/2016
     """
+
+    field = field.lower()
 
     # read parameters from config file
     indir = config.get('paths', 'archive_dir_ocn')
@@ -42,9 +51,10 @@ def ocn_modelvsobs(config, field):
     # reading only those that are between the start and end dates
     startDate = config.get('time', 'climo_start_date')
     endDate = config.get('time', 'climo_end_date')
-    infiles = streams.readpath('timeSeriesStatsOutput',
-                               startDate=startDate, endDate=endDate)
-    print 'Reading files {} through {}'.format(infiles[0],infiles[-1])
+    streamName = streams.find_stream(streamMap['timeSeriesStats'])
+    infiles = streams.readpath(streamName, startDate=startDate,
+                               endDate=endDate)
+    print 'Reading files {} through {}'.format(infiles[0], infiles[-1])
 
     plots_dir = config.get('paths', 'plots_dir')
     obsdir = config.get('paths', 'obs_' + field.lower() + 'dir')
@@ -57,55 +67,46 @@ def ocn_modelvsobs(config, field):
     outputTimes = config.getExpression(field.lower() + '_modelvsobs',
                                        'comparisonTimes')
 
-    f = netcdf_dataset(meshfile,mode='r')
+    f = netcdf_dataset(meshfile, mode='r')
     lonCell = f.variables["lonCell"][:]
     latCell = f.variables["latCell"][:]
 
-    if field.lower() == 'mld':
-        obs_filename = "%s/holtetalley_mld_climatology.nc" % obsdir
+    varList = [field]
 
-        ds = xr.open_mfdataset(infiles, preprocess=lambda x: 
-                               preprocess_mpas(x, yearoffset=yr_offset,
-                                               timestr=['xtime_start', 'xtime_end'],
-                                               onlyvars=['time_avg_dThreshMLD']))
-        ds = remove_repeated_time_index(ds)
-        ds.rename({'time_avg_dThreshMLD':'mpasData'}, inplace = True)
+    if field == 'mld':
 
-        #Load MLD observational data
+        selvals = None
+
+        # Load MLD observational data
+        obs_filename = "{}/holtetalley_mld_climatology.nc".format(obsdir)
         dsData = xr.open_mfdataset(obs_filename)
 
-        #Increment month value to be consistent with the model output
+        # Increment month value to be consistent with the model output
         dsData.iMONTH.values += 1
 
-        #Rename the time dimension to be consistent with the SST dataset
-        dsData.rename({'month':'calmonth'}, inplace = True)
-        dsData.rename({'iMONTH':'month'}, inplace = True)
+        # Rename the time dimension to be consistent with the SST dataset
+        dsData.rename({'month': 'calmonth'}, inplace=True)
+        dsData.rename({'iMONTH': 'month'}, inplace=True)
 
-        #rename appropriate observational data for compactness
-        dsData.rename({'mld_dt_mean':'observationData'}, inplace = True)
+        obsFieldName = 'mld_dt_mean'
 
-        #Reorder dataset for consistence
+        # Reorder dataset for consistence
         dsData = dsData.transpose('month', 'iLON', 'iLAT')
 
-        #Set appropriate MLD figure labels
+        # Set appropriate MLD figure labels
         obsTitleLabel = "Observations (HolteTalley density threshold MLD)"
         fileOutLabel = "mldHolteTalleyARGO"
         unitsLabel = 'm'
 
-    elif field.lower() == 'sst':
+    elif field == 'sst':
 
-        ds = xr.open_mfdataset(infiles, preprocess=lambda x: 
-                               preprocess_mpas(x, yearoffset=yr_offset,
-                                               timestr=['xtime_start', 'xtime_end'],
-		                               onlyvars=['time_avg_activeTracers_temperature'],
-		                               selvals={'nVertLevels':0}))
-        ds = remove_repeated_time_index(ds)
-        ds.rename({'time_avg_activeTracers_temperature':'mpasData'}, inplace = True)
+        selvals = {'nVertLevels': 0}
 
-        obs_filename = "%s/MODEL.SST.HAD187001-198110.OI198111-201203.nc" % obsdir
+        obs_filename = \
+            "{}/MODEL.SST.HAD187001-198110.OI198111-201203.nc".format(obsdir)
         dsData = xr.open_mfdataset(obs_filename)
-        #Select years for averaging (pre-industrial or present-day)
-        #This seems fragile as definitions can change
+        # Select years for averaging (pre-industrial or present-day)
+        # This seems fragile as definitions can change
         if yr_offset < 1900:
             time_start = datetime.datetime(1870, 1, 1)
             time_end = datetime.datetime(1900, 12, 31)
@@ -118,14 +119,24 @@ def ocn_modelvsobs(config, field):
         ds_tslice = dsData.sel(time=slice(time_start, time_end))
         monthly_clim_data = ds_tslice.groupby('time.month').mean('time')
 
-        #Rename the observation data for code compactness
+        # Rename the observation data for code compactness
         dsData = monthly_clim_data.transpose('month', 'lon', 'lat')
-        dsData.rename({'SST':'observationData'}, inplace = True)
+        obsFieldName = 'SST'
 
-        #Set appropriate figure labels for SST
-        obsTitleLabel = "Observations (Hadley/OI, %s)" % preIndustrial_txt
+        # Set appropriate figure labels for SST
+        obsTitleLabel = \
+            "Observations (Hadley/OI, {})".format(preIndustrial_txt)
         fileOutLabel = "sstHADOI"
         unitsLabel = r'$^o$C'
+
+    ds = xr.open_mfdataset(
+        infiles,
+        preprocess=lambda x: preprocess_mpas(x, yearoffset=yr_offset,
+                                             timestr='Time',
+                                             onlyvars=varList,
+                                             selvals=selvals,
+                                             variable_map=variableMap))
+    ds = remove_repeated_time_index(ds)
 
     time_start = datetime.datetime(yr_offset+climo_yr1, 1, 1)
     time_end = datetime.datetime(yr_offset+climo_yr2, 12, 31)
@@ -136,21 +147,30 @@ def ocn_modelvsobs(config, field):
     latData = latData.flatten()
     lonData = lonData.flatten()
 
-    daysarray = np.ones((12, dsData.observationData.values.shape[1], dsData.observationData.values.shape[2]))
+    daysarray = np.ones((12, dsData[obsFieldName].values.shape[1],
+                         dsData[obsFieldName].values.shape[2]))
 
     for i, dval in enumerate(constants.dinmonth):
         daysarray[i, :, :] = dval
-        inds = np.where(np.isnan(dsData.observationData[i, :, :].values))
+        inds = np.where(np.isnan(dsData[obsFieldName][i, :, :].values))
         daysarray[i, inds[0], inds[1]] = np.NaN
 
-
     # initialize interpolation variables
-    d2, inds2, lonTarg, latTarg = init_tree(np.rad2deg(lonCell), np.rad2deg(latCell), constants.lonmin,
-                                            constants.lonmax, constants.latmin, constants.latmax,
-                                            constants.dLongitude, constants.dLatitude)
-    d, inds, lonTargD, latTargD = init_tree(lonData, latData, constants.lonmin, constants.lonmax,
-								constants.latmin, constants.latmax, constants.dLongitude,
-								constants.dLatitude)
+    d2, inds2, lonTarg, latTarg = init_tree(np.rad2deg(lonCell),
+                                            np.rad2deg(latCell),
+                                            constants.lonmin,
+                                            constants.lonmax,
+                                            constants.latmin,
+                                            constants.latmax,
+                                            constants.dLongitude,
+                                            constants.dLatitude)
+    d, inds, lonTargD, latTargD = init_tree(lonData, latData,
+                                            constants.lonmin,
+                                            constants.lonmax,
+                                            constants.latmin,
+                                            constants.latmax,
+                                            constants.dLongitude,
+                                            constants.dLatitude)
     nLon = lonTarg.shape[0]
     nLat = lonTarg.shape[1]
 
@@ -163,50 +183,59 @@ def ocn_modelvsobs(config, field):
         monthsvalue = constants.monthdictionary[timestring]
 
         if isinstance(monthsvalue, (int, long)):
-            modeldata = monthly_clim.sel(month=monthsvalue).mpasData.values
-            obsdata = dsData.sel(month = monthsvalue).observationData.values
+            modeldata = monthly_clim.sel(month=monthsvalue)[field].values
+            obsdata = dsData.sel(month=monthsvalue)[obsFieldName].values
         else:
-            modeldata = np.sum(constants.dinmonth[monthsvalue-1]*monthly_clim.sel(month=monthsvalue).
-        		               mpasData.values.T, axis=1) / np.sum(constants.dinmonth[monthsvalue-1])
-            obsdata = np.nansum(daysarray[monthsvalue-1, :, :]*dsData.sel(month = monthsvalue).
-                                observationData.values, axis=0) / np.nansum(daysarray[monthsvalue-1, :, :],
-                                axis=0)
+
+            modeldata = np.sum(
+                constants.dinmonth[monthsvalue-1] *
+                monthly_clim.sel(month=monthsvalue)[field].values.T,
+                axis=1) / np.sum(constants.dinmonth[monthsvalue-1])
+            obsdata = np.nansum(
+                daysarray[monthsvalue-1, :, :] *
+                dsData.sel(month=monthsvalue)[obsFieldName].values,
+                axis=0) / np.nansum(daysarray[monthsvalue-1, :, :], axis=0)
 
         modelOutput[i, :, :] = interp_fields(modeldata, d2, inds2, lonTarg)
-        observations[i, :, :] = interp_fields(obsdata.flatten(), d, inds, lonTargD)
+        observations[i, :, :] = interp_fields(obsdata.flatten(), d, inds,
+                                              lonTargD)
 
     for i in range(len(outputTimes)):
         bias[i, :, :] = modelOutput[i, :, :] - observations[i, :, :]
 
-    clevsModelObs = config.getExpression(field.lower() + '_modelvsobs',
+    clevsModelObs = config.getExpression(field + '_modelvsobs',
                                          'clevsModelObs')
-    cmap = plt.get_cmap(config.get(field.lower() + '_modelvsobs',
+    cmap = plt.get_cmap(config.get(field + '_modelvsobs',
                                    'cmapModelObs'))
-    cmapIndices = config.getExpression(field.lower() + '_modelvsobs',
+    cmapIndices = config.getExpression(field + '_modelvsobs',
                                        'cmapIndicesModelObs')
     cmapModelObs = cols.ListedColormap(cmap(cmapIndices), "cmapModelObs")
-    clevsDiff = config.getExpression(field.lower() + '_modelvsobs',
+    clevsDiff = config.getExpression(field + '_modelvsobs',
                                      'clevsDiff')
-    cmap = plt.get_cmap(config.get(field.lower() + '_modelvsobs', 'cmapDiff'))
-    cmapIndices = config.getExpression(field.lower() + '_modelvsobs',
+    cmap = plt.get_cmap(config.get(field + '_modelvsobs', 'cmapDiff'))
+    cmapIndices = config.getExpression(field + '_modelvsobs',
                                        'cmapIndicesDiff')
     cmapDiff = cols.ListedColormap(cmap(cmapIndices), "cmapDiff")
 
     for i in range(len(outputTimes)):
+        fileout = "{}/{}_{}_{}_years{:04d}-{:04d}.png".format(
+            plots_dir, fileOutLabel, casename, outputTimes[i], climo_yr1,
+            climo_yr2)
+        title = "{} ({}, years {:04d}-{:04d})".format(
+            field.upper(), outputTimes[i], climo_yr1, climo_yr2)
         plot_global_comparison(config,
                                lonTarg,
                                latTarg,
                                modelOutput[i, :, :],
                                observations[i, :, :],
-                               bias[i, :,:],
+                               bias[i, :, :],
                                cmapModelObs,
                                clevsModelObs,
                                cmapDiff,
                                clevsDiff,
-                               fileout = "%s/%s_%s_%s_years%04d-%04d.png" % (plots_dir, fileOutLabel,
-				                                casename, outputTimes[i], climo_yr1, climo_yr2),
-                               title = "%s (%s, years %04d-%04d)" % (field.upper(), outputTimes[i], climo_yr1, climo_yr2),
-                               modelTitle = "%s" % casename,
-                               obsTitle = obsTitleLabel,
-                               diffTitle = "Model-Observations",
-                               cbarlabel = unitsLabel)
+                               fileout=fileout,
+                               title=title,
+                               modelTitle="{}".format(casename),
+                               obsTitle=obsTitleLabel,
+                               diffTitle="Model-Observations",
+                               cbarlabel=unitsLabel)

--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -100,7 +100,7 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
                                              yearoffset=yr_offset,
                                              timestr='Time',
                                              onlyvars=varList,
-                                             variable_map=variableMap))
+                                             varmap=variableMap))
 
     ds = remove_repeated_time_index(ds)
 

--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -20,6 +20,9 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
     config is an instance of an MpasAnalysisConfigParser containing
     configuration options.
 
+    config is an instance of MpasAnalysisConfigParser containing configuration
+    options.
+
     If present, streamMap is a dictionary of MPAS-O stream names that map to
     their mpas_analysis counterparts.
 

--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -3,9 +3,9 @@ from netCDF4 import Dataset as netcdf_dataset
 import xarray as xr
 import pandas as pd
 import datetime
-import os.path
 
-from ..shared.mpas_xarray.mpas_xarray import preprocess_mpas, remove_repeated_time_index
+from ..shared.mpas_xarray.mpas_xarray import preprocess_mpas, \
+    remove_repeated_time_index
 
 from ..shared.plot.plotting import timeseries_analysis_plot
 
@@ -13,12 +13,21 @@ from ..shared.io import NameList, StreamsFile
 
 from ..shared.timekeeping.Date import Date
 
-def ohc_timeseries(config):
+
+def ohc_timeseries(config, streamMap=None, variableMap=None):
     """
     Performs analysis of ocean heat content (OHC) from time-series output.
+    config is an instance of an MpasAnalysisConfigParser containing
+    configuration options.
+
+    If present, streamMap is a dictionary of MPAS-O stream names that map to
+    their mpas_analysis counterparts.
+
+    If present, variableMap is a dictionary of MPAS-O variable names that map
+    to their mpas_analysis counterparts.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 11/28/2016
+    Last Modified: 12/04/2016
     """
 
     # read parameters from config file
@@ -39,21 +48,22 @@ def ohc_timeseries(config):
     # reading only those that are between the start and end dates
     startDate = config.get('time', 'timeseries_start_date')
     endDate = config.get('time', 'timeseries_end_date')
-    infiles = streams.readpath('timeSeriesStatsOutput',
-                               startDate=startDate, endDate=endDate)
-    print 'Reading files {} through {}'.format(infiles[0],infiles[-1])
+    streamName = streams.find_stream(streamMap['timeSeriesStats'])
+    infiles = streams.readpath(streamName, startDate=startDate,
+                               endDate=endDate)
+    print 'Reading files {} through {}'.format(infiles[0], infiles[-1])
 
-    casename = config.get('case','casename')
-    ref_casename_v0 = config.get('case','ref_casename_v0')
-    indir_v0data = config.get('paths','ref_archive_v0_ocndir')
+    casename = config.get('case', 'casename')
+    ref_casename_v0 = config.get('case', 'ref_casename_v0')
+    indir_v0data = config.get('paths', 'ref_archive_v0_ocndir')
 
-    compare_with_obs = config.getboolean('ohc_timeseries','compare_with_obs')
+    compare_with_obs = config.getboolean('ohc_timeseries', 'compare_with_obs')
 
-    plots_dir = config.get('paths','plots_dir')
+    plots_dir = config.get('paths', 'plots_dir')
 
-    yr_offset = config.getint('time','yr_offset')
+    yr_offset = config.getint('time', 'yr_offset')
 
-    N_movavg = config.getint('ohc_timeseries','N_movavg')
+    N_movavg = config.getint('ohc_timeseries', 'N_movavg')
 
     regions = config.getExpression('regions', 'regions')
     plot_titles = config.getExpression('regions', 'plot_titles')
@@ -61,32 +71,33 @@ def ohc_timeseries(config):
 
     # Define/read in general variables
     print "  Read in depth and compute specific depth indexes..."
-    f = netcdf_dataset(inputfile,mode='r')
+    f = netcdf_dataset(inputfile, mode='r')
     # reference depth [m]
     depth = f.variables["refBottomDepth"][:]
     # specific heat [J/(kg*degC)]
     cp = namelist.getfloat('config_specific_heat_sea_water')
     # [kg/m3]
     rho = namelist.getfloat('config_density0')
-    fac = 1e-22*rho*cp;
+    fac = 1e-22*rho*cp
 
-    k700m = np.where(depth>700.)[0][0]-1
-    k2000m = np.where(depth>2000.)[0][0]-1
+    k700m = np.where(depth > 700.)[0][0] - 1
+    k2000m = np.where(depth > 2000.)[0][0] - 1
 
     kbtm = len(depth)-1
 
     # Load data
     print "  Load ocean data..."
-    varList = ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
-               'time_avg_avgValueWithinOceanLayerRegion_sumLayerMaskValue',
-               'time_avg_avgValueWithinOceanLayerRegion_avgLayerArea',
-               'time_avg_avgValueWithinOceanLayerRegion_avgLayerThickness']
-    ds = xr.open_mfdataset(infiles,
-                           preprocess=lambda x:
-                           preprocess_mpas(x,
-                                           yearoffset=yr_offset,
-                                           timestr=['xtime_start','xtime_end'],
-                                           onlyvars=varList))
+    varList = ['avgLayerTemperature',
+               'sumLayerMaskValue',
+               'avgLayerArea',
+               'avgLayerThickness']
+    ds = xr.open_mfdataset(
+        infiles,
+        preprocess=lambda x: preprocess_mpas(x,
+                                             yearoffset=yr_offset,
+                                             timestr='Time',
+                                             onlyvars=varList,
+                                             variable_map=variableMap))
 
     ds = remove_repeated_time_index(ds)
 
@@ -101,78 +112,89 @@ def ohc_timeseries(config):
     # Select year-1 data and average it (for later computing anomalies)
     time_start = datetime.datetime(time_start.year, 1, 1)
     time_end = datetime.datetime(time_start.year, 12, 31)
-    ds_yr1 = ds.sel(Time=slice(time_start,time_end))
+    ds_yr1 = ds.sel(Time=slice(time_start, time_end))
     mean_yr1 = ds_yr1.mean('Time')
 
-
     print "  Compute temperature anomalies..."
-    avgLayerTemperature = ds.time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature
-    avgLayerTemperature_yr1 = mean_yr1.time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature
+    avgLayerTemperature = ds.avgLayerTemperature
+    avgLayerTemperature_yr1 = mean_yr1.avgLayerTemperature
 
     avgLayTemp_anomaly = avgLayerTemperature - avgLayerTemperature_yr1
 
     year_start = (pd.to_datetime(ds.Time.min().values)).year
-    year_end   = (pd.to_datetime(ds.Time.max().values)).year
-    time_start = datetime.datetime(year_start,1,1)
-    time_end   = datetime.datetime(year_end,12,31)
+    year_end = (pd.to_datetime(ds.Time.max().values)).year
+    time_start = datetime.datetime(year_start, 1, 1)
+    time_end = datetime.datetime(year_end, 12, 31)
 
     if ref_casename_v0 != "None":
         print "  Load in OHC for ACMEv0 case..."
-        infiles_v0data = "".join([indir_v0data,'/OHC.',ref_casename_v0,'.year*.nc'])
-        ds_v0 = xr.open_mfdataset(infiles_v0data, preprocess=lambda x:
-                                  preprocess_mpas(x, yearoffset=yr_offset))
+        infiles_v0data = "{}/OHC.{}.year*.nc".format(
+            indir_v0data, ref_casename_v0)
+        ds_v0 = xr.open_mfdataset(
+            infiles_v0data,
+            preprocess=lambda x: preprocess_mpas(x, yearoffset=yr_offset))
         ds_v0 = remove_repeated_time_index(ds_v0)
-        ds_v0_tslice = ds_v0.sel(Time=slice(time_start,time_end))
+        ds_v0_tslice = ds_v0.sel(Time=slice(time_start, time_end))
 
-    sumLayerMaskValue = ds.time_avg_avgValueWithinOceanLayerRegion_sumLayerMaskValue
-    avgLayerArea = ds.time_avg_avgValueWithinOceanLayerRegion_avgLayerArea
-    avgLayerThickness = ds.time_avg_avgValueWithinOceanLayerRegion_avgLayerThickness
+    sumLayerMaskValue = ds.sumLayerMaskValue
+    avgLayerArea = ds.avgLayerArea
+    avgLayerThickness = ds.avgLayerThickness
 
     print "  Compute OHC and make plots..."
     for index in range(len(iregions)):
         iregion = iregions[index]
 
         # Compute volume of each layer in the region:
-        layerArea = sumLayerMaskValue[:,iregion,:] * avgLayerArea[:,iregion,:]
-        layerVolume = layerArea * avgLayerThickness[:,iregion,:]
+        layerArea = sumLayerMaskValue[:, iregion, :] * \
+            avgLayerArea[:, iregion, :]
+        layerVolume = layerArea * avgLayerThickness[:, iregion, :]
 
         # Compute OHC:
-        ohc = layerVolume * avgLayTemp_anomaly[:,iregion,:]
+        ohc = layerVolume * avgLayTemp_anomaly[:, iregion, :]
         # OHC over 0-bottom depth range:
         ohc_tot = ohc.sum('nVertLevels')
         ohc_tot = fac*ohc_tot
 
         # OHC over 0-700m depth range:
-        ohc_700m = fac*ohc[:,0:k700m].sum('nVertLevels')
+        ohc_700m = fac*ohc[:, 0:k700m].sum('nVertLevels')
 
         # OHC over 700m-2000m depth range:
-        ohc_2000m = fac*ohc[:,k700m+1:k2000m].sum('nVertLevels')
+        ohc_2000m = fac*ohc[:, k700m+1:k2000m].sum('nVertLevels')
 
         # OHC over 2000m-bottom depth range:
-        ohc_btm = ohc[:,k2000m+1:kbtm].sum('nVertLevels')
+        ohc_btm = ohc[:, k2000m+1:kbtm].sum('nVertLevels')
         ohc_btm = fac*ohc_btm
 
-        title = 'OHC, %s, 0-bottom (thick-), 0-700m (thin-), 700-2000m (--), 2000m-bottom (-.) \n %s'%(plot_titles[iregion], casename)
+        title = 'OHC, {}, 0-bottom (thick-), 0-700m (thin-), 700-2000m (--),' \
+            ' 2000m-bottom (-.) \n {}'.format(plot_titles[iregion], casename)
 
         xlabel = "Time [years]"
         ylabel = "[x$10^{22}$ J]"
 
         if ref_casename_v0 != "None":
-            figname = "%s/ohc_%s_%s_%s.png" % (plots_dir,regions[iregion],casename,ref_casename_v0)
+            figname = "{}/ohc_{}_{}_{}.png".format(plots_dir,
+                                                   regions[iregion],
+                                                   casename,
+                                                   ref_casename_v0)
             ohc_v0_tot = ds_v0_tslice.ohc_tot
             ohc_v0_700m = ds_v0_tslice.ohc_700m
             ohc_v0_2000m = ds_v0_tslice.ohc_2000m
             ohc_v0_btm = ds_v0_tslice.ohc_btm
-            title = "".join([title," (r), ",ref_casename_v0," (b)"])
-            timeseries_analysis_plot(config, [ohc_tot, ohc_700m, ohc_2000m, ohc_btm,
-                                              ohc_v0_tot, ohc_v0_700m, ohc_v0_2000m, ohc_v0_btm],
+            title = "{} (r), {} (b)".format(title, ref_casename_v0)
+            timeseries_analysis_plot(config, [ohc_tot, ohc_700m, ohc_2000m,
+                                              ohc_btm, ohc_v0_tot, ohc_v0_700m,
+                                              ohc_v0_2000m, ohc_v0_btm],
                                      N_movavg, title, xlabel, ylabel, figname,
-                                     lineStyles = ['r-', 'r-', 'r--', 'r-.', 'b-', 'b-', 'b--', 'b-.'],
-                                     lineWidths = [2, 1, 1.5, 1.5, 2, 1, 1.5, 1.5])
+                                     lineStyles=['r-', 'r-', 'r--', 'r-.',
+                                                 'b-', 'b-', 'b--', 'b-.'],
+                                     lineWidths=[2, 1, 1.5, 1.5, 2, 1, 1.5,
+                                                 1.5])
 
         if not compare_with_obs and ref_casename_v0 == "None":
-            figname = "%s/ohc_%s_%s.png" % (plots_dir,regions[iregion],casename)
-            timeseries_analysis_plot(config, [ohc_tot, ohc_700m, ohc_2000m, ohc_btm],
+            figname = "{}/ohc_{}_{}.png".format(plots_dir, regions[iregion],
+                                                casename)
+            timeseries_analysis_plot(config, [ohc_tot, ohc_700m, ohc_2000m,
+                                              ohc_btm],
                                      N_movavg, title, xlabel, ylabel, figname,
-                                     lineStyles = ['r-', 'r-', 'r--', 'r-.'],
-                                     lineWidths = [2, 1, 1.5, 1.5])
+                                     lineStyles=['r-', 'r-', 'r--', 'r-.'],
+                                     lineWidths=[2, 1, 1.5, 1.5])

--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -11,12 +11,14 @@ from ..shared.plot.plotting import timeseries_analysis_plot
 
 from ..shared.io import NameList, StreamsFile
 
+from ..shared.timekeeping.Date import Date
+
 def ohc_timeseries(config):
     """
     Performs analysis of ocean heat content (OHC) from time-series output.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 11/25/2016
+    Last Modified: 11/28/2016
     """
 
     # read parameters from config file
@@ -50,8 +52,6 @@ def ohc_timeseries(config):
     plots_dir = config.get('paths','plots_dir')
 
     yr_offset = config.getint('time','yr_offset')
-    timeseries_yr1 = yr_offset + config.getint('time', 'timeseries_yr1')
-    timeseries_yr2 = yr_offset + config.getint('time', 'timeseries_yr2')
 
     N_movavg = config.getint('ohc_timeseries','N_movavg')
 
@@ -90,14 +90,17 @@ def ohc_timeseries(config):
 
     ds = remove_repeated_time_index(ds)
 
+    # convert the start and end dates to datetime objects using
+    # the Date class, which ensures the results are within the
+    # supported range
+    time_start = Date(startDate).to_datetime(yr_offset)
+    time_end = Date(endDate).to_datetime(yr_offset)
     # select only the data in the specified range of years
-    # time_start = datetime.datetime(timeseries_yr1, 1, 1)
-    # time_end = datetime.datetime(timeseries_yr2, 12, 31)
-    # ds = ds.sel(Time=slice(time_start, time_end))
+    ds = ds.sel(Time=slice(time_start, time_end))
 
     # Select year-1 data and average it (for later computing anomalies)
-    time_start = datetime.datetime(timeseries_yr1, 1, 1)
-    time_end = datetime.datetime(timeseries_yr1, 12, 31)
+    time_start = datetime.datetime(time_start.year, 1, 1)
+    time_end = datetime.datetime(time_start.year, 12, 31)
     ds_yr1 = ds.sel(Time=slice(time_start,time_end))
     mean_yr1 = ds_yr1.mean('Time')
 

--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -17,6 +17,9 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
     Performs analysis of the time-series output of sea-surface temperature
     (SST).
 
+    config is an instance of MpasAnalysisConfigParser containing configuration
+    options.
+
     If present, streamMap is a dictionary of MPAS-O stream names that map to
     their mpas_analysis counterparts.
 

--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -68,7 +68,7 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
         preprocess=lambda x: preprocess_mpas(x, yearoffset=yr_offset,
                                              timestr='Time',
                                              onlyvars=varList,
-                                             variable_map=variableMap))
+                                             varmap=variableMap))
     ds = remove_repeated_time_index(ds)
 
     # convert the start and end dates to datetime objects using

--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -9,13 +9,15 @@ from ..shared.plot.plotting import timeseries_analysis_plot
 
 from ..shared.io import StreamsFile
 
+from ..shared.timekeeping.Date import Date
+
 def sst_timeseries(config):
     """
     Performs analysis of the time-series output of sea-surface temperature
     (SST).
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 10/27/2016
+    Last Modified: 11/28/2016
     """
     # Define/read in general variables
     print "  Load SST data..."
@@ -54,6 +56,14 @@ def sst_timeseries(config):
                                            timestr=['xtime_start', 'xtime_end'],
                                            onlyvars=['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']))
     ds = remove_repeated_time_index(ds)
+
+    # convert the start and end dates to datetime objects using
+    # the Date class, which ensures the results are within the
+    # supported range
+    time_start = Date(startDate).to_datetime(yr_offset)
+    time_end = Date(endDate).to_datetime(yr_offset)
+    # select only the data in the specified range of years
+    ds = ds.sel(Time=slice(time_start, time_end))
 
     SSTregions = ds.time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature
 

--- a/mpas_analysis/ocean/variable_stream_map.py
+++ b/mpas_analysis/ocean/variable_stream_map.py
@@ -1,0 +1,46 @@
+# mappings of stream names from various MPAS-O versions to those in
+# mpas_analysis
+oceanStreamMap = {'timeSeriesStats': ['timeSeriesStatsOutput',
+                                      'timeSeriesStatsMonthly',
+                                      'timeSeriesStatsMonthlyOutput']}
+
+
+oceanVariableMap = {}
+oceanVariableMap['Time'] = [['xtime_startMonthly', 'xtime_endMonthly'],
+                            ['xtime_start', 'xtime_end'],
+                            'time_avg_daysSinceStartOfSim']
+
+# SST
+oceanVariableMap['avgSurfaceTemperature'] = \
+    ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature',
+     'time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature_1',
+     'timeMonthly_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
+
+# OHC
+oceanVariableMap['avgLayerTemperature'] = \
+    ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
+     'time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature_1',
+    'timeMonthly_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature']
+oceanVariableMap['sumLayerMaskValue'] = \
+    ['time_avg_avgValueWithinOceanLayerRegion_sumLayerMaskValue',
+     'time_avg_avgValueWithinOceanLayerRegion_sumLayerMaskValue_1',
+     'timeMonthly_avg_avgValueWithinOceanLayerRegion_sumLayerMaskValue']
+oceanVariableMap['avgLayerArea'] = \
+    ['time_avg_avgValueWithinOceanLayerRegion_avgLayerArea',
+     'time_avg_avgValueWithinOceanLayerRegion_avgLayerArea_1',
+     'timeMonthly_avg_avgValueWithinOceanLayerRegion_avgLayerArea']
+oceanVariableMap['avgLayerThickness'] = \
+    ['time_avg_avgValueWithinOceanLayerRegion_avgLayerThickness',
+     'time_avg_avgValueWithinOceanLayerRegion_avgLayerThickness_1',
+     'timeMonthly_avg_avgValueWithinOceanLayerRegion_avgLayerThickness']
+
+# model vs. obs.
+oceanVariableMap['mld'] = \
+    ['time_avg_dThreshMLD',
+     'time_avg_dThreshMLD_1',
+     'timeMonthly_avg_dThreshMLD']
+
+oceanVariableMap['sst'] = \
+    ['time_avg_activeTracers_temperature',
+     'time_avg_activeTracers_temperature_1',
+     'timeMonthly_avg_activeTracers_temperature']

--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -155,7 +155,7 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
                                              timestr='Time',
                                              onlyvars=['iceAreaCell',
                                                        'iceVolumeCell'],
-                                             variable_map=variableMap))
+                                             varmap=variableMap))
     ds = remove_repeated_time_index(ds)
 
     # Compute climatologies (first motnhly and then seasonally)

--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -23,6 +23,15 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
     Performs analysis of sea-ice properties by comparing with
     previous model results and/or observations.
 
+    config is an instance of MpasAnalysisConfigParser containing configuration
+    options.
+
+    If present, streamMap is a dictionary of MPAS-O stream names that map to
+    their mpas_analysis counterparts.
+
+    If present, variableMap is a dictionary of MPAS-O variable names that map
+    to their mpas_analysis counterparts.
+
     Author: Xylar Asay-Davis, Milena Veneziani
     Last Modified: 12/07/2016
     """

--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -8,22 +8,23 @@ import numpy as np
 import numpy.ma as ma
 import xarray as xr
 import datetime
-#import calendar
+
 from netCDF4 import Dataset as netcdf_dataset
 
-from ..shared.mpas_xarray.mpas_xarray import preprocess_mpas, remove_repeated_time_index
+from ..shared.mpas_xarray.mpas_xarray import preprocess_mpas, \
+    remove_repeated_time_index
 from ..shared.plot.plotting import plot_polar_comparison
 
 from ..shared.io import StreamsFile
-from ..shared.io.utility import paths
 
-def seaice_modelvsobs(config):
+
+def seaice_modelvsobs(config, streamMap=None, variableMap=None):
     """
     Performs analysis of sea-ice properties by comparing with
     previous model results and/or observations.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 10/27/2016
+    Last Modified: 12/07/2016
     """
 
     # read parameters from config file
@@ -36,99 +37,127 @@ def seaice_modelvsobs(config):
     # reading only those that are between the start and end dates
     startDate = config.get('time', 'climo_start_date')
     endDate = config.get('time', 'climo_end_date')
-    infiles = streams.readpath('timeSeriesStatsMonthlyOutput',
-                               startDate=startDate, endDate=endDate)
-    print 'Reading files {} through {}'.format(infiles[0],infiles[-1])
+    streamName = streams.find_stream(streamMap['timeSeriesStats'])
+    infiles = streams.readpath(streamName, startDate=startDate,
+                               endDate=endDate)
+    print 'Reading files {} through {}'.format(infiles[0], infiles[-1])
 
-    plots_dir = config.get('paths','plots_dir')
-    obsdir = config.get('paths','obs_seaicedir')
+    plots_dir = config.get('paths', 'plots_dir')
+    obsdir = config.get('paths', 'obs_seaicedir')
 
-    casename = config.get('case','casename')
+    casename = config.get('case', 'casename')
 
-    remapfile = config.get('data','mpas_remapfile')
-    climodir = config.get('data','mpas_climodir')
+    remapfile = config.get('data', 'mpas_remapfile')
+    climodir = config.get('data', 'mpas_climodir')
 
-    climo_yr1 = config.getint('time','climo_yr1')
-    climo_yr2 = config.getint('time','climo_yr2')
-    yr_offset = config.getint('time','yr_offset')
+    climo_yr1 = config.getint('time', 'climo_yr1')
+    climo_yr2 = config.getint('time', 'climo_yr2')
+    yr_offset = config.getint('time', 'yr_offset')
 
-    #climodir = "%s/%s" % (climodir,casename)
-    climodir_regridded = "%s/mpas_regridded" % climodir
-    if not os.path.isdir("%s" % climodir):
+    # climodir = "{}/{}".format(climodir, casename)
+    climodir_regridded = "{}/mpas_regridded".format(climodir)
+    if not os.path.isdir(climodir):
         print "\nClimatology directory does not exist. Create it...\n"
-        os.mkdir("%s" % climodir)
-    if not os.path.isdir("%s" % climodir_regridded):
+        os.mkdir(climodir)
+    if not os.path.isdir(climodir_regridded):
         print "\nRegridded directory does not exist. Create it...\n"
-        os.mkdir("%s" % climodir_regridded)
+        os.mkdir(climodir_regridded)
 
     print indir
     print climodir
 
     # Model climo (output) filenames
     climofiles = {}
-    climofiles['winNH'] = "mpas-cice_climo.years%04d-%04d.jfm.nc" % (climo_yr1,climo_yr2)
-    climofiles['sumNH'] = "mpas-cice_climo.years%04d-%04d.jas.nc" % (climo_yr1,climo_yr2)
-    climofiles['winSH'] = "mpas-cice_climo.years%04d-%04d.djf.nc" % (climo_yr1,climo_yr2)
-    climofiles['sumSH'] = "mpas-cice_climo.years%04d-%04d.jja.nc" % (climo_yr1,climo_yr2)
-    climofiles['on']  = "mpas-cice_climo.years%04d-%04d.on.nc" % (climo_yr1,climo_yr2)
-    climofiles['fm']  = "mpas-cice_climo.years%04d-%04d.fm.nc" % (climo_yr1,climo_yr2)
+    climofiles['winNH'] = "mpas-cice_climo.years{:04d}-{:04d}.jfm.nc".format(
+        climo_yr1, climo_yr2)
+    climofiles['sumNH'] = "mpas-cice_climo.years{:04d}-{:04d}.jas.nc".format(
+        climo_yr1, climo_yr2)
+    climofiles['winSH'] = "mpas-cice_climo.years{:04d}-{:04d}.djf.nc".format(
+        climo_yr1, climo_yr2)
+    climofiles['sumSH'] = "mpas-cice_climo.years{:04d}-{:04d}.jja.nc".format(
+        climo_yr1, climo_yr2)
+    climofiles['on'] = "mpas-cice_climo.years{:04d}-{:04d}.on.nc".format(
+        climo_yr1, climo_yr2)
+    climofiles['fm'] = "mpas-cice_climo.years{:04d}-{:04d}.fm.nc".format(
+        climo_yr1, climo_yr2)
 
     # make a dictionary of the months in each climotology
     monthsInClim = {}
-    monthsInClim['winNH'] = [1,2,3]
-    monthsInClim['sumNH'] = [7,8,9]
-    monthsInClim['winSH'] = [12,1,2]
-    monthsInClim['sumSH'] = [6,7,8]
-    monthsInClim['on'] = [10,11]
-    monthsInClim['fm'] = [2,3]
-
+    monthsInClim['winNH'] = [1, 2, 3]
+    monthsInClim['sumNH'] = [7, 8, 9]
+    monthsInClim['winSH'] = [12, 1, 2]
+    monthsInClim['sumSH'] = [6, 7, 8]
+    monthsInClim['on'] = [10, 11]
+    monthsInClim['fm'] = [2, 3]
 
     # Obs filenames
     obs_iceconc_filenames = {}
-    obs_iceconc_filenames['winNH_NASATeam'] = "%s/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc" % obsdir
-    obs_iceconc_filenames['sumNH_NASATeam'] = "%s/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc" % obsdir
-    obs_iceconc_filenames['winSH_NASATeam'] = "%s/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc" % obsdir
-    obs_iceconc_filenames['sumSH_NASATeam'] = "%s/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc" % obsdir
-    obs_iceconc_filenames['winNH_Bootstrap'] = "%s/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc" % obsdir
-    obs_iceconc_filenames['sumNH_Bootstrap'] = "%s/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc" % obsdir
-    obs_iceconc_filenames['winSH_Bootstrap'] = "%s/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc" % obsdir
-    obs_iceconc_filenames['sumSH_Bootstrap'] = "%s/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc" % obsdir
+    obs_iceconc_filenames['winNH_NASATeam'] = \
+        "{}/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_" \
+        "jfm.interp0.5x0.5.nc".format(obsdir)
+    obs_iceconc_filenames['sumNH_NASATeam'] = \
+        "{}/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_" \
+        "jas.interp0.5x0.5.nc".format(obsdir)
+    obs_iceconc_filenames['winSH_NASATeam'] = \
+        "{}/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_" \
+        "djf.interp0.5x0.5.nc".format(obsdir)
+    obs_iceconc_filenames['sumSH_NASATeam'] = \
+        "{}/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_" \
+        "jja.interp0.5x0.5.nc".format(obsdir)
+    obs_iceconc_filenames['winNH_Bootstrap'] = \
+        "{}/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_" \
+        "NH_jfm.interp0.5x0.5.nc".format(obsdir)
+    obs_iceconc_filenames['sumNH_Bootstrap'] = \
+        "{}/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_" \
+        "NH_jas.interp0.5x0.5.nc".format(obsdir)
+    obs_iceconc_filenames['winSH_Bootstrap'] = \
+        "{}/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_" \
+        "SH_djf.interp0.5x0.5.nc".format(obsdir)
+    obs_iceconc_filenames['sumSH_Bootstrap'] = \
+        "{}/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_" \
+        "SH_jja.interp0.5x0.5.nc".format(obsdir)
     obs_icethick_filenames = {}
-    obs_icethick_filenames['onNH'] = "%s/ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc" % obsdir
-    obs_icethick_filenames['fmNH'] = "%s/ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc" % obsdir
-    obs_icethick_filenames['onSH'] = "%s/ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc" % obsdir
-    obs_icethick_filenames['fmSH'] = "%s/ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc" % obsdir
+    obs_icethick_filenames['onNH'] = "{}/ICESat/ICESat_gridded_mean_" \
+        "thickness_NH_on.interp0.5x0.5.nc".format(obsdir)
+    obs_icethick_filenames['fmNH'] = "{}/ICESat/ICESat_gridded_mean_" \
+        "thickness_NH_fm.interp0.5x0.5.nc".format(obsdir)
+    obs_icethick_filenames['onSH'] = "{}/ICESat/ICESat_gridded_mean_" \
+        "thickness_SH_on.interp0.5x0.5.nc".format(obsdir)
+    obs_icethick_filenames['fmSH'] = "{}/ICESat/ICESat_gridded_mean_" \
+        "thickness_SH_fm.interp0.5x0.5.nc".format(obsdir)
 
     # Checks on directory/files existence:
     for climName in obs_iceconc_filenames:
         obs_filename = obs_iceconc_filenames[climName]
-        if os.path.isfile("%s" % obs_filename) != True:
-            raise SystemExit("Obs file %s not found. Exiting..." % obs_filename)
+        if not os.path.isfile(obs_filename):
+            raise SystemExit("Obs file {} not found. Exiting...".format(
+                obs_filename))
     for climName in obs_icethick_filenames:
         obs_filename = obs_icethick_filenames[climName]
-        if os.path.isfile("%s" % obs_filename) != True:
-            raise SystemExit("Obs file %s not found. Exiting..." % obs_filename)
-
+        if not os.path.isfile(obs_filename):
+            raise SystemExit("Obs file {} not found. Exiting...".format(
+                obs_filename))
 
     # Load data
     print "  Load sea-ice data..."
-    ds = xr.open_mfdataset(infiles, preprocess=lambda x: 
-                           preprocess_mpas(x, yearoffset=yr_offset,
-                                           timestr='timeSeriesStatsMonthly_avg_daysSinceStartOfSim_1',
-                                           onlyvars=['timeSeriesStatsMonthly_avg_iceAreaCell_1',
-                                                     'timeSeriesStatsMonthly_avg_iceVolumeCell_1']))
+    ds = xr.open_mfdataset(
+        infiles,
+        preprocess=lambda x: preprocess_mpas(x, yearoffset=yr_offset,
+                                             timestr='Time',
+                                             onlyvars=['iceAreaCell',
+                                                       'iceVolumeCell'],
+                                             variable_map=variableMap))
     ds = remove_repeated_time_index(ds)
 
     # Compute climatologies (first motnhly and then seasonally)
     print "  Compute seasonal climatologies..."
-    time_start = datetime.datetime(yr_offset+climo_yr1,1,1)
-    time_end = datetime.datetime(yr_offset+climo_yr2,12,31)
-    ds_tslice = ds.sel(Time=slice(time_start,time_end))
+    time_start = datetime.datetime(yr_offset+climo_yr1, 1, 1)
+    time_end = datetime.datetime(yr_offset+climo_yr2, 12, 31)
+    ds_tslice = ds.sel(Time=slice(time_start, time_end))
     # check that each year has 24 months (?)
     monthly_clim = ds_tslice.groupby('Time.month').mean('Time')
-    daysInMonth = [31,28,31,30,31,30,31,31,30,31,30,31]
-    monthLetters = ['J','F','M','A','M','J','J','A','S','O','N','D']
-
+    daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    monthLetters = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D']
 
     clims = {}
     for climName in monthsInClim:
@@ -148,9 +177,10 @@ def seaice_modelvsobs(config):
     print "  Regrid fields to regular grid..."
     for climName in clims:
         # Save to netcdf files
-        outFileName = "%s/%s" % (climodir,climofiles[climName])
+        outFileName = "{}/{}".format(climodir, climofiles[climName])
         clims[climName].to_netcdf(outFileName)
-        args = ["ncremap", "-P", "mpas", "-i", outFileName, "-m", remapfile, "-O", climodir_regridded]
+        args = ["ncremap", "-P", "mpas", "-i", outFileName, "-m", remapfile,
+                "-O", climodir_regridded]
         try:
             subprocess.check_call(args)
         except subprocess.CalledProcessError, e:
@@ -163,7 +193,7 @@ def seaice_modelvsobs(config):
 
     # interate over observations of sea-ice concentration
     first = True
-    for climName in ['winNH','winSH','sumNH','sumSH']:
+    for climName in ['winNH', 'winSH', 'sumNH', 'sumSH']:
         hemisphere = climName[-2:]
         season = climName[:-2]
 
@@ -175,26 +205,29 @@ def seaice_modelvsobs(config):
         clevsModelObs = config.getExpression('seaice_modelvsobs',
                                              'clevsModelObs_conc_{}'.format(
                                                  season))
-        cmap = plt.get_cmap(config.get('seaice_modelvsobs','cmapModelObs'))
+        cmap = plt.get_cmap(config.get('seaice_modelvsobs', 'cmapModelObs'))
         cmapIndices = config.getExpression('seaice_modelvsobs',
                                            'cmapIndicesModelObs')
-        cmapModelObs = cols.ListedColormap(cmap(cmapIndices),"cmapModelObs")
+        cmapModelObs = cols.ListedColormap(cmap(cmapIndices), "cmapModelObs")
 
         clevsDiff = config.getExpression('seaice_modelvsobs',
                                          'clevsDiff_conc_{}'.format(season))
-        cmap = plt.get_cmap(config.get('seaice_modelvsobs','cmapDiff'))
+        cmap = plt.get_cmap(config.get('seaice_modelvsobs', 'cmapDiff'))
         cmapIndices = config.getExpression('seaice_modelvsobs',
                                            'cmapIndicesDiff')
-        cmapDiff = cols.ListedColormap(cmap(cmapIndices),"cmapDiff")
+        cmapDiff = cols.ListedColormap(cmap(cmapIndices), "cmapDiff")
 
-        lon0 = config.getfloat('seaice_modelvsobs','lon0_%s'%hemisphere)
-        latmin = config.getfloat('seaice_modelvsobs','latmin_%s'%hemisphere)
+        lon0 = config.getfloat('seaice_modelvsobs',
+                               'lon0_{}'.format(hemisphere))
+        latmin = config.getfloat('seaice_modelvsobs',
+                                 'latmin_{}'.format(hemisphere))
 
         # Load in sea-ice data
         #  Model...
         # ice concentrations
-        f = netcdf_dataset("%s/%s" % (climodir_regridded,climofiles[climName]),mode='r')
-        iceconc = f.variables["timeSeriesStatsMonthly_avg_iceAreaCell_1"][:]
+        fileName = "{}/{}".format(climodir_regridded, climofiles[climName])
+        f = netcdf_dataset(fileName, mode='r')
+        iceconc = f.variables["iceAreaCell"][:]
         if(first):
             lons = f.variables["lon"][:]
             lats = f.variables["lat"][:]
@@ -206,9 +239,10 @@ def seaice_modelvsobs(config):
 
         #  ...and observations
         # ice concentrations from NASATeam (or Bootstrap) algorithm
-        for obsName in ['NASATeam','Bootstrap']:
+        for obsName in ['NASATeam', 'Bootstrap']:
 
-            f = netcdf_dataset(obs_iceconc_filenames['%s_%s'%(climName, obsName)],mode='r')
+            fileName = obs_iceconc_filenames['{}_{}'.format(climName, obsName)]
+            f = netcdf_dataset(fileName, mode='r')
             obs_iceconc = f.variables["AICE"][:]
             f.close()
 
@@ -219,6 +253,11 @@ def seaice_modelvsobs(config):
                 monthsName.append(monthLetters[month-1])
             monthsName = ''.join(monthsName)
 
+            title = "{} ({}, years {:04d}-{:04d})".format(
+                suptitle, monthsName, climo_yr1, climo_yr2)
+            fileout = "{}/iceconc{}{}_{}_{}_years{:04d}-{:04d}.png".format(
+                plots_dir, obsName, hemisphere, casename, monthsName,
+                climo_yr1, climo_yr2)
             plot_polar_comparison(
                 config,
                 Lons,
@@ -230,29 +269,28 @@ def seaice_modelvsobs(config):
                 clevsModelObs,
                 cmapDiff,
                 clevsDiff,
-                title = "%s (%s, years %04d-%04d)" % (suptitle, monthsName, climo_yr1, climo_yr2),
-                fileout = "%s/iceconc%s%s_%s_%s_years%04d-%04d.png" % (plots_dir, obsName, hemisphere,
-                                                                       casename, monthsName, climo_yr1, climo_yr2),
-                plotProjection = plotProjection,
-                latmin = latmin,
-                lon0 = lon0,
-                modelTitle = "%s" % casename,
-                obsTitle = "Observations (SSM/I %s)" % (obsName),
-                diffTitle = "Model-Observations",
-                cbarlabel = "%")
-
+                title=title,
+                fileout=fileout,
+                plotProjection=plotProjection,
+                latmin=latmin,
+                lon0=lon0,
+                modelTitle=casename,
+                obsTitle="Observations (SSM/I {})".format(obsName),
+                diffTitle="Model-Observations",
+                cbarlabel="%")
 
     print "  Make ice thickness plots..."
     # Plot Northern Hemisphere FM sea-ice thickness
     suptitle = "Ice thickness"
     # interate over observations of sea-ice thickness
-    for climName in ['fm','on']:
+    for climName in ['fm', 'on']:
 
         # Load in sea-ice data
         #  Model...
         # ice concentrations
-        f = netcdf_dataset("%s/%s" % (climodir_regridded,climofiles[climName]),mode='r')
-        icethick = f.variables["timeSeriesStatsMonthly_avg_iceVolumeCell_1"][:]
+        fileName = "{}/{}".format(climodir_regridded, climofiles[climName])
+        f = netcdf_dataset(fileName, mode='r')
+        icethick = f.variables["iceVolumeCell"][:]
         f.close()
 
         monthsName = []
@@ -260,46 +298,55 @@ def seaice_modelvsobs(config):
             monthsName.append(monthLetters[month-1])
         monthsName = ''.join(monthsName)
 
-        for hemisphere in ['NH','SH']:
+        for hemisphere in ['NH', 'SH']:
             #  ...and observations
             # ice concentrations from NASATeam (or Bootstrap) algorithm
 
             clevsModelObs = config.getExpression(
                 'seaice_modelvsobs',
                 'clevsModelObs_thick_{}'.format(hemisphere))
-            cmap = plt.get_cmap(config.get('seaice_modelvsobs','cmapModelObs'))
+            cmap = plt.get_cmap(config.get('seaice_modelvsobs',
+                                           'cmapModelObs'))
             cmapIndices = config.getExpression('seaice_modelvsobs',
                                                'cmapIndicesModelObs')
-            cmapModelObs = cols.ListedColormap(cmap(cmapIndices),"cmapModelObs")
+            cmapModelObs = cols.ListedColormap(cmap(cmapIndices),
+                                               "cmapModelObs")
 
             clevsDiff = config.getExpression(
                 'seaice_modelvsobs',
                 'clevsDiff_thick_{}'.format(hemisphere))
-            cmap = plt.get_cmap(config.get('seaice_modelvsobs','cmapDiff'))
+            cmap = plt.get_cmap(config.get('seaice_modelvsobs', 'cmapDiff'))
             cmapIndices = config.getExpression('seaice_modelvsobs',
                                                'cmapIndicesDiff')
-            cmapDiff = cols.ListedColormap(cmap(cmapIndices),"cmapDiff")
+            cmapDiff = cols.ListedColormap(cmap(cmapIndices), "cmapDiff")
 
-            lon0 = config.getfloat('seaice_modelvsobs','lon0_%s'%hemisphere)
-            latmin = config.getfloat('seaice_modelvsobs','latmin_%s'%hemisphere)
+            lon0 = config.getfloat('seaice_modelvsobs',
+                                   'lon0_{}'.format(hemisphere))
+            latmin = config.getfloat('seaice_modelvsobs',
+                                     'latmin_{}'.format(hemisphere))
 
-            f = netcdf_dataset(obs_icethick_filenames['%s%s'%(climName,hemisphere)],mode='r')
+            fileName = obs_icethick_filenames['{}{}'.format(climName,
+                                                            hemisphere)]
+            f = netcdf_dataset(fileName, mode='r')
             obs_icethick = f.variables["HI"][:]
             f.close()
             # Mask thickness fields
-            icethick[ icethick == 0 ] = ma.masked
-            obs_icethick = ma.masked_values(obs_icethick,0)
+            icethick[icethick == 0] = ma.masked
+            obs_icethick = ma.masked_values(obs_icethick, 0)
             if hemisphere == 'NH':
                 # Obs thickness should be nan above 86 (ICESat data)
-                obs_icethick[ Lats > 86 ] = ma.masked
+                obs_icethick[Lats > 86] = ma.masked
                 plotProjection = 'npstere'
             else:
                 plotProjection = 'spstere'
 
             diff = icethick - obs_icethick
 
-
-
+            title = "{} ({}, years {:04d}-{:04d})".format(suptitle, monthsName,
+                                                          climo_yr1, climo_yr2)
+            fileout = "{}/icethick{}_{}_{}_years{:04d}-{:04d}.png".format(
+                plots_dir, hemisphere, casename, monthsName, climo_yr1,
+                climo_yr2)
             plot_polar_comparison(
                 config,
                 Lons,
@@ -311,14 +358,12 @@ def seaice_modelvsobs(config):
                 clevsModelObs,
                 cmapDiff,
                 clevsDiff,
-                title = "%s (%s, years %04d-%04d)" % (suptitle, monthsName, climo_yr1, climo_yr2),
-                fileout = "%s/icethick%s_%s_%s_years%04d-%04d.png" % (plots_dir, hemisphere,
-                                                                      casename, monthsName, climo_yr1, climo_yr2),
-                plotProjection = plotProjection,
-                latmin = latmin,
-                lon0 = lon0,
-                modelTitle = "%s" % casename,
-                obsTitle = "Observations (ICESat)",
-                diffTitle = "Model-Observations",
-                cbarlabel = "m")
-
+                title=title,
+                fileout=fileout,
+                plotProjection=plotProjection,
+                latmin=latmin,
+                lon0=lon0,
+                modelTitle=casename,
+                obsTitle="Observations (ICESat)",
+                diffTitle="Model-Observations",
+                cbarlabel="m")

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -2,23 +2,23 @@ import numpy as np
 import xarray as xr
 import pandas as pd
 import datetime
-import os.path
 
-from ..shared.mpas_xarray.mpas_xarray import preprocess_mpas, remove_repeated_time_index
+from ..shared.mpas_xarray.mpas_xarray import preprocess_mpas, \
+    remove_repeated_time_index
 
-from ..shared.plot.plotting  import timeseries_analysis_plot
+from ..shared.plot.plotting import timeseries_analysis_plot
 
 from ..shared.io import StreamsFile
-from ..shared.io.utility import paths
 
 from ..shared.timekeeping.Date import Date
 
-def seaice_timeseries(config):
+
+def seaice_timeseries(config, streamMap=None, variableMap=None):
     """
     Performs analysis of time series of sea-ice properties.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 11/28/2016
+    Last Modified: 12/07/2016
     """
 
     # read parameters from config file
@@ -31,54 +31,58 @@ def seaice_timeseries(config):
     # reading only those that are between the start and end dates
     startDate = config.get('time', 'timeseries_start_date')
     endDate = config.get('time', 'timeseries_end_date')
-    infiles = streams.readpath('timeSeriesStatsMonthlyOutput',
-                               startDate=startDate, endDate=endDate)
-    print 'Reading files {} through {}'.format(infiles[0],infiles[-1])
+    streamName = streams.find_stream(streamMap['timeSeriesStats'])
+    infiles = streams.readpath(streamName, startDate=startDate,
+                               endDate=endDate)
+    print 'Reading files {} through {}'.format(infiles[0], infiles[-1])
 
-    varnames=['iceAreaCell','iceVolumeCell']
+    varnames = ['iceAreaCell', 'iceVolumeCell']
 
-    plot_titles = {'iceAreaCell':'Sea-ice area',
-                   'iceVolumeCell':'Sea-ice volume',
-                   'iceThickness':'Sea-ice thickness'}
+    plot_titles = {'iceAreaCell': 'Sea-ice area',
+                   'iceVolumeCell': 'Sea-ice volume',
+                   'iceThickness': 'Sea-ice thickness'}
 
-    units_dict = {'iceAreaCell':'[km$^2$]',
-                  'iceVolumeCell':'[10$^3$ km$^3$]',
-                   'iceThickness':'[m]'}
+    units_dict = {'iceAreaCell': '[km$^2$]',
+                  'iceVolumeCell': '[10$^3$ km$^3$]',
+                  'iceThickness': '[m]'}
 
-    obs_filenames = {'iceAreaCell':[config.get('seaIceData','obs_iceareaNH'),
-                                    config.get('seaIceData','obs_iceareaSH')],
-                     'iceVolumeCell':[config.get('seaIceData','obs_icevolNH'),
-                                      config.get('seaIceData','obs_icevolSH')]}
-
+    obs_filenames = {
+        'iceAreaCell': [config.get('seaIceData', 'obs_iceareaNH'),
+                        config.get('seaIceData', 'obs_iceareaSH')],
+        'iceVolumeCell': [config.get('seaIceData', 'obs_icevolNH'),
+                          config.get('seaIceData', 'obs_icevolSH')]}
 
     # Some plotting rules
     title_font_size = config.get('seaice_timeseries', 'title_font_size')
 
-    indir = config.get('paths','archive_dir_ocn')
-    meshfile = config.get('data','mpas_meshfile')
+    indir = config.get('paths', 'archive_dir_ocn')
+    meshfile = config.get('data', 'mpas_meshfile')
 
-    casename = config.get('case','casename')
-    ref_casename_v0 = config.get('case','ref_casename_v0')
-    indir_v0data = config.get('paths','ref_archive_v0_seaicedir')
+    casename = config.get('case', 'casename')
+    ref_casename_v0 = config.get('case', 'ref_casename_v0')
+    indir_v0data = config.get('paths', 'ref_archive_v0_seaicedir')
 
-    compare_with_obs = config.getboolean('seaice_timeseries','compare_with_obs')
+    compare_with_obs = config.getboolean('seaice_timeseries',
+                                         'compare_with_obs')
 
-    plots_dir = config.get('paths','plots_dir')
+    plots_dir = config.get('paths', 'plots_dir')
 
-    yr_offset = config.getint('time','yr_offset')
+    yr_offset = config.getint('time', 'yr_offset')
 
-    N_movavg = config.getint('seaice_timeseries','N_movavg')
+    N_movavg = config.getint('seaice_timeseries', 'N_movavg')
 
     print "  Load sea-ice data..."
     # Load mesh
     dsmesh = xr.open_dataset(meshfile)
 
     # Load data
-    ds = xr.open_mfdataset(infiles, preprocess=lambda x: 
-                           preprocess_mpas(x, yearoffset=yr_offset,
-                                           timestr='timeSeriesStatsMonthly_avg_daysSinceStartOfSim_1',
-                                           onlyvars=['timeSeriesStatsMonthly_avg_iceAreaCell_1',
-                                                     'timeSeriesStatsMonthly_avg_iceVolumeCell_1']))
+    ds = xr.open_mfdataset(
+        infiles,
+        preprocess=lambda x: preprocess_mpas(x, yearoffset=yr_offset,
+                                             timestr='Time',
+                                             onlyvars=['iceAreaCell',
+                                                       'iceVolumeCell'],
+                                             variable_map=variableMap))
     ds = remove_repeated_time_index(ds)
 
     # convert the start and end dates to datetime objects using
@@ -92,15 +96,17 @@ def seaice_timeseries(config):
     ds = ds.merge(dsmesh)
 
     year_start = (pd.to_datetime(ds.Time.min().values)).year
-    year_end   = (pd.to_datetime(ds.Time.max().values)).year
-    time_start = datetime.datetime(year_start,1,1)
-    time_end   = datetime.datetime(year_end,12,31)
+    year_end = (pd.to_datetime(ds.Time.max().values)).year
+    time_start = datetime.datetime(year_start, 1, 1)
+    time_end = datetime.datetime(year_end, 12, 31)
 
     if ref_casename_v0 != "None":
-        infiles_v0data = "".join([indir_v0data,'/icevol.',ref_casename_v0,'.year*.nc'])
-        ds_v0 = xr.open_mfdataset(infiles_v0data, preprocess=lambda x: 
-                                  preprocess_mpas(x, yearoffset=yr_offset))
-        ds_v0_tslice = ds_v0.sel(Time=slice(time_start,time_end))
+        infiles_v0data = "{}/icevol.{}.year*.nc".format(indir_v0data,
+                                                        ref_casename_v0)
+        ds_v0 = xr.open_mfdataset(
+            infiles_v0data,
+            preprocess=lambda x: preprocess_mpas(x, yearoffset=yr_offset))
+        ds_v0_tslice = ds_v0.sel(Time=slice(time_start, time_end))
 
     # Make Northern and Southern Hemisphere partition:
     areaCell = ds.areaCell
@@ -115,11 +121,11 @@ def seaice_timeseries(config):
         plot_title = plot_titles[varname]
         units = units_dict[varname]
 
-        print "  Compute NH and SH time series of %s..."%(varname)
+        print "  Compute NH and SH time series of {}...".format(varname)
         if varname == "iceThickCell":
-            varnamefull = "timeSeriesStatsMonthly_avg_iceVolumeCell_1"
+            varnamefull = "iceVolumeCell"
         else:
-            varnamefull = "".join(["timeSeriesStatsMonthly_avg_",varname,"_1"])
+            varnamefull = varname
         var = ds[varnamefull]
 
         var_nh = var.where(ind_nh)*areaCell_nh
@@ -132,15 +138,15 @@ def seaice_timeseries(config):
         if varname == "iceAreaCell":
             var_nh = var_nh.sum('nCells')
             var_sh = var_sh.sum('nCells')
-            var_nh = 1e-6*var_nh # m^2 to km^2
-            var_sh = 1e-6*var_sh # m^2 to km^2
+            var_nh = 1e-6*var_nh  # m^2 to km^2
+            var_sh = 1e-6*var_sh  # m^2 to km^2
             var_nh_iceext = 1e-6*var_nh_iceext.sum('nCells')
             var_sh_iceext = 1e-6*var_sh_iceext.sum('nCells')
         elif varname == "iceVolumeCell":
             var_nh = var_nh.sum('nCells')
             var_sh = var_sh.sum('nCells')
-            var_nh = 1e-3*1e-9*var_nh # m^3 to 10^3 km^3
-            var_sh = 1e-3*1e-9*var_sh # m^3 to 10^3 km^3
+            var_nh = 1e-3*1e-9*var_nh  # m^3 to 10^3 km^3
+            var_sh = 1e-3*1e-9*var_sh  # m^3 to 10^3 km^3
         else:
             var_nh = var_nh.mean('nCells')/areaCell_nh.mean('nCells')
             var_sh = var_sh.mean('nCells')/areaCell_sh.mean('nCells')
@@ -150,67 +156,82 @@ def seaice_timeseries(config):
         xlabel = "Time [years]"
 
         if ref_casename_v0 != "None":
-            figname_nh = "%s/%sNH_%s_%s.png" % (plots_dir,varname,casename,ref_casename_v0)
-            figname_sh = "%s/%sSH_%s_%s.png" % (plots_dir,varname,casename,ref_casename_v0)
+            figname_nh = "{}/{}NH_{}_{}.png".format(plots_dir, varname,
+                                                    casename, ref_casename_v0)
+            figname_sh = "{}/{}SH_{}_{}.png".format(plots_dir, varname,
+                                                    casename, ref_casename_v0)
         else:
-            figname_nh = "%s/%sNH_%s.png" % (plots_dir,varname,casename)
-            figname_sh = "%s/%sSH_%s.png" % (plots_dir,varname,casename)
+            figname_nh = "{}/{}NH_{}.png".format(plots_dir, varname, casename)
+            figname_sh = "{}/{}SH_{}.png".format(plots_dir, varname, casename)
 
-        title_nh = "%s (NH), %s (r)" % (plot_title,casename)
-        title_sh = "%s (SH), %s (r)" % (plot_title,casename)
+        title_nh = "{} (NH), {} (r)".format(plot_title, casename)
+        title_sh = "{} (SH), {} (r)".format(plot_title, casename)
 
         if compare_with_obs:
             if varname == "iceAreaCell":
-                title_nh = "%s\nSSM/I observations, annual cycle (k)" % title_nh
-                title_sh = "%s\nSSM/I observations, annual cycle (k)" % title_sh
+                title_nh = \
+                    "{}\nSSM/I observations, annual cycle (k)".format(title_nh)
+                title_sh = \
+                    "{}\nSSM/I observations, annual cycle (k)".format(title_sh)
             elif varname == "iceVolumeCell":
-                title_nh = "%s\nPIOMAS, annual cycle (k)" % title_nh
-                title_sh = "%s\n" % title_sh
+                title_nh = "{}\nPIOMAS, annual cycle (k)".format(title_nh)
+                title_sh = "{}\n".format(title_sh)
 
         if ref_casename_v0 != "None":
-            title_nh = "%s\n %s (b)" % (title_nh,ref_casename_v0)
-            title_sh = "%s\n %s (b)" % (title_sh,ref_casename_v0)
-
+            title_nh = "{}\n {} (b)".format(title_nh, ref_casename_v0)
+            title_sh = "{}\n {} (b)".format(title_sh, ref_casename_v0)
 
         if varname == "iceAreaCell":
 
             if compare_with_obs:
-                ds_obs = xr.open_mfdataset(obs_filenameNH, preprocess=lambda x: 
-                                           preprocess_mpas(x, yearoffset=yr_offset))
+                ds_obs = xr.open_mfdataset(
+                    obs_filenameNH,
+                    preprocess=lambda x: preprocess_mpas(x,
+                                                         yearoffset=yr_offset))
                 ds_obs = remove_repeated_time_index(ds_obs)
                 var_nh_obs = ds_obs.IceArea
-                var_nh_obs = replicate_cycle(var_nh,var_nh_obs)
+                var_nh_obs = replicate_cycle(var_nh, var_nh_obs)
 
-                ds_obs = xr.open_mfdataset(obs_filenameSH, preprocess=lambda x: 
-                                           preprocess_mpas(x, yearoffset=yr_offset))
+                ds_obs = xr.open_mfdataset(
+                    obs_filenameSH,
+                    preprocess=lambda x: preprocess_mpas(x,
+                                                         yearoffset=yr_offset))
                 ds_obs = remove_repeated_time_index(ds_obs)
                 var_sh_obs = ds_obs.IceArea
-                var_sh_obs = replicate_cycle(var_sh,var_sh_obs)
+                var_sh_obs = replicate_cycle(var_sh, var_sh_obs)
 
             if ref_casename_v0 != "None":
-                infiles_v0data = "".join([indir_v0data,'/icearea.',ref_casename_v0,'.year*.nc'])
-                ds_v0 = xr.open_mfdataset(infiles_v0data, preprocess=lambda x: 
-                                          preprocess_mpas(x, yearoffset=yr_offset))
-                ds_v0_tslice = ds_v0.sel(Time=slice(time_start,time_end))
+                infiles_v0data = "{}/icearea.{}.year*.nc".format(
+                    indir_v0data, ref_casename_v0)
+                ds_v0 = xr.open_mfdataset(
+                    infiles_v0data,
+                    preprocess=lambda x: preprocess_mpas(x,
+                                                         yearoffset=yr_offset))
+                ds_v0_tslice = ds_v0.sel(Time=slice(time_start, time_end))
                 var_nh_v0 = ds_v0_tslice.icearea_nh
                 var_sh_v0 = ds_v0_tslice.icearea_sh
 
         elif varname == "iceVolumeCell":
 
             if compare_with_obs:
-                ds_obs = xr.open_mfdataset(obs_filenameNH, preprocess=lambda x: 
-                                           preprocess_mpas(x, yearoffset=yr_offset))
+                ds_obs = xr.open_mfdataset(
+                    obs_filenameNH,
+                    preprocess=lambda x: preprocess_mpas(x,
+                                                         yearoffset=yr_offset))
                 ds_obs = remove_repeated_time_index(ds_obs)
                 var_nh_obs = ds_obs.IceVol
-                var_nh_obs = replicate_cycle(var_nh,var_nh_obs)
+                var_nh_obs = replicate_cycle(var_nh, var_nh_obs)
 
                 var_sh_obs = None
 
             if ref_casename_v0 != "None":
-                infiles_v0data = "".join([indir_v0data,'/icevol.',ref_casename_v0,'.year*.nc'])
-                ds_v0 = xr.open_mfdataset(infiles_v0data, preprocess=lambda x: 
-                                          preprocess_mpas(x, yearoffset=yr_offset))
-                ds_v0_tslice = ds_v0.sel(Time=slice(time_start,time_end))
+                infiles_v0data = "{}/icevol.{}.year*.nc".format(
+                    indir_v0data, ref_casename_v0)
+                ds_v0 = xr.open_mfdataset(
+                    infiles_v0data,
+                    preprocess=lambda x: preprocess_mpas(x,
+                                                         yearoffset=yr_offset))
+                ds_v0_tslice = ds_v0.sel(Time=slice(time_start, time_end))
                 var_nh_v0 = ds_v0_tslice.icevolume_nh
                 var_sh_v0 = ds_v0_tslice.icevolume_sh
 
@@ -248,39 +269,41 @@ def seaice_timeseries(config):
                                          title_font_size=title_font_size)
             else:
                 # we will combine north and south onto a single graph
-                figname = "%s/%s.%s.png" % (plots_dir,casename,varname)
-                title = "%s, NH (r), SH (k)\n%s" % (plot_title,casename)
+                figname = "{}/{}.{}.png".format(plots_dir, casename, varname)
+                title = "{}, NH (r), SH (k)\n{}".format(plot_title, casename)
                 timeseries_analysis_plot(config, [var_nh, var_sh], N_movavg,
                                          title, xlabel, units, figname,
-                                         lineStyles=['r-','k-'],
+                                         lineStyles=['r-', 'k-'],
                                          lineWidths=[1.2, 1.2],
                                          title_font_size=title_font_size)
 
         elif varname == "iceThickCell":
 
-            figname = "%s/%s.%s.png" % (plots_dir,casename,varname)
-            title = "%s NH (r), SH (k)\n%s" % (plot_title,casename)
-            timeseries_analysis_plot(config, [var_nh,var_sh], N_movavg, title,
-                                      xlabel, units, figname,
-                                      lineStyles=['r-','k-'],
-                                      lineWidths=[1.2, 1.2],
-                                      title_font_size=title_font_size)
+            figname = "{}/{}.{}.png".format(plots_dir, casename, varname)
+            title = "{} NH (r), SH (k)\n{}".format(plot_title, casename)
+            timeseries_analysis_plot(config, [var_nh, var_sh], N_movavg, title,
+                                     xlabel, units, figname,
+                                     lineStyles=['r-', 'k-'],
+                                     lineWidths=[1.2, 1.2],
+                                     title_font_size=title_font_size)
 
         else:
-            raise SystemExit("varname variable %s not supported for plotting" % varname)
+            raise ValueError(
+                "varname variable {} not supported for plotting".format(
+                    varname))
 
 
-def replicate_cycle(ds,ds_toreplicate):
+def replicate_cycle(ds, ds_toreplicate):
     dsshift = ds_toreplicate.copy()
-    shiftT = ((dsshift.Time.max() - dsshift.Time.min())
-            + (dsshift.Time.isel(Time=1) - dsshift.Time.isel(Time=0)))
+    shiftT = ((dsshift.Time.max() - dsshift.Time.min()) +
+              (dsshift.Time.isel(Time=1) - dsshift.Time.isel(Time=0)))
     nT = np.ceil((ds.Time.max() - ds.Time.min())/shiftT)
 
     # replicate cycle:
     for i in np.arange(nT):
         dsnew = ds_toreplicate.copy()
         dsnew['Time'] = dsnew.Time + (i+1)*shiftT
-        dsshift = xr.concat([dsshift,dsnew], dim='Time')
+        dsshift = xr.concat([dsshift, dsnew], dim='Time')
     # constrict replicated ds_short to same time dimension as ds_long:
     dsshift = dsshift.sel(Time=ds.Time.values, method='nearest')
     return dsshift

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -17,6 +17,15 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
     """
     Performs analysis of time series of sea-ice properties.
 
+    config is an instance of MpasAnalysisConfigParser containing configuration
+    options.
+
+    If present, streamMap is a dictionary of MPAS-O stream names that map to
+    their mpas_analysis counterparts.
+
+    If present, variableMap is a dictionary of MPAS-O variable names that map
+    to their mpas_analysis counterparts.
+
     Author: Xylar Asay-Davis, Milena Veneziani
     Last Modified: 12/07/2016
     """

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -91,7 +91,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
                                              timestr='Time',
                                              onlyvars=['iceAreaCell',
                                                        'iceVolumeCell'],
-                                             variable_map=variableMap))
+                                             varmap=variableMap))
     ds = remove_repeated_time_index(ds)
 
     # convert the start and end dates to datetime objects using

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -11,12 +11,14 @@ from ..shared.plot.plotting  import timeseries_analysis_plot
 from ..shared.io import StreamsFile
 from ..shared.io.utility import paths
 
+from ..shared.timekeeping.Date import Date
+
 def seaice_timeseries(config):
     """
     Performs analysis of time series of sea-ice properties.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 10/27/2016
+    Last Modified: 11/28/2016
     """
 
     # read parameters from config file
@@ -78,6 +80,14 @@ def seaice_timeseries(config):
                                            onlyvars=['timeSeriesStatsMonthly_avg_iceAreaCell_1',
                                                      'timeSeriesStatsMonthly_avg_iceVolumeCell_1']))
     ds = remove_repeated_time_index(ds)
+
+    # convert the start and end dates to datetime objects using
+    # the Date class, which ensures the results are within the
+    # supported range
+    time_start = Date(startDate).to_datetime(yr_offset)
+    time_end = Date(endDate).to_datetime(yr_offset)
+    # select only the data in the specified range of years
+    ds = ds.sel(Time=slice(time_start, time_end))
 
     ds = ds.merge(dsmesh)
 

--- a/mpas_analysis/sea_ice/variable_stream_map.py
+++ b/mpas_analysis/sea_ice/variable_stream_map.py
@@ -1,0 +1,16 @@
+# mappings of stream names from various MPAS-SI versions to those in
+# mpas_analysis
+seaIceStreamMap = {'timeSeriesStats': ['timeSeriesStatsMonthlyOutput']}
+
+
+seaIceVariableMap = {}
+seaIceVariableMap['Time'] = \
+    [['xtime_start', 'xtime_end'],
+     'timeSeriesStatsMonthly_avg_daysSinceStartOfSim_1',
+     'time_avg_daysSinceStartOfSim']
+
+seaIceVariableMap['iceAreaCell'] = \
+    ['timeSeriesStatsMonthly_avg_iceAreaCell_1']
+
+seaIceVariableMap['iceVolumeCell'] = \
+    ['timeSeriesStatsMonthly_avg_iceVolumeCell_1']

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 """
-    Module of classes / routines to manipulate fortran namelist and streams
-    files.
+Module of classes / routines to manipulate fortran namelist and streams
+files.
 
-    Phillip Wolfram, Xylar Asay-Davis
-    Last modified: 11/02/2016
+Phillip Wolfram, Xylar Asay-Davis
+Last modified: 12/05/2016
 """
 
 from lxml import etree
@@ -14,6 +14,7 @@ import os.path
 from ..containers import ReadOnlyDict
 from .utility import paths
 from ..timekeeping.Date import Date
+
 
 def convert_namelist_to_dict(fname, readonly=True):
     """
@@ -72,7 +73,8 @@ class NameList:
 
     # provide accessor for dictionary notation (returns string)
     def __getitem__(self, key):
-        """ Accessor for bracket noation, e.g., nml['field'], returns string """
+        """ Accessor for bracket noation, e.g., nml['field'], returns string
+        """
         return self.nml[key]
 
     # provide accessors for get, getint, getfloat, getbool with appropriate
@@ -91,7 +93,7 @@ class NameList:
             return True
         else:
             return False
-    #}}}
+    # }}}
 
 
 class StreamsFile:
@@ -144,17 +146,20 @@ class StreamsFile:
         on or before the endDate are included in the file list.
         """
         template = self.read(streamName, 'filename_template')
-        replacements = {'$Y':'[0-9][0-9][0-9][0-9]',
-                        '$M':'[0-9][0-9]',
-                        '$D':'[0-9][0-9]',
-                        '$S':'[0-9][0-9][0-9][0-9][0-9]',
-                        '$h':'[0-9][0-9]',
-                        '$m':'[0-9][0-9]',
-                        '$s':'[0-9][0-9]'}
+        if template is None:
+            raise ValueError('Stream {} not found in streams file {}.'.format(
+                streamName, self.fname))
+        replacements = {'$Y': '[0-9][0-9][0-9][0-9]',
+                        '$M': '[0-9][0-9]',
+                        '$D': '[0-9][0-9]',
+                        '$S': '[0-9][0-9][0-9][0-9][0-9]',
+                        '$h': '[0-9][0-9]',
+                        '$m': '[0-9][0-9]',
+                        '$s': '[0-9][0-9]'}
 
         path = template
         for old in replacements:
-            path = path.replace(old,replacements[old])
+            path = path.replace(old, replacements[old])
 
         if not os.path.isabs(path):
             # this is not an absolute path, so make it an absolute path
@@ -205,5 +210,35 @@ class StreamsFile:
                 outFileList.append(fileName)
 
         return outFileList
+
+    def has_stream(self, streamName):
+        """
+        Returns True if the streams file has a stream with the given
+        streamName, otherwise returns False.
+
+        Xylar Asay-Davis
+        Last modified: 12/04/2016
+        """
+        for stream in self.root:
+            # assumes streamname is unique in XML
+            if stream.get('name') == streamName:
+                return True
+        return False
+
+    def find_stream(self, possibleStreams):
+        """
+        If one (or more) of the names in possibleStreams is a stream in this
+        streams file, returns the first match.  If no match is found, raises
+        a ValueError.
+
+        Xylar Asay-Davis
+        Last modified: 12/07/2016
+        """
+        for streamName in possibleStreams:
+            if self.has_stream(streamName):
+                return streamName
+                
+        raise ValueError('Stream {} not found in streams file {}.'.format(
+            streamName, self.fname))
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_date.py
+++ b/mpas_analysis/test/test_date.py
@@ -6,6 +6,7 @@ Xylar Asay-Davis
 """
 
 import pytest
+import datetime
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.timekeeping.Date import Date
 
@@ -118,5 +119,37 @@ class TestDate(TestCase):
         diff = date1-date2
         self.assertEqual(diff, Date(dateString='1995-12-26', isInterval=False))
 
+        date = Date(dateString='1996-01-15', isInterval=False)
+        datetime1 = date.to_datetime(yearOffset=0)
+        datetime2 = datetime.datetime(year=1996, month=1, day=15)
+        self.assertEqual(datetime1, datetime2)
+
+        date = Date(dateString='0000-00-20', isInterval=True)
+        timedelta1 = date.to_timedelta()
+        timedelta2 = datetime.timedelta(days=20)
+        self.assertEqual(timedelta1, timedelta2)
+
+        # since pandas and xarray use the numpy type 'datetime[ns]`, which
+        # has a limited range of dates, the date 0001-01-01 gets increased to
+        # the minimum allowed year boundary, 1678-01-01 to avoid invalid
+        # dates.
+        date = Date(dateString='0001-01-01', isInterval=False)
+        datetime1 = date.to_datetime(yearOffset=0)
+        datetime2 = datetime.datetime(year=1678, month=1, day=1)
+        self.assertEqual(datetime1, datetime2)
+
+        date = Date(dateString='0001-01-01', isInterval=False)
+        datetime1 = date.to_datetime(yearOffset=1849)
+        datetime2 = datetime.datetime(year=1850, month=1, day=1)
+        self.assertEqual(datetime1, datetime2)
+
+        # since pandas and xarray use the numpy type 'datetime[ns]`, which
+        # has a limited range of dates, the date 9999-01-01 gets decreased to
+        # the maximum allowed year boundary, 2262-01-01 to avoid invalid
+        # dates.
+        date = Date(dateString='9999-01-01', isInterval=False)
+        datetime1 = date.to_datetime(yearOffset=0)
+        datetime2 = datetime.datetime(year=2262, month=1, day=1)
+        self.assertEqual(datetime1, datetime2)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -176,7 +176,7 @@ class TestNamelist(TestCase):
                 timestr='Time',
                 onlyvars=varList,
                 yearoffset=1850,
-                variable_map=varMap))
+                varmap=varMap))
 
         # make sure the remapping happened as expected
         self.assertEqual(sorted(ds.data_vars.keys()), sorted(varList))

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -127,13 +127,15 @@ def analysis(config):  # {{{
         print ""
         print "Plotting 2-d maps of SST climatologies..."
         from mpas_analysis.ocean.ocean_modelvsobs import ocn_modelvsobs
-        ocn_modelvsobs(config, 'sst')
+        ocn_modelvsobs(config, 'sst', streamMap=oceanStreamMap,
+                       variableMap=oceanVariableMap)
 
     if config.getboolean('mld_modelvsobs', 'generate'):
         print ""
         print "Plotting 2-d maps of MLD climatologies..."
         from mpas_analysis.ocean.ocean_modelvsobs import ocn_modelvsobs
-        ocn_modelvsobs(config, 'mld')
+        ocn_modelvsobs(config, 'mld', streamMap=oceanStreamMap,
+                       variableMap=oceanVariableMap)
 
     # GENERATE SEA-ICE DIAGNOSTICS
     if config.getboolean('seaice_timeseries', 'generate'):

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -15,6 +15,12 @@ import matplotlib as mpl
 from mpas_analysis.configuration.MpasAnalysisConfigParser \
     import MpasAnalysisConfigParser
 
+from mpas_analysis.ocean.variable_stream_map import oceanStreamMap, \
+    oceanVariableMap
+
+# from mpas_analysis.sea_ice.variable_stream_map import seaIceStreamMap, \
+#     seaIceVariableMap
+
 
 def path_existence(config, section, option, ignorestr=None):  # {{{
     inpath = config.get(section, option)
@@ -89,7 +95,8 @@ def analysis(config):  # {{{
         print ""
         print "Plotting OHC time series..."
         from mpas_analysis.ocean.ohc_timeseries import ohc_timeseries
-        ohc_timeseries(config)
+        ohc_timeseries(config, streamMap=oceanStreamMap,
+                       variableMap=oceanVariableMap)
 
     if config.getboolean('sst_timeseries', 'generate'):
         print ""

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -18,8 +18,8 @@ from mpas_analysis.configuration.MpasAnalysisConfigParser \
 from mpas_analysis.ocean.variable_stream_map import oceanStreamMap, \
     oceanVariableMap
 
-# from mpas_analysis.sea_ice.variable_stream_map import seaIceStreamMap, \
-#     seaIceVariableMap
+from mpas_analysis.sea_ice.variable_stream_map import seaIceStreamMap, \
+    seaIceVariableMap
 
 
 def path_existence(config, section, option, ignorestr=None):  # {{{
@@ -142,14 +142,16 @@ def analysis(config):  # {{{
         print ""
         print "Plotting sea-ice area and volume time series..."
         from mpas_analysis.sea_ice.timeseries import seaice_timeseries
-        seaice_timeseries(config)
+        seaice_timeseries(config, streamMap=seaIceStreamMap,
+                          variableMap=seaIceVariableMap)
 
     if config.getboolean('seaice_modelvsobs', 'generate'):
         print ""
         print "Plotting 2-d maps of sea-ice concentration and thickness " \
             "climatologies..."
         from mpas_analysis.sea_ice.modelvsobs import seaice_modelvsobs
-        seaice_modelvsobs(config)
+        seaice_modelvsobs(config, streamMap=seaIceStreamMap,
+                          variableMap=seaIceVariableMap)
 
     # GENERATE LAND-ICE DIAGNOSTICS
 

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -102,7 +102,8 @@ def analysis(config):  # {{{
         print ""
         print "Plotting SST time series..."
         from mpas_analysis.ocean.sst_timeseries import sst_timeseries
-        sst_timeseries(config)
+        sst_timeseries(config, streamMap=oceanStreamMap,
+                       variableMap=oceanVariableMap)
 
     if config.getboolean('nino34_timeseries', 'generate'):
         print ""


### PR DESCRIPTION
This merge adds dictionaries that can be used to map between the names of variables and streams used internally in MPAS-Analysis to the associated names used in various versions of MPAS dycores.  This helps with cross-compatibility with various MPAS and ACME versions.

mpas_xarray has been modified to include the ability to find the MPAS dycore name of a variable in a data set given the MPAS-Analysis name and the associated map.  mpas_xarray can also now rename variables in a dataset from their MPAS dycore names to those used by MPAS-Analysis using the same map.

The streams file reader has been augmented to include a function that informs the user if a given stream is present, allowing analysis scripts to find the correct name of a given stream using the streams mapping dictionary.