### PR TITLE
Increased safety for config with numpy eval

### DIFF
--- a/mpas_analysis/configuration/MpasAnalysisConfigParser.py
+++ b/mpas_analysis/configuration/MpasAnalysisConfigParser.py
@@ -66,7 +66,12 @@ class MpasAnalysisConfigParser(ConfigParser):
         """
         expressionString = self.get(section, option)
         if usenumpyfunc:
-            sanitizedstr = expressionString.replace('np.', '').replace('numpy.','')
+            assert '__' not in expressionString, \
+                    "'__' is not allowed in {} "\
+                    "for `usenumpyfunc=True`".format(expressionString)
+            sanitizedstr = expressionString.replace('np.', '')\
+                                           .replace('numpy.','')\
+                                           .replace('__','')
             result = eval(sanitizedstr, npallow)
         else:
             result =  ast.literal_eval(expressionString)

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -79,5 +79,7 @@ class TestMPASAnalysisConfigParser(TestCase):
                                   np.linspace(0, 1, 10))
         for testNumpy in ['testNumpypi' + str(ii) for ii in np.arange(3)] + ['testNumpyPi']:
             self.assertEqual(self.config.getExpression('TestNumpy', testNumpy, usenumpyfunc=True), np.pi)
+        with self.assertRaisesRegexp(AssertionError, "'__' is not allowed in .* for `usenumpyfunc=True`"):
+            self.config.getExpression('TestNumpy', 'testBadStr', usenumpyfunc=True),
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_mpas_config_parser/config.analysis
+++ b/mpas_analysis/test/test_mpas_config_parser/config.analysis
@@ -43,3 +43,4 @@ testNumpypi0 = pi
 testNumpypi1 = np.pi
 testNumpypi2 = numpy.pi
 testNumpyPi = Pi
+testBadStr = __bad_string__


### PR DESCRIPTION
Prevents use of system built in variables by restricting
string to exclude `__` for use in numpy evaluation.