### PR TITLE
Returns error for invalid path in streams file

### DIFF
--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -167,6 +167,10 @@ class StreamsFile:
 
         fileList = paths(path)
 
+        if len(fileList) == 0:
+            raise ValueError("Path {} in streams file {} for '{}' not found.".format(
+                path, self.fname, streamName))
+
         if (startDate is None) and (endDate is None):
             return fileList
 


### PR DESCRIPTION
Ensures that paths read in streams files are valid.
An error is reported if the path in the streams file
does not exist.

This is important for analysis of ACME files that have
been moved from their original locations because
the path in the streams files may no longer be relevant.