### PR TITLE
Switch time variable to use netcdftime.datetime and reference dates

### DIFF
--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -90,11 +90,13 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
         decode_times=False)
     ds = remove_repeated_time_index(ds)
 
-    # convert the start and end dates to datetime objects using
-    # the Date class, which ensures the results are within the
-    # supported range
-    time_start = Date(startDate).to_datetime(yr_offset)
-    time_end = Date(endDate).to_datetime(yr_offset)
+    # convert the start and end dates to netcdftime.datetime objects using
+    # the Date class and adding the yr_offset
+    offset = Date(dateString='{:04d}-00-00'.format(yr_offset), isInterval=True)
+    offset = offset.to_timedelta()
+    time_start = Date(startDate).to_netcdftime() + offset
+    time_end = Date(endDate).to_netcdftime() + offset
+
     # select only the data in the specified range of years
     ds = ds.sel(Time=slice(time_start, time_end))
 

--- a/mpas_analysis/shared/timekeeping/Date.py
+++ b/mpas_analysis/shared/timekeeping/Date.py
@@ -9,6 +9,7 @@ import functools
 import numpy
 import datetime
 
+
 @functools.total_ordering
 class Date(object):
     """
@@ -94,9 +95,9 @@ class Date(object):
         year = numpy.maximum(datetime.MINYEAR,
                              numpy.minimum(datetime.MAXYEAR,
                                            self.years+yearOffset))
-        outDate =  datetime.datetime(year=year, month=self.months+1,
-                                     day=self.days+1, hour=self.hours,
-                                     minute=self.minutes, second=self.seconds)
+        outDate = datetime.datetime(year=year, month=self.months+1,
+                                    day=self.days+1, hour=self.hours,
+                                    minute=self.minutes, second=self.seconds)
 
         minDate = datetime.datetime(year=1678, month=1, day=1,
                                     hour=0, minute=0, second=0)
@@ -117,7 +118,7 @@ class Date(object):
                              "instead of to_timedelta")
 
         days = 365*self.years + self._monthsToDays(self.months) + self.days
-        return datetime.timedelta(days=self.days, hours=self.hours,
+        return datetime.timedelta(days=days, hours=self.hours,
                                   minutes=self.minutes, seconds=self.seconds)
 
     def __lt__(self, other):

--- a/mpas_analysis/shared/timekeeping/Date.py
+++ b/mpas_analysis/shared/timekeeping/Date.py
@@ -8,6 +8,7 @@
 import functools
 import numpy
 import datetime
+import netcdftime
 
 
 @functools.total_ordering
@@ -82,10 +83,10 @@ class Date(object):
         Converts the date object to a datetime object.
         The yearOffset is added to this date's year, and
         the resulting date is clamped to the range supported by
-        numpy's datetime64[ns], used internally by xarray an
-        pandas
+        datetime
 
-        Last modified: 11/28/2016
+        Last modified: 01/27/2017
+
         Author: Xylar Asay-Davis
         """
         if self.isInterval:
@@ -98,12 +99,41 @@ class Date(object):
         outDate = datetime.datetime(year=year, month=self.months+1,
                                     day=self.days+1, hour=self.hours,
                                     minute=self.minutes, second=self.seconds)
+        return outDate
 
-        minDate = datetime.datetime(year=1678, month=1, day=1,
-                                    hour=0, minute=0, second=0)
-        maxDate = datetime.datetime(year=2262, month=1, day=1,
-                                    hour=0, minute=0, second=0)
-        outDate = max(minDate, min(maxDate, outDate))
+    def to_netcdftime(self, calendar='365_day'):
+        """
+        Converts the date object to one of the subclasses of
+        netcdftime.datetime (depending on calendar).
+
+        `calendar` is one of the calendars supported by `netcdftime`:
+            'standard', 'gregorian', 'proleptic_gregorian',
+            'noleap', 'julian', 'all_leap', '365_day', '366_day', '360_day'
+
+        Last modified: 01/27/2017
+
+        Author: Xylar Asay-Davis
+        """
+        if self.isInterval:
+            raise ValueError("self.isInterval == True. Use to_timedelta "
+                             "instead of to_datetime")
+
+        NetCDFDatetimes = {
+            'standard': datetime.datetime,
+            'gregorian': datetime.datetime,
+            'proleptic_gregorian': netcdftime.DatetimeProlepticGregorian,
+            'noleap': netcdftime.DatetimeNoLeap,
+            'julian': netcdftime.DatetimeJulian,
+            'all_leap': netcdftime.DatetimeAllLeap,
+            '365_day': netcdftime.DatetimeNoLeap,
+            '366_day': netcdftime.DatetimeAllLeap,
+            '360_day': netcdftime.Datetime360Day}
+
+        NetCDFDatetime = NetCDFDatetimes[calendar]
+
+        outDate = NetCDFDatetime(year=self.years, month=self.months+1,
+                                 day=self.days+1, hour=self.hours,
+                                 minute=self.minutes, second=self.seconds)
         return outDate
 
     def to_timedelta(self):


### PR DESCRIPTION
This merge allows two very important changes:
    * support for all calendars allowed by netcdftime (including `'365_day'`)
    * support for arbitrary years (not just between 1678 and 2262, or between 1 and 9999)
    
Calls to `xarray.open_mfdataset` should now include a flag
`decode_times=False` to prevent times (e.g. `daysSinceStartOfSym`)
from being decoded into datetimes with the wrong calendar.
    
Two arguments have been added to `mpas_xarray.preprocess_mpas`,
`inrefdate` and `outrefdate`.  The first is the reference date for
MPAS runs and the second is the same reference date as used in
the analysis.  The difference between the two is the yr_offset
(as usual).  This new convention, however, allows for different
values of `inrefdate` for the MPAS or ACME run being analyzed and
that of the reference or observational data set to be read in.
In either case, the `outrefdate` is likely to be the same.