### PR TITLE
Add month coord in MLD observations

### DIFF
--- a/mpas_analysis/ocean/ocean_modelvsobs.py
+++ b/mpas_analysis/ocean/ocean_modelvsobs.py
@@ -97,6 +97,7 @@ def ocn_modelvsobs(config, field, streamMap=None, variableMap=None):
         # Rename the time dimension to be consistent with the SST dataset
         dsData.rename({'month': 'calmonth'}, inplace=True)
         dsData.rename({'iMONTH': 'month'}, inplace=True)
+        dsData.coords['month'] = dsData['calmonth']
 
         obsFieldName = 'mld_dt_mean'
 


### PR DESCRIPTION
This fixes an indexing error in `ocean.ocean_modelvsobs` when plotting mixed layer depth that occurs in xarray 0.9.1.