### PR TITLE
Move variable mapping out of mpas_xarray into new generalized_reader module

### DIFF
--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -1,0 +1,341 @@
+"""
+Utility functions for importing MPAS files into xarray. These functions extend
+the capabilities of mpas_xarray to include mapping variable names from MPAS
+names to MPAS-Analysis generalized names and support for slicing to given
+start and end dates.
+
+open_multifile_dataset : opens a data set, maps variable names, preprocess
+    the data set removes repeated time indices, and slices the time coordinate
+    to lie between desired start and end dates.
+
+Authors
+-------
+Xylar Asay-Davis
+
+Last modified
+-------------
+02/16/2017
+"""
+
+import xarray
+from functools import partial
+
+from ..mpas_xarray import mpas_xarray
+from ..timekeeping.utility import stringToDatetime, clampToNumpyDatetime64
+
+
+def open_multifile_dataset(fileNames, calendar, timeVariableName='Time',
+                           variableList=None, selValues=None,
+                           iselValues=None, variableMap=None,
+                           startDate=None, endDate=None,
+                           yearOffset=0):  # {{{
+    """
+    Opens and returns an xarray data set given file name(s) and the MPAS
+    calendar name.
+
+    Parameters
+    ----------
+    fileNames : list of strings
+        A lsit of file paths to read
+
+    calendar : {'gregorian', 'gregorian_noleap'}, optional
+        The name of one of the calendars supported by MPAS cores
+
+    timeVariableName : string, optional
+        The name of the time variable (typically 'Time' if using a variableMap
+        or 'xtime' if not using a variableMap)
+
+    variableList : list of strings, optional
+        If present, a list of variables to be included in the data set
+
+    selValues : dict, optional
+        A dictionary of coordinate names (keys) and values or arrays of
+        values used to slice the variales in the data set.  See
+        xarray.DataSet.sel() for details on how this dictonary is used.
+        An example:
+            selectCorrdValues = {'cellLon': 180.0}
+
+    iselValues : dict, optional
+        A dictionary of coordinate names (keys) and indices, slices or
+        arrays of indices used to slice the variales in the data set.  See
+        xarray.DataSet.isel() for details on how this dictonary is used.
+        An example:
+            iselValues = {'nVertLevels': slice(0, 3),
+                           'nCells': cellIDs}
+
+    variableMap : dict, optional
+        A dictionary with keys that are variable names used by
+        MPAS-Analysis and values that are lists of possible names for the same
+        variable in the MPAS dycore that produced the data set (which may
+        differ between versions).
+
+    startDate, endDate : string or datetime.datetime, optional
+        If present, the first and last dates to be used in the data set.  The
+        time variable is sliced to only include dates within this range.
+
+    yearOffset : float, optional
+        An offset used to convert an MPAS date to a date in the range supported
+        by xarray (numpy.datetime64).  Resulting dates must be between 1678
+        and 2622.
+
+    Returns
+    -------
+    ds : An xarray data set.
+
+    Raises
+    ------
+    TypeError
+        If the time variable has an unsupported type (not a date string,
+        a floating-pont number of days since the start of the simulation
+        or a numpy.datatime64 object).
+
+    ValueError
+        If the time variable is not found in the data set.
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/16/2017
+    """
+
+    preprocess_partial = partial(_preprocess,
+                                 calendar=calendar,
+                                 timeVariableName=timeVariableName,
+                                 variableList=variableList,
+                                 selValues=selValues,
+                                 iselValues=iselValues,
+                                 variableMap=variableMap,
+                                 startDate=startDate,
+                                 endDate=endDate,
+                                 yearOffset=yearOffset)
+
+    ds = xarray.open_mfdataset(fileNames,
+                               preprocess=preprocess_partial,
+                               decode_times=False, concat_dim='Time')
+
+    ds = mpas_xarray.remove_repeated_time_index(ds)
+
+    if startDate is not None and endDate is not None:
+        if isinstance(startDate, str):
+            startDate = clampToNumpyDatetime64(stringToDatetime(
+                startDate), yearOffset)
+        if isinstance(endDate, str):
+            endDate = clampToNumpyDatetime64(stringToDatetime(
+                endDate), yearOffset)
+
+    # select only the data in the specified range of dates
+    ds = ds.sel(Time=slice(startDate, endDate))
+
+    return ds  # }}}
+
+
+def _preprocess(ds, calendar, timeVariableName, variableList, selValues,
+                iselValues, variableMap, startDate, endDate,
+                yearOffset):  # {{{
+    """
+    Performs variable remapping, then calls mpas_xarray.preprocess, to
+    perform the remainder of preprocessing.
+
+    Parameters
+    ----------
+    ds : xarray.DataSet object
+        The data set containing an MPAS time variable to be used to build
+        an xarray time coordinate and with variable names to be
+        substituted.
+
+    calendar : {'gregorian', 'gregorian_noleap'}, optional
+        The name of one of the calendars supported by MPAS cores
+
+    timeVariableName : string
+        The name of the time variable (typically 'Time' if using a variableMap
+        or 'xtime' if not using a variableMap)
+
+    variableList : list of strings
+        If present, a list of variables to be included in the data set
+
+    selValues : dict
+        A dictionary of coordinate names (keys) and values or arrays of
+        values used to slice the variales in the data set.  See
+        xarray.DataSet.sel() for details on how this dictonary is used.
+        An example:
+            selectCorrdValues = {'cellLon': 180.0}
+
+    iselValues : dict
+        A dictionary of coordinate names (keys) and indices, slices or
+        arrays of indices used to slice the variales in the data set.  See
+        xarray.DataSet.isel() for details on how this dictonary is used.
+        An example:
+            iselValues = {'nVertLevels': slice(0, 3),
+                           'nCells': cellIDs}
+
+    variableMap : dict
+        A dictionary with keys that are variable names used by
+        MPAS-Analysis and values that are lists of possible names for the same
+        variable in the MPAS dycore that produced the data set (which may
+        differ between versions).
+
+    startDate, endDate : string or datetime.datetime
+        If present, the first and last dates to be used in the data set.  The
+        time variable is sliced to only include dates within this range.
+
+    yearOffset : float
+        An offset used to convert an MPAS date to a date in the range supported
+        by xarray (numpy.datetime64).  Resulting dates must be between 1678
+        and 2622.
+
+    Returns
+    -------
+    ds : xarray.DataSet object
+        A copy of the data set with the time coordinate set and which
+        has been sliced.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/16/2017
+    """
+
+    submap = variableMap
+
+    # time_variable_names is a special case so we take it out of the map
+    # and handle it manually (adding a new variable rather than renaming
+    # an existing one)
+    if variableMap is not None and timeVariableName in variableMap:
+        # make a copy of variableMap and remove timeVariableName
+        submap = variableMap.copy()
+        submap.pop(timeVariableName, None)
+        # temporarily change the time variable name
+        timeVariableName = \
+            _map_variable_name(timeVariableName,
+                               ds,
+                               variableMap)
+
+    if submap is not None:
+        ds = _rename_variables(ds, submap)
+
+    # now that the variables are mapped, do the normal preprocessing in
+    # mpas_xarray
+    ds = mpas_xarray.preprocess(ds,
+                                timeVariableName=timeVariableName,
+                                variableList=variableList,
+                                selValues=selValues,
+                                iselValues=iselValues,
+                                yearOffset=yearOffset)
+
+    return ds  # }}}
+
+
+def _map_variable_name(variableName, ds, variableMap):  # {{{
+    """
+    Given a `variableName` in a `variableMap` and an xarray `ds`,
+    return the name of the the first variable in `variableMap[variableName]`
+    that is found in ds.
+
+    variableMap is a dictionary with keys that are variable names used by
+    MPAS-Analysis and values that are lists of possible names for the same
+    variable in the MPAS dycore that produced the data set (which may differ
+    between versions).
+
+    Parameters
+    ----------
+    variableName : string
+        Name of a variable in `varriableMap`
+
+    ds : `xarray.DataSet` object
+        A data set in which the mapped variable name should be found
+
+    variableMap : dict
+        A dictionary with keys that are variable names used by
+        MPAS-Analysis and values that are lists of possible names for the same
+        variable in the MPAS dycore that produced the data set (which may
+        differ between versions).
+
+    Returns
+    -------
+    mappedVariableName : The corresponding variable name to `variableName`
+        found in `ds`.
+
+    Raises
+    ------
+    ValueError
+        If none of the possible variable names in `variableMap[variableName]`
+        can be found in `ds`.
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/08/2017
+    """
+    possibleVariables = variableMap[variableName]
+    for variable in possibleVariables:
+        if isinstance(variable, (list, tuple)):
+            allFound = True
+            for subvariable in variable:
+                if subvariable not in ds.data_vars.keys():
+                    allFound = False
+                    break
+            if allFound:
+                return variable
+
+        elif variable in ds.data_vars.keys():
+            return variable
+
+    raise ValueError('Variable {} could not be mapped. None of the '
+                     'possible mapping variables {}\n match any of the '
+                     'variables in {}.'.format(
+                         variableName, possibleVariables,
+                         ds.data_vars.keys()))
+    # }}}
+
+
+def _rename_variables(ds, variableMap):  # {{{
+    """
+    Given an `xarray.DataSet` object `ds` and a dictionary mapping
+    variable names `variableMap`, returns a new data set in which variables
+    from `ds` with names equal to values in `variableMap` are renamed
+    to the corresponding key in `variableMap`.
+
+    Parameters
+    ----------
+    ds : `xarray.DataSet` object
+        A data set in which the mapped variable names should be renamed
+
+    variableMap : dict
+        A dictionary with keys that are variable names used by
+        MPAS-Analysis and values that are lists of possible names for the same
+        variable in the MPAS dycore that produced the data set (which may
+        differ between versions).
+
+    Returns
+    -------
+    outDataSEt : A new `xarray.DataSet` object with the variable renamed.
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/08/2017
+    """
+
+    renameDict = {}
+    for datasetVariable in ds.data_vars:
+        for mapVariable in variableMap:
+            renameList = variableMap[mapVariable]
+            if datasetVariable in renameList:
+                renameDict[datasetVariable] = mapVariable
+                break
+
+    return ds.rename(renameDict)  # }}}
+
+# vim: ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -1,61 +1,142 @@
-#!/usr/bin/env python
-"""
-mpas_xarray.py
-==============================================================
-Wrapper to handle importing MPAS files into xarray.
-
- Module:
- 1. converts MPAS time in various formats to xarray time.  The MPAS time
-    variable is provided via
-    `preprocess_mpas(..., timestr='xtime', ...)`.
-    `timestr` can either be a single variable name or a pair of variable
-    names.  In the latter case, each time variable is converted to an
-    xarray time and the mean of the two times is used as the final xarray
-    time.  Each variable name in `timestr` can refer either to a float
-    array containing the the number of days since the start of the
-    simulation (e.g. `daysSinceStartOfSim`) or a string variable with the
-    date and time (e.g. `xtime`) in the usual MPAS format:
-    YYYY-MM-DD_hh:mm:ss
- 2. provides capability to remove redundant time entries from reading of
-    multiple netCDF datasets via `remove_repeated_time_index`.
- 3. provides capability to build a variable map between MPAS dycore variable
-    names and those used in mpas_analysis.  This aids in supporting multiple
-    versions of MPAS dycores.  The function `map_variable(...)` can be used
-    to find the associated MPAS dycore variable name in a dataset given a
-    variable name as used in mpas_analysis.  The function
-    `rename_variables(...)` can be used to rename all variables in a variable
-    map from their MPAS dycore names to the corresponding mpas_analysis names.
-
- Example Usage:
-
->>> from mpas_xarray import preprocess_mpas, remove_repeated_time_index
->>>
->>> ds = xarray.open_mfdataset('globalStats*nc', preprocess=preprocess_mpas)
->>> ds = remove_repeated_time_index(ds)
-
-Phillip J. Wolfram, Xylar Asay-Davis
-Last modified: 12/07/2016
-"""
-
 import datetime
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-import xarray as xr
+import xarray
+from functools import partial
+
+"""
+Utility functions for importing MPAS files into xarray.
+
+open_multifile_dataset : open an xarray data set from MPAS data files
+subset_variables : Keep only a subset of variables in a dataset
+preprocess : preprocess a single file of an xarray dataset
+remove_repeated_time_index : remove redundant indices in the 'Time' coordinate
+
+Authors
+-------
+Phillip J. Wolfram, Xylar Asay-Davis
+
+Last modified
+-------------
+02/16/2017
+"""
 
 
-def subset_variables(ds, vlist):  # {{{
+def open_multifile_dataset(fileNames, timeVariableName='Time',
+                           variableList=None, selValues=None,
+                           iselValues=None, yearOffset=0):  # {{{
     """
-    Reduces an xarray dataset ds to only contain the variables in vlist.
+    Opens and returns an xarray data set given file name(s) and the MPAS
+    calendar name.
 
-    Phillip J. Wolfram
-    01/10/2017
+    Parameters
+    ----------
+    fileNames : list of strings
+        A lsit of file paths to read
+
+    timeVariableName : string, optional
+        The name of the time variable (typically 'Time' if using a variableMap
+        or 'xtime' if not using a variableMap)
+
+    variableList : list of strings, optional
+        If present, a list of variables to be included in the data set
+
+    selectCorrdValues : dict, optional
+        A dictionary of coordinate names (keys) and values or arrays of
+        values used to slice the variales in the data set.  See
+        xarray.DataSet.sel() for details on how this dictonary is used.
+        An example:
+            selectCorrdValues = {'cellLon': 180.0}
+
+    iselValues : dict, optional
+        A dictionary of coordinate names (keys) and indices, slices or
+        arrays of indices used to slice the variales in the data set.  See
+        xarray.DataSet.isel() for details on how this dictonary is used.
+        An example:
+            iselValues = {'nVertLevels': slice(0, 3),
+                           'nCells': cellIDs}
+
+    yearOffset : float, optional
+        An offset used to convert an MPAS date to a date in the range supported
+        by xarray (numpy.datetime64).  Resulting dates must be between 1678
+        and 2622.
+
+    Returns
+    -------
+    ds : An xarray data set.
+
+    Raises
+    ------
+    TypeError
+        If the time variable has an unsupported type (not a date string,
+        a floating-pont number of days since the start of the simulation
+        or a numpy.datatime64 object).
+
+    ValueError
+        If the time variable is not found in the data set.
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/16/2017
+    """
+
+    preprocess_partial = partial(preprocess,
+                                 timeVariableName=timeVariableName,
+                                 variableList=variableList,
+                                 selValues=selValues,
+                                 iselValues=iselValues,
+                                 yearOffset=yearOffset)
+
+    ds = xarray.open_mfdataset(fileNames,
+                               preprocess=preprocess_partial,
+                               decode_times=False, concat_dim='Time')
+
+    ds = remove_repeated_time_index(ds)
+
+    return ds  # }}}
+
+
+def subset_variables(ds, variableList):  # {{{
+    """
+    Given a data set and a list of variable names, returns a new data set that
+    contains only variables with those names.
+
+    Parameters
+    ----------
+    ds : xarray.DataSet object
+        The data set from which a subset of variables is to be extracted.
+
+    variableList : string or list of strings
+        The names of the variables to be extracted.
+
+    Returns
+    -------
+    ds : xarray.DataSet object
+        A copy of the original data set with only the variables in
+        variableList.
+
+    Raises
+    ------
+    ValueError
+        If the resulting data set is empty.
+
+    Authors
+    -------
+    Phillip J. Wolfram, Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/16/2017
     """
 
     allvars = ds.data_vars.keys()
 
     # get set of variables to drop (all ds variables not in vlist)
-    dropvars = set(allvars) - set(vlist)
+    dropvars = set(allvars) - set(variableList)
 
     # drop spurious variables
     ds = ds.drop(dropvars)
@@ -69,51 +150,185 @@ def subset_variables(ds, vlist):  # {{{
     # drop spurious coordinates
     ds = ds.drop(dropcoords)
 
-    assert len(ds.variables.keys()) > 0, \
-        'MPAS_XARRAY ERROR: Empty dataset is returned.\n' \
-        'Variables {}\nare not found within the dataset ' \
-        'variables: {}.'.format(vlist, allvars)
+    if len(ds.data_vars.keys()) == 0:
+        raise ValueError(
+                'Empty dataset is returned.\n'
+                'Variables {}\n'
+                'are not found within the dataset '
+                'variables: {}.'.format(variableList, allvars))
 
     return ds  # }}}
 
 
-def assert_valid_datetimes(datetimes, yearoffset):  # {{{
+def preprocess(ds, timeVariableName, variableList, selValues,
+               iselValues, yearOffset):  # {{{
+    """
+    Builds correct time specification for MPAS, allowing a date offset
+    because the time must be between 1678 and 2262 based on the xarray
+    library.  Also, if slicing information (`selValues` and/or
+    `iselValues`) was provided in `openMultifileDataSet`, this
+    function performs the appropriate slicing on the data set.
+
+    Parameters
+    ----------
+    ds : xarray.DataSet object
+        The data set containing an MPAS time variable to be used to build
+        an xarray time coordinate.
+
+    timeVariableName : string
+        The name of the time variable (typically 'Time' if using a variableMap
+        or 'xtime' if not using a variableMap)
+
+    variableList : list of strings
+        If present, a list of variables to be included in the data set
+
+    selectCorrdValues : dict
+        A dictionary of coordinate names (keys) and values or arrays of
+        values used to slice the variales in the data set.  See
+        xarray.DataSet.sel() for details on how this dictonary is used.
+        An example:
+            selectCorrdValues = {'cellLon': 180.0}
+
+    iselValues : dict
+        A dictionary of coordinate names (keys) and indices, slices or
+        arrays of indices used to slice the variales in the data set.  See
+        xarray.DataSet.isel() for details on how this dictonary is used.
+        An example:
+            iselValues = {'nVertLevels': slice(0, 3),
+                           'nCells': cellIDs}
+
+    yearOffset : float
+        An offset used to convert an MPAS date to a date in the range supported
+        by xarray (numpy.datetime64).  Resulting dates must be between 1678
+        and 2622.
+
+    Returns
+    -------
+    ds : xarray.DataSet object
+        A copy of the data set with the time coordinate set and which
+        has been sliced.
+
+    Authors
+    -------
+    Phillip J. Wolfram, Milena Veneziani, Luke van Roekel
+    and Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/16/2017
+    """
+
+    datetimes = _get_datetimes(ds, timeVariableName,
+                               yearOffset)
+
+    _assert_valid_datetimes(datetimes, yearOffset)
+
+    # append the corret time information
+    ds.coords['Time'] = datetimes
+    # record the yroffset
+    ds.attrs.__setitem__('time_yearoffset', str(yearOffset))
+
+    if variableList is not None:
+        ds = subset_variables(ds,
+                              _ensure_list(variableList))
+
+    _assert_valid_selections(ds, selValues,
+                             iselValues)
+
+    if selValues is not None:
+        ds = ds.sel(**selValues)
+
+    if iselValues is not None:
+        ds = ds.isel(**iselValues)
+
+    return ds  # }}}
+
+
+def remove_repeated_time_index(ds):  # {{{
+    """
+    Remove repeated times from xarray dataset.
+
+    Parameters
+    ----------
+    ds : xarray.DataSet object
+        The data set potentially containing repeated time indices.
+
+    Returns
+    -------
+    ds : xarray.DataSet object
+        A copy of the original data set with any repeated time indices removed.
+
+    Authors
+    -------
+    Phillip J. Wolfram, Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/10/2017
+    """
+    # get repeated indices
+    times = ds.Time.values
+    indices = range(len(times))
+    uniqueTimes = set()
+    remove = []
+    for timeIndex, time in enumerate(times):
+        if time not in uniqueTimes:
+            uniqueTimes.add(time)
+        else:
+            remove.append(timeIndex)
+
+    # remove repeaded indices, working backwards from the last
+    remove.reverse()
+    for timeIndex in remove:
+        indices.pop(timeIndex)
+
+    # remove repeated indices
+    ds = ds.isel(Time=indices)
+
+    return ds  # }}}
+
+
+def _assert_valid_datetimes(datetimes, yearOffset):  # {{{
     """
     Ensure that datatimes are compatable with xarray
 
-    Phillip J. Wolfram
-    04/20/2016
+    Authors
+    -------
+    Phillip J. Wolfram, Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/16/2017
     """
     assert datetimes[0].year > 1678, \
-        'ERROR: yearoffset={}'.format(yearoffset) + \
+        'ERROR: yearOffset={}'.format(yearOffset) + \
         ' must be large enough to ensure datetimes larger than year 1678'
     assert datetimes[-1].year < 2262, \
-        'ERROR: yearoffset={}'.format(yearoffset) + \
+        'ERROR: yearOffset={}'.format(yearOffset) + \
         ' must be small enough to ensure datetimes smaller than year 2262'
 
     return  # }}}
 
 
-def assert_valid_selections(ds, selvals, iselvals):  # {{{
+def _assert_valid_selections(ds, selvals, iselvals):  # {{{
     """
     Ensure that dataset selections are compatable.
 
-    It is possible selVals and iselVals may conflict, e.g., selVals restricts
-    the dataset to a point where iselvals is unable to be satisfied, hence a
-    check is needed to make sure that keys in selvals and iselvals are unique.
-    Additionally, keys for selvals and iselvals are tested to make sure they
-    are dataset dimensions that can be used for selection.
+    It is possible selVals and iselVals may conflict, e.g., selVals
+    restricts the dataset to a point where iselvals is unable to be
+    satisfied, hence a check is needed to make sure that keys in selvals
+    and iselvals are unique.  Additionally, keys for selvals and iselvals
+    are tested to make sure they are dataset dimensions that can be used
+    for selection.
 
-    Phillip J. Wolfram
-    Last modified: 12/07/2016
+    Authors
+    -------
+    Phillip J. Wolfram, Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/10/2017
     """
-
-    if (selvals is not None) and (iselvals is not None):
-        duplicatedkeys = len(np.intersect1d(selvals.keys(), iselvals.keys()))
-        assert len(duplicatedkeys) == 0, \
-            'Duplicated selection of variables {} was found!  ' \
-            'Selection is ambiguous.'.format(duplicatedkeys)
-
     def test_vals_in_ds(vals, dims):
         if vals is not None:
             for val in vals.keys():
@@ -121,18 +336,30 @@ def assert_valid_selections(ds, selvals, iselvals):  # {{{
                     '{} is not a dimension in the dataset ' \
                     'that can be used for selection.'.format(val)
 
+    if (selvals is not None) and (iselvals is not None):
+        duplicatedkeys = len(np.intersect1d(selvals.keys(),
+                                            iselvals.keys()))
+        assert len(duplicatedkeys) == 0, \
+            'Duplicated selection of variables {} was found!  ' \
+            'Selection is ambiguous.'.format(duplicatedkeys)
+
     test_vals_in_ds(selvals, ds.dims)
     test_vals_in_ds(iselvals, ds.dims)
 
     return  # }}}
 
 
-def ensure_list(alist):  # {{{
+def _ensure_list(alist):  # {{{
     """
     Ensure that variables used as a list are actually lists.
 
-    Phillip J. Wolfram
-    09/08/2016
+    Authors
+    -------
+    Phillip J. Wolfram, Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/10/2017
     """
 
     if isinstance(alist, str):
@@ -142,285 +369,92 @@ def ensure_list(alist):  # {{{
     return alist  # }}}
 
 
-def get_datetimes(ds, timestr, yearoffset):  # {{{
+def _get_datetimes(ds, timeVariableName, yearOffset):  # {{{
     """
-    Computes a list of datetimes from the time variable in the dataset ds with
-    variable name (or a list of 2 names) given by timestr, typically one of
-    'daysSinceStartOfSim', 'xtime', or ['xtime_start', 'xtime_end'].
+    A helper function for computing a time coordinate from an MPAS time
+    variable.  Given a data set and a time variable name (or tuple of 2
+    time names), returns a list of objects representing the time coordinate
 
-    The variable(s) pointed to by timestr should contain time information as a
-    date string, a floating-point number of days or a number of days
-    represented as a pandas timedelta (in ns).  The result is a list of
-    datetimes corresponding to the input dates offset as appropriate by the
-    yearoffset.
+    Parameters
+    ----------
+    ds : xarray.DataSet object
+        The data set containing an MPAS time variable to be used to build
+        an xarray time coordinate.
 
+    timeVariableName : string or tuple or list of strings, optional
+        The name of the time variable in the MPAS data set that will be
+        used to build the 'Time' coordinate.  The array(s) named by
+        timeVariableName should contain date strings or the number of
+        days since the start of the simulation. Typically,
+        timeVariableName is one of {'daysSinceStartOfSim','xtime'}.
+        If a list of two variable
+        names is provided, times from the two are averaged together to
+        determine the value of the time coordinate.  In such cases,
+        timeVariableName is typically {['xtime_start', 'xtime_end']}.
+
+    yearOffset : int, optional
+        An offset to be added to all years in the resulting array of dates.
+        This offset is typically required to convert MPAS dates
+        starting with year 0001 into dates in the range supported by xarray
+        (1678 <= year <= 2262).
+
+    Returns
+    -------
+    datetimes : list of datetime.datetime objects
+        An array that represents the xarray time coordinate for the
+        data set, based on the given MPAs time variable name.
+
+    Raises
+    ------
+    TypeError
+        If the time variable has an unsupported type (not a date string,
+        a floating-pont number of days since the start of the simulation
+        or a numpy.datatime64 object).
+
+    Authors
+    -------
     Xylar Asay-Davis
-    Last modified: 12/05/2016
+
+    Last modified
+    -------------
+    02/16/2017
     """
 
-    if isinstance(timestr, (tuple, list)):
+    if isinstance(timeVariableName, (tuple, list)):
         # we want to average the two
-        assert(len(timestr) == 2)
-        starts = get_datetimes(ds, timestr[0], yearoffset)
-        ends = get_datetimes(ds, timestr[1], yearoffset)
+        assert(len(timeVariableName) == 2)
+        starts = _get_datetimes(ds, timeVariableName[0], yearOffset)
+        ends = _get_datetimes(ds, timeVariableName[1], yearOffset)
         datetimes = [starts[i] + (ends[i] - starts[i])/2
                      for i in range(len(starts))]
         return datetimes
 
-    time_var = ds[timestr]
+    timeVariable = ds[timeVariableName]
 
-    if time_var.dtype == '|S64':
+    if timeVariable.dtype == '|S64':
         # this is a variable like date strings like 'xtime'
-        time = [''.join(atime).strip() for atime in time_var.values]
-        datetimes = [datetime.datetime(yearoffset + int(x[:4]), int(x[5:7]),
-                                       int(x[8:10]), int(x[11:13]),
-                                       int(x[14:16]), int(x[17:19]))
+        time = [''.join(atime).strip() for atime in timeVariable.values]
+        datetimes = [datetime.datetime(yearOffset + int(x[:4]),
+                                       int(x[5:7]), int(x[8:10]),
+                                       int(x[11:13]), int(x[14:16]),
+                                       int(x[17:19]))
                      for x in time]
-    elif time_var.dtype == 'float64':
-        # this array contains floating-point days like 'daysSinceStartOfSim'
-        start = datetime.datetime(year=yearoffset+1, month=1, day=1)
+    elif timeVariable.dtype == 'float64':
+        # this array contains floating-point days like
+        # 'daysSinceStartOfSim'
+        start = datetime.datetime(year=yearOffset+1, month=1, day=1)
         datetimes = [start + datetime.timedelta(x)
-                     for x in time_var.values]
-    elif time_var.dtype == 'timedelta64[ns]':
+                     for x in timeVariable.values]
+    elif timeVariable.dtype == 'timedelta64[ns]':
         # this array contains a variable like 'daysSinceStartOfSim' as a
         # timedelta64
-        start = datetime.datetime(year=yearoffset+1, month=1, day=1)
+        start = datetime.datetime(year=yearOffset+1, month=1, day=1)
         datetimes = [start + x for x in
-                     pd.to_timedelta(time_var.values, unit='ns')]
+                     pd.to_timedelta(timeVariable.values, unit='ns')]
     else:
-        raise TypeError("time_var of unsupported type {}".format(
-            time_var.dtype))
+        raise TypeError("timeVariable of unsupported type {}".format(
+            timeVariable.dtype))
 
     return datetimes  # }}}
-
-
-def map_variable(variable_name, ds, varmap):  # {{{
-    """
-    Find the variable (or list of variables) in dataset ds that map to the
-    mpas_analysis variable given by variable_name.
-
-    varmap is a dictionary with keys that are variable names used by
-    MPAS-Analysis and values that are lists of possible names for the same
-    variable in the MPAS dycore that produced the data set (which may differ
-    between versions).
-
-    Xylar Asay-Davis
-    12/04/2016
-    """
-    possible_variables = varmap[variable_name]
-    for var in possible_variables:
-        if isinstance(var, (list, tuple)):
-            allFound = True
-            for subvar in var:
-                if subvar not in ds.data_vars.keys():
-                    allFound = False
-                    break
-            if allFound:
-                return var
-
-        elif var in ds.data_vars.keys():
-            return var
-
-    raise ValueError('Variable {} could not be mapped. None of the '
-                     'possible mapping variables {}\n match any of the '
-                     'variables in {}.'.format(
-                         variable_name, possible_variables,
-                         ds.data_vars.keys()))
-    # }}}
-
-
-def rename_variables(ds, varmap, timestr):  # {{{
-    """
-    Rename all variables in ds based on which are found in varmap.
-
-    varmap is a dictionary with keys that are variable names used by
-    MPAS-Analysis and values that are lists of possible names for the same
-    variable in the MPAS dycore that produced the data set (which may differ
-    between versions).
-
-    timestr is points to the time variable(s), which are treated as a special
-    case since they may need to be averaged.
-
-    Returns a new timestr after mapping in timestr is in varmap, otherwise
-    returns timestr unchanged.
-
-    Xylar Asay-Davis
-    12/08/2016
-    """
-
-    submap = varmap
-    if timestr in varmap:
-        # make a copy of varmap and remove timestr
-        submap = varmap.copy()
-        submap.pop(timestr, None)
-
-    rename_dict = {}
-    for ds_var in ds.data_vars:
-        for map_var in submap:
-            rename_list = varmap[map_var]
-            if ds_var in rename_list:
-                rename_dict[ds_var] = map_var
-                break
-
-    ds.rename(rename_dict, inplace=True)
-
-    if timestr in varmap:
-        timestr = map_variable(timestr, ds, varmap)
-
-    return timestr  # }}}
-
-
-def preprocess_mpas(ds, onlyvars=None, selvals=None, iselvals=None,
-                    timestr='xtime', yearoffset=1849,
-                    varmap=None):  # {{{
-    """
-    Builds correct time specification for MPAS, allowing a date offset because
-    the time must be between 1678 and 2262 based on the xarray library.
-
-    The time specification is relevant for so-called time-slice model
-    experiments, in which CO2 and greenhouse gas conditions are kept
-    constant over the entire model simulation. Typical time-slice experiments
-    are run with 1850 (pre-industrial) conditions and 2000 (present-day)
-    conditions. Hence, a default date offset is chosen to be yearoffset=1849,
-    (year 0001 of an 1850 run will correspond with Jan 1st, 1850).
-
-    The data set is assumed to have an array of date strings with variable
-    name (or list of 2 names) given by timestr, typically one of
-    'daysSinceStartOfSim', 'xtime', or ['xtime_start', 'xtime_end'].
-
-    The onlyvars option reduces the dataset to only include variables in the
-    onlyvars list. If onlyvars=None, include all dataset variables.
-
-    iselvals and selvals provide index and value-based slicing operations for
-    individual datasets prior to their merge via xarray.
-    iselvals is a dictionary, e.g. iselvals = {'nVertLevels': slice(0, 3),
-                                               'nCells': cellIDs}
-    selvals is a dictionary, e.g. selvals = {'cellLon': 180.0}
-
-    varmap is an optional dictionary that can be used to rename
-    variables in the data set to standard names expected by mpas_analysis.
-    If timestr is present in varmap, the values of varmap[timestr]
-    will be used to determine the associated time variable in ds. However, the
-    variable(s) associated with timestr in ds will not be renamed.  This is
-    because there may be more than one variable in ds that maps to timestr
-    (e.g. xtime_start and xtime_end), so that a one-to-one mapping is not
-    possible for this variable.
-
-    Phillip J. Wolfram, Milena Veneziani, Luke van Roekel and Xylar Asay-Davis
-    Last modified: 12/05/2016
-    """
-
-    if varmap is not None:
-        timestr = rename_variables(ds, varmap, timestr)
-
-    datetimes = get_datetimes(ds, timestr, yearoffset)
-
-    assert_valid_datetimes(datetimes, yearoffset)
-
-    # append the corret time information
-    ds.coords['Time'] = datetimes
-    # record the yroffset
-    ds.attrs.__setitem__('time_yearoffset', str(yearoffset))
-
-    if onlyvars is not None:
-        ds = subset_variables(ds, ensure_list(onlyvars))
-
-    assert_valid_selections(ds, selvals, iselvals)
-
-    if selvals is not None:
-        ds = ds.sel(**selvals)
-
-    if iselvals is not None:
-        ds = ds.isel(**iselvals)
-
-    return ds  # }}}
-
-
-def remove_repeated_time_index(ds):  # {{{
-    """
-    Remove repeated times from xarray dataset.
-
-    Phillip J. Wolfram
-    12/01/2015
-    """
-    # get repeated indices
-    time = ds.Time.values
-    index = range(len(time))
-    uniquetime = set()
-    remove = []
-    for tid, atime in enumerate(time):
-        if atime not in uniquetime:
-            uniquetime.add(atime)
-        else:
-            remove.append(tid)
-
-    remove.reverse()
-    for tid in remove:
-        index.pop(tid)
-
-    # remove repeated indices
-    ds = ds.isel(Time=index)
-
-    return ds  # }}}
-
-
-def test_load_mpas_xarray_datasets(path):  # {{{
-    ds = xr.open_mfdataset(path, preprocess=lambda x:
-                           preprocess_mpas(x, yearoffset=1850))
-    ds = remove_repeated_time_index(ds)
-
-    # make a simple plot from the data
-    ds.Time.plot()
-    plt.show()
-
-    return  # }}}
-
-
-def test_load_mpas_xarray_timeSeriesStats_datasets(path):  # {{{
-    timestr = 'timeSeriesStatsMonthly_avg_daysSinceStartOfSim_1'
-    ds = xr.open_mfdataset(path, preprocess=lambda x:
-                           preprocess_mpas(x,
-                                           timeSeriesStats=True,
-                                           timestr=timestr))
-    ds = remove_repeated_time_index(ds)
-    ds2 = xr.open_mfdataset(path, preprocess=lambda x:
-                            preprocess_mpas(x, yearoffset=1850))
-    ds2 = remove_repeated_time_index(ds2)
-
-    # make a simple plot from the data
-    def plot_data(ds):
-        var = ds["timeSeriesStatsMonthly_avg_iceAreaCell_1"]
-        return var.where(var > 0).mean('nCells').plot()
-
-    plot_data(ds)
-    plot_data(ds2)
-    plt.title("Curve centered around right times (b) \n " +
-              "Curve shifted towards end of avg period (g)")
-    plt.show()
-
-    return  # }}}
-
-
-if __name__ == "__main__":
-    from optparse import OptionParser
-
-    parser = OptionParser()
-    parser.add_option("-f", "--file", dest="inputfilename",
-                      help="files to be opened with xarray, could be of form "
-                      "'output*.nc'",
-                      metavar="FILE")
-    parser.add_option("--istimeavg", dest="istimeavg",
-                      help="option to use the preprocess for "
-                      "timeSeriesStatsAM fields")
-
-    options, args = parser.parse_args()
-    if not options.inputfilename:
-        parser.error("Input filename or expression ('-f') is a required"
-                     "input, e.g. -f 'output*.npz'")
-
-    if not options.istimeavg:
-        test_load_mpas_xarray_datasets(options.inputfilename)
-    else:
-        test_load_mpas_xarray_timeSeriesStats_datasets(options.inputfilename)
 
 # vim: ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_generalized_reader.py
+++ b/mpas_analysis/test/test_generalized_reader.py
@@ -1,0 +1,103 @@
+"""
+Unit test infrastructure for the generalized_reader.
+
+Xylar Asay-Davis
+02/15/20167
+"""
+
+import pytest
+from mpas_analysis.test import TestCase, loaddatadir
+from mpas_analysis.shared.generalized_reader.generalized_reader \
+    import open_multifile_dataset
+
+
+@pytest.mark.usefixtures("loaddatadir")
+class TestGeneralizedReader(TestCase):
+
+    def test_variable_map(self):
+        fileName = str(self.datadir.join('example_jan.nc'))
+        variableMap = {
+            'avgSurfaceTemperature':
+                ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature',
+                 'other_string',
+                 'yet_another_string'],
+            'daysSinceStartOfSim':
+                ['time_avg_daysSinceStartOfSim',
+                 'xtime',
+                 'something_else'],
+            'avgLayerTemperature':
+                ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
+                 'test1',
+                 'test2'],
+            'Time': [['xtime_start', 'xtime_end'],
+                     'time_avg_daysSinceStartOfSim']}
+
+        variableList = ['avgSurfaceTemperature', 'avgLayerTemperature',
+                        'refBottomDepth', 'daysSinceStartOfSim']
+
+        for calendar in ['gregorian', 'gregorian_noleap']:
+            # preprocess_mpas will use variableMap to map the variable names
+            # from their values in the file to the desired values in
+            # variableList
+            ds = open_multifile_dataset(fileNames=fileName,
+                                        calendar=calendar,
+                                        timeVariableName='Time',
+                                        variableList=variableList,
+                                        variableMap=variableMap,
+                                        yearOffset=1850)
+
+            # make sure the remapping happened as expected
+            self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
+
+    def test_open_dataset_fn(self):
+        fileName = str(self.datadir.join('example_jan.nc'))
+        timestr = ['xtime_start', 'xtime_end']
+        variableList = \
+            ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
+
+        for calendar in ['gregorian', 'gregorian_noleap']:
+            ds = open_multifile_dataset(fileNames=fileName,
+                                        calendar=calendar,
+                                        timeVariableName=timestr,
+                                        variableList=variableList,
+                                        yearOffset=1850)
+            self.assertEqual(ds.data_vars.keys(), variableList)
+
+    def test_start_end(self):
+        fileName = str(self.datadir.join('example_jan_feb.nc'))
+        timestr = ['xtime_start', 'xtime_end']
+        variableList = \
+            ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
+
+        for calendar in ['gregorian', 'gregorian_noleap']:
+            # all dates
+            ds = open_multifile_dataset(fileNames=fileName,
+                                        calendar=calendar,
+                                        timeVariableName=timestr,
+                                        variableList=variableList,
+                                        startDate='0001-01-01',
+                                        endDate='9999-12-31',
+                                        yearOffset=1850)
+            self.assertEqual(len(ds.Time), 2)
+
+            # just the first date
+            ds = open_multifile_dataset(fileNames=fileName,
+                                        calendar=calendar,
+                                        timeVariableName=timestr,
+                                        variableList=variableList,
+                                        startDate='0005-01-01',
+                                        endDate='0005-02-01',
+                                        yearOffset=1850)
+            self.assertEqual(len(ds.Time), 1)
+
+            # just the second date
+            ds = open_multifile_dataset(fileNames=fileName,
+                                        calendar=calendar,
+                                        timeVariableName=timestr,
+                                        variableList=variableList,
+                                        startDate='0005-02-01',
+                                        endDate='0005-03-01',
+                                        yearOffset=1850)
+            self.assertEqual(len(ds.Time), 1)
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_generalized_reader/example_jan.nc
+++ b/mpas_analysis/test/test_generalized_reader/example_jan.nc
@@ -1,0 +1,1 @@
+../test_mpas_xarray/example_jan.nc

--- a/mpas_analysis/test/test_generalized_reader/example_jan_feb.nc
+++ b/mpas_analysis/test/test_generalized_reader/example_jan_feb.nc
@@ -1,0 +1,1 @@
+../test_mpas_xarray/example_jan_feb.nc

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -2,73 +2,65 @@
 Unit test infrastructure for mpas_xarray.
 
 Xylar Asay-Davis, Phillip J. Wolfram
-12/07/2016
+02/15/2017
 """
 
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.mpas_xarray import mpas_xarray
-import xarray as xr
 import pandas as pd
 
 
 @pytest.mark.usefixtures("loaddatadir")
-class TestNamelist(TestCase):
+class TestMpasXarray(TestCase):
 
     def test_subset_variables(self):
         fileName = str(self.datadir.join('example_jan.nc'))
         timestr = ['xtime_start', 'xtime_end']
-        varList = ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
+        variableList = \
+            ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
 
         # first, test loading the whole data set and then calling
         # subset_variables explicitly
-        ds = xr.open_mfdataset(
-            fileName,
-            preprocess=lambda x: mpas_xarray.preprocess_mpas(x,
-                                                             timestr=timestr,
-                                                             yearoffset=1850))
-        ds = mpas_xarray.subset_variables(ds, varList)
-        self.assertEqual(sorted(ds.data_vars.keys()), sorted(varList))
+        ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                                timeVariableName=timestr,
+                                                yearOffset=1850)
+        ds = mpas_xarray.subset_variables(ds, variableList)
+        self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
         self.assertEqual(pd.Timestamp(ds.Time.values[0]),
                          pd.Timestamp('1855-01-16 12:22:30'))
 
         # next, test the same with the onlyvars argument
-        ds = xr.open_mfdataset(
-            fileName,
-            preprocess=lambda x: mpas_xarray.preprocess_mpas(x,
-                                                             timestr=timestr,
-                                                             onlyvars=varList,
-                                                             yearoffset=1850))
-        self.assertEqual(ds.data_vars.keys(), varList)
+        ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                                timeVariableName=timestr,
+                                                variableList=variableList,
+                                                yearOffset=1850)
+        self.assertEqual(ds.data_vars.keys(), variableList)
 
-        with self.assertRaisesRegexp(AssertionError,
+        with self.assertRaisesRegexp(ValueError,
                                      'Empty dataset is returned.'):
             missingvars = ['foo', 'bar']
-            ds = xr.open_mfdataset(
-                fileName,
-                preprocess=lambda x:
-                    mpas_xarray.preprocess_mpas(x,
-                                                timestr=timestr,
-                                                onlyvars=missingvars,
-                                                yearoffset=1850))
+            ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                                    timeVariableName=timestr,
+                                                    variableList=missingvars,
+                                                    yearOffset=1850)
 
     def test_iselvals(self):
         fileName = str(self.datadir.join('example_jan.nc'))
         timestr = 'time_avg_daysSinceStartOfSim'
-        varList = \
+        variableList = \
             ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
              'refBottomDepth']
 
         iselvals = {'nVertLevels': slice(0, 3)}
-        ds = xr.open_mfdataset(
-            fileName,
-            preprocess=lambda x: mpas_xarray.preprocess_mpas(x,
-                                                             timestr=timestr,
-                                                             onlyvars=varList,
-                                                             iselvals=iselvals,
-                                                             yearoffset=1850))
-        self.assertEqual(sorted(ds.data_vars.keys()), sorted(varList))
-        self.assertEqual(ds[varList[0]].shape, (1, 7, 3))
+        ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                                timeVariableName=timestr,
+                                                variableList=variableList,
+                                                iselValues=iselvals,
+                                                yearOffset=1850)
+
+        self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
+        self.assertEqual(ds[variableList[0]].shape, (1, 7, 3))
         self.assertEqual(ds['refBottomDepth'].shape, (3,))
         self.assertApproxEqual(ds['refBottomDepth'][-1],
                                4.882000207901)
@@ -80,17 +72,15 @@ class TestNamelist(TestCase):
     def test_no_units(self):
         fileName = str(self.datadir.join('example_no_units_jan.nc'))
         timestr = 'time_avg_daysSinceStartOfSim'
-        varList = \
+        variableList = \
             ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
              'refBottomDepth']
 
-        ds = xr.open_mfdataset(
-            fileName,
-            preprocess=lambda x: mpas_xarray.preprocess_mpas(x,
-                                                             timestr=timestr,
-                                                             onlyvars=varList,
-                                                             yearoffset=1850))
-        self.assertEqual(sorted(ds.data_vars.keys()), sorted(varList))
+        ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                                timeVariableName=timestr,
+                                                variableList=variableList,
+                                                yearOffset=1850)
+        self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
         date = pd.Timestamp(ds.Time.values[0])
         # round to nearest second
         date = pd.Timestamp(long(round(date.value, -9)))
@@ -99,7 +89,7 @@ class TestNamelist(TestCase):
     def test_bad_selvals(self):
         fileName = str(self.datadir.join('example_jan.nc'))
         timestr = 'time_avg_daysSinceStartOfSim'
-        varList = \
+        variableList = \
             ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
              'refBottomDepth']
 
@@ -107,95 +97,53 @@ class TestNamelist(TestCase):
         with self.assertRaisesRegexp(AssertionError,
                                      'not a dimension in the dataset that '
                                      'can be used for selection'):
-            ds = xr.open_mfdataset(
-                fileName,
-                preprocess=lambda x:
-                    mpas_xarray.preprocess_mpas(x,
-                                                timestr=timestr,
-                                                onlyvars=varList,
-                                                selvals=selvals,
-                                                yearoffset=1850))
+            mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                               timeVariableName=timestr,
+                                               variableList=variableList,
+                                               selValues=selvals,
+                                               yearOffset=1850)
 
     def test_selvals(self):
         fileName = str(self.datadir.join('example_jan.nc'))
         timestr = 'time_avg_daysSinceStartOfSim'
-        varList = \
+        variableList = \
             ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
              'refBottomDepth']
 
-        dsRef = xr.open_mfdataset(
-            fileName,
-            preprocess=lambda x: mpas_xarray.preprocess_mpas(x,
-                                                             timestr=timestr,
-                                                             onlyvars=varList,
-                                                             selvals=None,
-                                                             yearoffset=1850))
+        dsRef = mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                                   timeVariableName=timestr,
+                                                   variableList=variableList,
+                                                   selValues=None,
+                                                   yearOffset=1850)
 
         for vertIndex in range(0, 11):
             selvals = {'nVertLevels': vertIndex}
-            ds = xr.open_mfdataset(
-                fileName,
-                preprocess=lambda x: mpas_xarray.preprocess_mpas(x,
-                                                                 timestr=timestr,
-                                                                 onlyvars=varList,
-                                                                 selvals=selvals,
-                                                                 yearoffset=1850))
-            self.assertEqual(ds.data_vars.keys(), varList)
-            self.assertEqual(ds[varList[0]].shape, (1, 7))
+            ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                                    timeVariableName=timestr,
+                                                    variableList=variableList,
+                                                    selValues=selvals,
+                                                    yearOffset=1850)
+
+            self.assertEqual(ds.data_vars.keys(), variableList)
+            self.assertEqual(ds[variableList[0]].shape, (1, 7))
             self.assertEqual(ds['refBottomDepth'],
                              dsRef['refBottomDepth'][vertIndex])
 
     def test_remove_repeated_time_index(self):
         fileName = str(self.datadir.join('example_jan*.nc'))
         timestr = ['xtime_start', 'xtime_end']
-        varList = ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
+        variableList = \
+            ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
 
-        ds = xr.open_mfdataset(
-            fileName,
-            preprocess=lambda x: mpas_xarray.preprocess_mpas(x,
-                                                             timestr=timestr,
-                                                             onlyvars=varList,
-                                                             yearoffset=1850))
+        # repeat time indices are removed in openMultifileDataSet
+        ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                                timeVariableName=timestr,
+                                                variableList=variableList,
+                                                yearOffset=1850)
 
-        self.assertEqual(sorted(ds.data_vars.keys()), sorted(varList))
-        self.assertEqual(len(ds.Time.values), 3)
-
-        ds = mpas_xarray.remove_repeated_time_index(ds)
+        self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
+        # There would be 3 time indices if repeat indices had not been removed.
+        # Make sure there are 2.
         self.assertEqual(len(ds.Time.values), 2)
-
-    def test_variable_map(self):
-        fileName = str(self.datadir.join('example_jan.nc'))
-        varMap = {
-            'avgSurfaceTemperature':
-                ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature',
-                 'other_string',
-                 'yet_another_string'],
-            'daysSinceStartOfSim':
-                ['time_avg_daysSinceStartOfSim',
-                 'xtime',
-                 'something_else'],
-            'avgLayerTemperature':
-                ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
-                 'test1',
-                 'test2'],
-            'Time': [['xtime_start', 'xtime_end'],
-                     'time_avg_daysSinceStartOfSim']}
-
-        varList = ['avgSurfaceTemperature', 'avgLayerTemperature',
-                   'refBottomDepth', 'daysSinceStartOfSim']
-
-        # preprocess_mpas will use varMap to map the variable names from their
-        # values in the file to the desired values in varList
-        ds = xr.open_mfdataset(
-            fileName,
-            preprocess=lambda x: mpas_xarray.preprocess_mpas(
-                x,
-                timestr='Time',
-                onlyvars=varList,
-                yearoffset=1850,
-                varmap=varMap))
-
-        # make sure the remapping happened as expected
-        self.assertEqual(sorted(ds.data_vars.keys()), sorted(varList))
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
This merge moves the capability to map variable names (used in MPAS-Analysis to support multiple MPAS and ACME versions as seamlessly as possible) out of `mpas_xarray` to a new `generalized_reader` module.

Both `mpas_xarray` and `generalized_reader` have functions, `open_multifile_dataset`, that can be used in place of existing calls to `xarray.open_mfdataset`.  These functions hide the complications of using a preprocessing function.  `generalized_reader.open_multifile_dataset` adds the capabilities to map variables and to select only 'Time' values between a given start and end date.

These changes have been made to allow MPAS files to be preprocessed in various ways without explicitly having to add complicating functionality to `mpas_xarray` itself.  After these changes, the thought is that `mpas_xarray` can remain generic to any MPAS data set, whereas `generalized_reader` can adapt to the specific needs for reading data sets within MPAS-Analysis.
