### PR TITLE
Switch meshfile to ocean (or sea ice) restart file

### DIFF
--- a/config.analysis
+++ b/config.analysis
@@ -29,7 +29,6 @@ ref_archive_v0_seaicedir = /global/project/projectdirs/acme/ACMEv0_lowres/B1850C
 
 [data]
 # paths to mesh and mapping files
-mpas_meshfile = /global/project/projectdirs/acme/milena/MPAS-grids/ocn/gridfile.oEC60to30.nc
 mpas_remapfile = /global/project/projectdirs/acme/mapping/maps/map_oEC60to30_TO_0.5x0.5degree_blin.160412.nc
 pop_remapfile = /global/project/projectdirs/acme/mapping/maps/map_gx1v6_TO_0.5x0.5degree_blin.160413.nc
 # path to climotology dataset

--- a/mpas_analysis/ocean/ocean_modelvsobs.py
+++ b/mpas_analysis/ocean/ocean_modelvsobs.py
@@ -63,7 +63,13 @@ def ocn_modelvsobs(config, field, streamMap=None, variableMap=None):
     plots_dir = config.get('paths', 'plots_dir')
     obsdir = config.get('paths', 'obs_' + field + 'dir')
     casename = config.get('case', 'casename')
-    meshfile = config.get('data', 'mpas_meshfile')
+
+    try:
+        inputfile = streams.readpath('restart')[0]
+    except ValueError:
+        raise IOError('No MPAS-O restart file found: need at least one '
+                      'restart file for ocn_modelvsobs calculation')
+
     climo_yr1 = config.getint('time', 'climo_yr1')
     climo_yr2 = config.getint('time', 'climo_yr2')
     yr_offset = config.getint('time', 'yr_offset')
@@ -71,7 +77,7 @@ def ocn_modelvsobs(config, field, streamMap=None, variableMap=None):
     outputTimes = config.getExpression(field + '_modelvsobs',
                                        'comparisonTimes')
 
-    f = netcdf_dataset(meshfile, mode='r')
+    f = netcdf_dataset(inputfile, mode='r')
     lonCell = f.variables["lonCell"][:]
     latCell = f.variables["latCell"][:]
 


### PR DESCRIPTION
ocean_modelvsobs has been changed to read an ocean restart file
instead of a meshfile, consistent with ocean/timeseries.

seaice/timeseries has been changed to first try to load a sea-ice
restart file, then an ocean restart file (raising an exception if
neither exists).  Also, only a small subset of the data from the
restart file is loaded (latCell, lonCell and areaCell) before
the dataset is merged with the time-varying sea ice data.

The mpas_meshfile option has been removed from the default config
file.