### PR TITLE
Fix bug in Date.to_timedelta 

### DIFF
--- a/mpas_analysis/shared/timekeeping/Date.py
+++ b/mpas_analysis/shared/timekeeping/Date.py
@@ -9,6 +9,7 @@ import functools
 import numpy
 import datetime
 
+
 @functools.total_ordering
 class Date(object):
     """
@@ -94,9 +95,9 @@ class Date(object):
         year = numpy.maximum(datetime.MINYEAR,
                              numpy.minimum(datetime.MAXYEAR,
                                            self.years+yearOffset))
-        outDate =  datetime.datetime(year=year, month=self.months+1,
-                                     day=self.days+1, hour=self.hours,
-                                     minute=self.minutes, second=self.seconds)
+        outDate = datetime.datetime(year=year, month=self.months+1,
+                                    day=self.days+1, hour=self.hours,
+                                    minute=self.minutes, second=self.seconds)
 
         minDate = datetime.datetime(year=1678, month=1, day=1,
                                     hour=0, minute=0, second=0)
@@ -117,7 +118,7 @@ class Date(object):
                              "instead of to_timedelta")
 
         days = 365*self.years + self._monthsToDays(self.months) + self.days
-        return datetime.timedelta(days=self.days, hours=self.hours,
+        return datetime.timedelta(days=days, hours=self.hours,
                                   minutes=self.minutes, seconds=self.seconds)
 
     def __lt__(self, other):

--- a/mpas_analysis/test/test_date.py
+++ b/mpas_analysis/test/test_date.py
@@ -128,6 +128,11 @@ class TestDate(TestCase):
         timedelta2 = datetime.timedelta(days=20)
         self.assertEqual(timedelta1, timedelta2)
 
+        date = Date(dateString='0001-01-20', isInterval=True)
+        timedelta1 = date.to_timedelta()
+        timedelta2 = datetime.timedelta(days=(365+31+20))
+        self.assertEqual(timedelta1, timedelta2)
+
         # since pandas and xarray use the numpy type 'datetime[ns]`, which
         # has a limited range of dates, the date 0001-01-01 gets increased to
         # the minimum allowed year boundary, 1678-01-01 to avoid invalid


### PR DESCRIPTION
This merge fixes a bug in Date.to_timedelta  where the local variable day is used instead of self.day.

Also, fix some PEP8 issues in Date.