### PR TITLE
Change sea ice concentration colorbar label to 'fraction'

### DIFF
--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -286,7 +286,7 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
                 modelTitle=casename,
                 obsTitle="Observations (SSM/I {})".format(obsName),
                 diffTitle="Model-Observations",
-                cbarlabel="%")
+                cbarlabel="fraction")
 
     print "  Make ice thickness plots..."
     # Plot Northern Hemisphere FM sea-ice thickness


### PR DESCRIPTION
sea ice concentration values plotted range from 0.0-1.0, but currently 
the colorbar is labeled as '%'.  This merge changes the label to 'fraction'.

Fixes #70