### PR TITLE
Adds matpltlib to CI req for mpas_xarray testing

### DIFF
--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -6,3 +6,4 @@ dependencies:
   - scipy
   - lxml
   - xarray
+  - matplotlib


### PR DESCRIPTION
Ensures that matplotlib is available for testing of mpas_xarray, e.g., see https://github.com/MPAS-Dev/MPAS-Analysis/pull/47#issuecomment-264892670