### PR TITLE
Ensures that subseted datasets are non-empty

### DIFF
--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -49,11 +49,13 @@ def subset_variables(ds, vlist):  # {{{
     Reduces an xarray dataset ds to only contain the variables in vlist.
 
     Phillip J. Wolfram
-    05/05/2016
+    01/10/2017
     """
 
+    allvars = ds.data_vars.keys()
+
     # get set of variables to drop (all ds variables not in vlist)
-    dropvars = set(ds.data_vars.keys()) - set(vlist)
+    dropvars = set(allvars) - set(vlist)
 
     # drop spurious variables
     ds = ds.drop(dropvars)
@@ -66,6 +68,10 @@ def subset_variables(ds, vlist):  # {{{
 
     # drop spurious coordinates
     ds = ds.drop(dropcoords)
+
+    assert len(ds.variables.keys()) > 0, 'MPAS_XARRAY ERROR: Empty dataset is returned.\n'\
+                                         'Variables {}\nare not found within the dataset variables: {}.'\
+                                         .format(vlist, allvars)
 
     return ds  # }}}
 

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -41,6 +41,15 @@ class TestNamelist(TestCase):
                                                              yearoffset=1850))
         self.assertEqual(ds.data_vars.keys(), varList)
 
+        with self.assertRaisesRegexp(AssertionError, 'Empty dataset is returned.'):
+            missingvars = ['foo', 'bar']
+            ds = xr.open_mfdataset(
+                fileName,
+                preprocess=lambda x: mpas_xarray.preprocess_mpas(x,
+                                                                 timestr=timestr,
+                                                                 onlyvars=missingvars,
+                                                                 yearoffset=1850))
+
     def test_iselvals(self):
         fileName = str(self.datadir.join('example_jan.nc'))
         timestr = 'time_avg_daysSinceStartOfSim'


### PR DESCRIPTION
This merge ensures that datasets returned following subseting 
via mpas_xarray are non-empty.

Previously, it would be possible to provide an argument
of onlyvars that would result in an empty dataset.  This
can result in difficult bugs to find and consquently
we assert that variable subsets via `subset_variables`
do not return empty datasets.