### PR TITLE
Improved plotting of timeseries

### DIFF
--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -63,9 +63,9 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
     # such as refBottomDepth and namelist fields such as config_density0, as
     # well as simulationStartTime, that are not guaranteed to be in the mesh file.
     try:
-       inputfile = streams.readpath('restart')[0]
-    except ValueError, e:
-       raise ValueError("No MPAS-O restart file found: need at least one rst file for OHC calculation")
+        inputfile = streams.readpath('restart')[0]
+    except ValueError:
+        raise IOError('No MPAS-O restart file found: need at least one restart file for OHC calculation')
 
     # get a list of timeSeriesStats output files from the streams file,
     # reading only those that are between the start and end dates
@@ -80,9 +80,9 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
     print '  Read in depth and compute specific depth indexes...'
     f = netcdf_dataset(inputfile, mode='r')
     # reference depth [m]
-    depth = f.variables["refBottomDepth"][:]
+    depth = f.variables['refBottomDepth'][:]
     # simulation start time
-    simStartTime = netCDF4.chartostring(f.variables["simulationStartTime"][:])
+    simStartTime = netCDF4.chartostring(f.variables['simulationStartTime'][:])
     simStartTime = str(simStartTime)
     f.close()
     # specific heat [J/(kg*degC)]
@@ -124,7 +124,7 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
     time_start_yr1 = Date(simStartTime).to_datetime(yr_offset)
     if time_start_yr1 < time_start:
         startDate_yr1 = simStartTime
-        endDate_yr1 = startDate_yr1[0:5]+"12-31"+startDate_yr1[10:]
+        endDate_yr1 = startDate_yr1[0:5]+'12-31'+startDate_yr1[10:]
         infiles_yr1 = streams.readpath(streamName, startDate=startDate_yr1,
                                        endDate=endDate_yr1)
         ds_yr1 = xr.open_mfdataset(
@@ -155,7 +155,7 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
 
     if ref_casename_v0 != 'None':
         print '  Load in OHC for ACMEv0 case...'
-        infiles_v0data = "{}/OHC.{}.year*.nc".format(
+        infiles_v0data = '{}/OHC.{}.year*.nc'.format(
             indir_v0data, ref_casename_v0)
         ds_v0 = xr.open_mfdataset(
             infiles_v0data,
@@ -198,13 +198,13 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
         ohc_btm = fac*ohc_btm
 
         title = 'OHC, {}, 0-bottom (thick-), 0-700m (thin-), 700-2000m (--),' \
-            ' 2000m-bottom (-.) \n {}'.format(plot_titles[iregion], casename)
+                ' 2000m-bottom (-.) \n {}'.format(plot_titles[iregion], casename)
 
-        xlabel = "Time [years]"
-        ylabel = "[x$10^{22}$ J]"
+        xlabel = 'Time [years]'
+        ylabel = '[x$10^{22}$ J]'
 
         if ref_casename_v0 != 'None':
-            figname = "{}/ohc_{}_{}_{}.png".format(plots_dir,
+            figname = '{}/ohc_{}_{}_{}.png'.format(plots_dir,
                                                    regions[iregion],
                                                    casename,
                                                    ref_casename_v0)
@@ -212,7 +212,7 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
             ohc_v0_700m = ds_v0_tslice.ohc_700m
             ohc_v0_2000m = ds_v0_tslice.ohc_2000m
             ohc_v0_btm = ds_v0_tslice.ohc_btm
-            title = "{} (r), {} (b)".format(title, ref_casename_v0)
+            title = '{} (r), {} (b)'.format(title, ref_casename_v0)
             timeseries_analysis_plot(config, [ohc_tot, ohc_700m, ohc_2000m,
                                               ohc_btm, ohc_v0_tot, ohc_v0_700m,
                                               ohc_v0_2000m, ohc_v0_btm],
@@ -223,7 +223,7 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
                                                  1.5])
 
         if not compare_with_obs and ref_casename_v0 == 'None':
-            figname = "{}/ohc_{}_{}.png".format(plots_dir, regions[iregion],
+            figname = '{}/ohc_{}_{}.png'.format(plots_dir, regions[iregion],
                                                 casename)
             timeseries_analysis_plot(config, [ohc_tot, ohc_700m, ohc_2000m,
                                               ohc_btm],

--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -31,7 +31,7 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
     to their mpas_analysis counterparts.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 12/04/2016
+    Last Modified: 01/07/2017
     """
 
     # read parameters from config file
@@ -60,16 +60,12 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
     streams = StreamsFile(streams_filename, streamsdir=indir)
 
     # Note: input file, not a mesh file because we need dycore specific fields
-    # such as refBottomDepth and namelist fields such as config_density0 that
-    # are not guaranteed to be in the mesh file.
-    # attempt to find fields in path-local restart file but default to input
-    # file if restart is unavailable.  This is done to make analysis robust
-    # to being run once the run directory is moved to a new machine.
+    # such as refBottomDepth and namelist fields such as config_density0, as
+    # well as simulationStartTime, that are not guaranteed to be in the mesh file.
     try:
-      inputfile = streams.readpath('restart')[0]
+       inputfile = streams.readpath('restart')[0]
     except ValueError, e:
-      print e, ' Trying to get mesh from input file.'
-      inputfile = streams.readpath('input')[0]
+       raise ValueError("No MPAS-O restart file found: need at least one rst file for OHC calculation")
 
     # get a list of timeSeriesStats output files from the streams file,
     # reading only those that are between the start and end dates

--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -88,7 +88,7 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
 
     if ref_casename_v0 != 'None':
         print '  Load in SST for ACMEv0 case...'
-        infiles_v0data = "{}/SST.{}.year*.nc".format(indir_v0data,
+        infiles_v0data = '{}/SST.{}.year*.nc'.format(indir_v0data,
                                                      ref_casename_v0)
         ds_v0 = xr.open_mfdataset(
             infiles_v0data,
@@ -106,24 +106,24 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
         iregion = iregions[index]
 
         title = plot_titles[iregion]
-        title = "SST, %s, %s (r-)" % (title, casename)
-        xlabel = "Time [years]"
-        ylabel = "[$^\circ$ C]"
+        title = 'SST, %s, %s (r-)' % (title, casename)
+        xlabel = 'Time [years]'
+        ylabel = '[$^\circ$ C]'
 
         SST = SSTregions[:, iregion]
 
         if ref_casename_v0 != 'None':
-            figname = "{}/sst_{}_{}_{}.png".format(plots_dir, regions[iregion],
+            figname = '{}/sst_{}_{}_{}.png'.format(plots_dir, regions[iregion],
                                                    casename, ref_casename_v0)
             SST_v0 = ds_v0_tslice.SST
 
-            title = "{}\n {} (b-)".format(title, ref_casename_v0)
+            title = '{}\n {} (b-)'.format(title, ref_casename_v0)
             timeseries_analysis_plot(config, [SST, SST_v0], N_movavg,
                                      title, xlabel, ylabel, figname,
                                      lineStyles=['r-', 'b-'],
                                      lineWidths=[1.2, 1.2])
         else:
-            figname = "{}/sst_{}_{}.png".format(plots_dir, regions[iregion],
+            figname = '{}/sst_{}_{}.png'.format(plots_dir, regions[iregion],
                                                 casename)
             timeseries_analysis_plot(config, [SST], N_movavg, title, xlabel,
                                      ylabel, figname, lineStyles=['r-'],

--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -31,7 +31,7 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
     """
 
     # Define/read in general variables
-    print "  Load SST data..."
+    print '  Load SST data...'
     # read parameters from config file
     indir = config.get('paths', 'archive_dir_ocn')
 
@@ -86,17 +86,22 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
     time_start = datetime.datetime(year_start, 1, 1)
     time_end = datetime.datetime(year_end, 12, 31)
 
-    if ref_casename_v0 != "None":
-        print "  Load in SST for ACMEv0 case..."
+    if ref_casename_v0 != 'None':
+        print '  Load in SST for ACMEv0 case...'
         infiles_v0data = "{}/SST.{}.year*.nc".format(indir_v0data,
                                                      ref_casename_v0)
         ds_v0 = xr.open_mfdataset(
             infiles_v0data,
             preprocess=lambda x: preprocess_mpas(x, yearoffset=yr_offset))
         ds_v0 = remove_repeated_time_index(ds_v0)
-        ds_v0_tslice = ds_v0.sel(Time=slice(time_start, time_end))
+        year_end_v0 = (pd.to_datetime(ds_v0.Time.max().values)).year
+        if year_start <= year_end_v0:
+            ds_v0_tslice = ds_v0.sel(Time=slice(time_start, time_end))
+        else:
+            print '   Warning: v0 time series lies outside current bounds of v1 time series. Skipping it.'
+            ref_casename_v0 = 'None'
 
-    print "  Make plots..."
+    print '  Make plots...'
     for index in range(len(iregions)):
         iregion = iregions[index]
 
@@ -107,7 +112,7 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
 
         SST = SSTregions[:, iregion]
 
-        if ref_casename_v0 != "None":
+        if ref_casename_v0 != 'None':
             figname = "{}/sst_{}_{}_{}.png".format(plots_dir, regions[iregion],
                                                    casename, ref_casename_v0)
             SST_v0 = ds_v0_tslice.SST

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -113,7 +113,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
     time_end = datetime.datetime(year_end, 12, 31)
 
     if ref_casename_v0 != 'None':
-        infiles_v0data = "{}/icevol.{}.year*.nc".format(indir_v0data,
+        infiles_v0data = '{}/icevol.{}.year*.nc'.format(indir_v0data,
                                                         ref_casename_v0)
         ds_v0 = xr.open_mfdataset(
             infiles_v0data,
@@ -139,8 +139,8 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
         units = units_dict[varname]
 
         print '  Compute NH and SH time series of {}...'.format(varname)
-        if varname == "iceThickCell":
-            varnamefull = "iceVolumeCell"
+        if varname == 'iceThickCell':
+            varnamefull = 'iceVolumeCell'
         else:
             varnamefull = varname
         var = ds[varnamefull]
@@ -152,14 +152,14 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
         var_nh_iceext = var_nh.where(ind_iceext)
         var_sh_iceext = var_sh.where(ind_iceext)
 
-        if varname == "iceAreaCell":
+        if varname == 'iceAreaCell':
             var_nh = var_nh.sum('nCells')
             var_sh = var_sh.sum('nCells')
             var_nh = 1e-6*var_nh  # m^2 to km^2
             var_sh = 1e-6*var_sh  # m^2 to km^2
             var_nh_iceext = 1e-6*var_nh_iceext.sum('nCells')
             var_sh_iceext = 1e-6*var_sh_iceext.sum('nCells')
-        elif varname == "iceVolumeCell":
+        elif varname == 'iceVolumeCell':
             var_nh = var_nh.sum('nCells')
             var_sh = var_sh.sum('nCells')
             var_nh = 1e-3*1e-9*var_nh  # m^3 to 10^3 km^3
@@ -170,35 +170,35 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
 
         print '  Make plots...'
 
-        xlabel = "Time [years]"
+        xlabel = 'Time [years]'
 
         if ref_casename_v0 != 'None':
-            figname_nh = "{}/{}NH_{}_{}.png".format(plots_dir, varname,
+            figname_nh = '{}/{}NH_{}_{}.png'.format(plots_dir, varname,
                                                     casename, ref_casename_v0)
-            figname_sh = "{}/{}SH_{}_{}.png".format(plots_dir, varname,
+            figname_sh = '{}/{}SH_{}_{}.png'.format(plots_dir, varname,
                                                     casename, ref_casename_v0)
         else:
-            figname_nh = "{}/{}NH_{}.png".format(plots_dir, varname, casename)
-            figname_sh = "{}/{}SH_{}.png".format(plots_dir, varname, casename)
+            figname_nh = '{}/{}NH_{}.png'.format(plots_dir, varname, casename)
+            figname_sh = '{}/{}SH_{}.png'.format(plots_dir, varname, casename)
 
-        title_nh = "{} (NH), {} (r)".format(plot_title, casename)
-        title_sh = "{} (SH), {} (r)".format(plot_title, casename)
+        title_nh = '{} (NH), {} (r)'.format(plot_title, casename)
+        title_sh = '{} (SH), {} (r)'.format(plot_title, casename)
 
         if compare_with_obs:
-            if varname == "iceAreaCell":
+            if varname == 'iceAreaCell':
                 title_nh = \
-                    "{}\nSSM/I observations, annual cycle (k)".format(title_nh)
+                    '{}\nSSM/I observations, annual cycle (k)'.format(title_nh)
                 title_sh = \
-                    "{}\nSSM/I observations, annual cycle (k)".format(title_sh)
-            elif varname == "iceVolumeCell":
-                title_nh = "{}\nPIOMAS, annual cycle (k)".format(title_nh)
-                title_sh = "{}\n".format(title_sh)
+                    '{}\nSSM/I observations, annual cycle (k)'.format(title_sh)
+            elif varname == 'iceVolumeCell':
+                title_nh = '{}\nPIOMAS, annual cycle (k)'.format(title_nh)
+                title_sh = '{}\n'.format(title_sh)
 
         if ref_casename_v0 != 'None':
-            title_nh = "{}\n {} (b)".format(title_nh, ref_casename_v0)
-            title_sh = "{}\n {} (b)".format(title_sh, ref_casename_v0)
+            title_nh = '{}\n {} (b)'.format(title_nh, ref_casename_v0)
+            title_sh = '{}\n {} (b)'.format(title_sh, ref_casename_v0)
 
-        if varname == "iceAreaCell":
+        if varname == 'iceAreaCell':
 
             if compare_with_obs:
                 ds_obs = xr.open_mfdataset(
@@ -218,7 +218,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
                 var_sh_obs = replicate_cycle(var_sh, var_sh_obs)
 
             if ref_casename_v0 != 'None':
-                infiles_v0data = "{}/icearea.{}.year*.nc".format(
+                infiles_v0data = '{}/icearea.{}.year*.nc'.format(
                     indir_v0data, ref_casename_v0)
                 ds_v0 = xr.open_mfdataset(
                     infiles_v0data,
@@ -228,7 +228,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
                 var_nh_v0 = ds_v0_tslice.icearea_nh
                 var_sh_v0 = ds_v0_tslice.icearea_sh
 
-        elif varname == "iceVolumeCell":
+        elif varname == 'iceVolumeCell':
 
             if compare_with_obs:
                 ds_obs = xr.open_mfdataset(
@@ -242,7 +242,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
                 var_sh_obs = None
 
             if ref_casename_v0 != 'None':
-                infiles_v0data = "{}/icevol.{}.year*.nc".format(
+                infiles_v0data = '{}/icevol.{}.year*.nc'.format(
                     indir_v0data, ref_casename_v0)
                 ds_v0 = xr.open_mfdataset(
                     infiles_v0data,
@@ -252,7 +252,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
                 var_nh_v0 = ds_v0_tslice.icevolume_nh
                 var_sh_v0 = ds_v0_tslice.icevolume_sh
 
-        if varname in ["iceAreaCell", "iceVolumeCell"]:
+        if varname in ['iceAreaCell', 'iceVolumeCell']:
             if compare_with_obs:
                 if ref_casename_v0 != 'None':
                     vars_nh = [var_nh, var_nh_obs, var_nh_v0]
@@ -286,18 +286,18 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
                                          title_font_size=title_font_size)
             else:
                 # we will combine north and south onto a single graph
-                figname = "{}/{}.{}.png".format(plots_dir, casename, varname)
-                title = "{}, NH (r), SH (k)\n{}".format(plot_title, casename)
+                figname = '{}/{}.{}.png'.format(plots_dir, casename, varname)
+                title = '{}, NH (r), SH (k)\n{}'.format(plot_title, casename)
                 timeseries_analysis_plot(config, [var_nh, var_sh], N_movavg,
                                          title, xlabel, units, figname,
                                          lineStyles=['r-', 'k-'],
                                          lineWidths=[1.2, 1.2],
                                          title_font_size=title_font_size)
 
-        elif varname == "iceThickCell":
+        elif varname == 'iceThickCell':
 
-            figname = "{}/{}.{}.png".format(plots_dir, casename, varname)
-            title = "{} NH (r), SH (k)\n{}".format(plot_title, casename)
+            figname = '{}/{}.{}.png'.format(plots_dir, casename, varname)
+            title = '{} NH (r), SH (k)\n{}'.format(plot_title, casename)
             timeseries_analysis_plot(config, [var_nh, var_sh], N_movavg, title,
                                      xlabel, units, figname,
                                      lineStyles=['r-', 'k-'],
@@ -306,7 +306,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
 
         else:
             raise ValueError(
-                "varname variable {} not supported for plotting".format(
+                'varname variable {} not supported for plotting'.format(
                     varname))
 
 

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -80,7 +80,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
 
     N_movavg = config.getint('seaice_timeseries', 'N_movavg')
 
-    print "  Load sea-ice data..."
+    print '  Load sea-ice data...'
     # Load mesh
     dsmesh = xr.open_dataset(meshfile)
 
@@ -112,13 +112,18 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
     time_start = datetime.datetime(year_start, 1, 1)
     time_end = datetime.datetime(year_end, 12, 31)
 
-    if ref_casename_v0 != "None":
+    if ref_casename_v0 != 'None':
         infiles_v0data = "{}/icevol.{}.year*.nc".format(indir_v0data,
                                                         ref_casename_v0)
         ds_v0 = xr.open_mfdataset(
             infiles_v0data,
             preprocess=lambda x: preprocess_mpas(x, yearoffset=yr_offset))
-        ds_v0_tslice = ds_v0.sel(Time=slice(time_start, time_end))
+        year_end_v0 = (pd.to_datetime(ds_v0.Time.max().values)).year
+        if year_start <= year_end_v0:
+            ds_v0_tslice = ds_v0.sel(Time=slice(time_start, time_end))
+        else:
+            print '   Warning: v0 time series lies outside current bounds of v1 time series. Skipping it.'
+            ref_casename_v0 = 'None'
 
     # Make Northern and Southern Hemisphere partition:
     areaCell = ds.areaCell
@@ -133,7 +138,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
         plot_title = plot_titles[varname]
         units = units_dict[varname]
 
-        print "  Compute NH and SH time series of {}...".format(varname)
+        print '  Compute NH and SH time series of {}...'.format(varname)
         if varname == "iceThickCell":
             varnamefull = "iceVolumeCell"
         else:
@@ -163,11 +168,11 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
             var_nh = var_nh.mean('nCells')/areaCell_nh.mean('nCells')
             var_sh = var_sh.mean('nCells')/areaCell_sh.mean('nCells')
 
-        print "  Make plots..."
+        print '  Make plots...'
 
         xlabel = "Time [years]"
 
-        if ref_casename_v0 != "None":
+        if ref_casename_v0 != 'None':
             figname_nh = "{}/{}NH_{}_{}.png".format(plots_dir, varname,
                                                     casename, ref_casename_v0)
             figname_sh = "{}/{}SH_{}_{}.png".format(plots_dir, varname,
@@ -189,7 +194,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
                 title_nh = "{}\nPIOMAS, annual cycle (k)".format(title_nh)
                 title_sh = "{}\n".format(title_sh)
 
-        if ref_casename_v0 != "None":
+        if ref_casename_v0 != 'None':
             title_nh = "{}\n {} (b)".format(title_nh, ref_casename_v0)
             title_sh = "{}\n {} (b)".format(title_sh, ref_casename_v0)
 
@@ -212,7 +217,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
                 var_sh_obs = ds_obs.IceArea
                 var_sh_obs = replicate_cycle(var_sh, var_sh_obs)
 
-            if ref_casename_v0 != "None":
+            if ref_casename_v0 != 'None':
                 infiles_v0data = "{}/icearea.{}.year*.nc".format(
                     indir_v0data, ref_casename_v0)
                 ds_v0 = xr.open_mfdataset(
@@ -236,7 +241,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
 
                 var_sh_obs = None
 
-            if ref_casename_v0 != "None":
+            if ref_casename_v0 != 'None':
                 infiles_v0data = "{}/icevol.{}.year*.nc".format(
                     indir_v0data, ref_casename_v0)
                 ds_v0 = xr.open_mfdataset(
@@ -249,7 +254,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
 
         if varname in ["iceAreaCell", "iceVolumeCell"]:
             if compare_with_obs:
-                if ref_casename_v0 != "None":
+                if ref_casename_v0 != 'None':
                     vars_nh = [var_nh, var_nh_obs, var_nh_v0]
                     vars_sh = [var_sh, var_sh_obs, var_sh_v0]
                     lineStyles = ['r-', 'k-', 'b-']
@@ -260,14 +265,14 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
                     vars_sh = [var_sh, var_sh_obs]
                     lineStyles = ['r-', 'k-']
                     lineWidths = [1.2, 1.2]
-            elif ref_casename_v0 != "None":
+            elif ref_casename_v0 != 'None':
                 # just v1 and v0 models
                 vars_nh = [var_nh, var_nh_v0]
                 vars_sh = [var_sh, var_sh_v0]
                 lineStyles = ['r-', 'b-']
                 lineWidths = [1.2, 1.2]
 
-            if compare_with_obs or ref_casename_v0 != "None":
+            if compare_with_obs or ref_casename_v0 != 'None':
                 # separate plots for nothern and southern hemispheres
                 timeseries_analysis_plot(config, vars_nh, N_movavg, title_nh,
                                          xlabel, units, figname_nh,


### PR DESCRIPTION
This PR improves the plotting of time series as well as solves some issues with plotting
ACME v0 timeseries (when available). Specifically, these are the two changes introduced here:
1) a check has been included about whether the v1 time series brackets the times of the v0 results. If time_start is greater than the last time stamp for which v0 data is available, then v0 time series are not plotted;
2) the ohc timeseries has been updated to always start from year 1. This is because OHC is intended to be calculated as anomaly with respect to the heat content of the very first year of the simulation. If timeseries_yr1 is different than simulation year 1, the OHC time series is adjusted to still start from year 1.