### PR TITLE
Fixes a faulty merge that corrupts ds.Time

### DIFF
--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -102,6 +102,9 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
     # select only the data in the specified range of years
     ds = ds.sel(Time=slice(time_start, time_end))
 
+    # handle the case where the "mesh" file has a spurious time dimension
+    if 'Time' in dsmesh.keys():
+      dsmesh = dsmesh.drop('Time')
     ds = ds.merge(dsmesh)
 
     year_start = (pd.to_datetime(ds.Time.min().values)).year


### PR DESCRIPTION
Previously, the `ds.merge(dsmesh)` resulted
in appending a 0 to the end of ds.Time

This error was noticed in https://github.com/ACME-Climate/PreAndPostProcessingScripts/pull/24
and resulted in errors like

```python
> ds.Time
<xarray.DataArray 'Time' (Time: 13)>
array([Timestamp('1850-01-16 11:30:00.041639'),
Timestamp('1850-02-14 22:23:34.373481'),
Timestamp('1850-03-16 09:35:48.508036'),
Timestamp('1850-04-15 20:30:00.166638'),
Timestamp('1850-05-16 07:37:44.719058'),
Timestamp('1850-06-15 18:28:00.251360'),
Timestamp('1850-07-16 05:39:40.930080'),
Timestamp('1850-08-16 04:39:40.971746'),
Timestamp('1850-09-15 15:24:00.379138'),
Timestamp('1850-10-16 02:41:37.182768'),
Timestamp('1850-11-15 13:22:00.463860'),
Timestamp('1850-12-16 00:43:33.393789'), 0], dtype=object)
Coordinates:

    Time (Time) object 1850-01-16T11:30:00.041639 ...
```