### PR TITLE
Define iceConc/iceThick filenames in config rather than in modelvsobs

### DIFF
--- a/config.template
+++ b/config.template
@@ -121,6 +121,18 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
+concNASATeamWinNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concNASATeamSumNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concNASATeamWinSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concNASATeamSumSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concBootstrpWinNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concBootstrpSumNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concBootstrpWinSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concBootstrpSumSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thickonNH = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thickfmNH = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thickonSH = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thickfmSH = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be

--- a/config.template
+++ b/config.template
@@ -121,18 +121,18 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
-concNASATeamWinNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concNASATeamSumNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concNASATeamWinSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concNASATeamSumSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
-concBootstrpWinNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concBootstrpSumNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concBootstrpWinSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concBootstrpSumSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
-thickonNH = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
-thickfmNH = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
-thickonSH = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
-thickfmSH = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
+concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be

--- a/configs/edison/config.20161117.beta0.A_WCYCL1850.ne30_oEC.edison
+++ b/configs/edison/config.20161117.beta0.A_WCYCL1850.ne30_oEC.edison
@@ -121,6 +121,18 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
+concNASATeamWinNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concNASATeamSumNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concNASATeamWinSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concNASATeamSumSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concBootstrpWinNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concBootstrpSumNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concBootstrpWinSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concBootstrpSumSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thickonNH = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thickfmNH = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thickonSH = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thickfmSH = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be

--- a/configs/edison/config.20161117.beta0.A_WCYCL1850.ne30_oEC.edison
+++ b/configs/edison/config.20161117.beta0.A_WCYCL1850.ne30_oEC.edison
@@ -121,18 +121,18 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
-concNASATeamWinNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concNASATeamSumNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concNASATeamWinSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concNASATeamSumSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
-concBootstrpWinNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concBootstrpSumNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concBootstrpWinSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concBootstrpSumSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
-thickonNH = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
-thickfmNH = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
-thickonSH = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
-thickfmSH = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
+concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be

--- a/configs/lanl/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
+++ b/configs/lanl/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
@@ -121,6 +121,18 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
+concNASATeamWinNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concNASATeamSumNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concNASATeamWinSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concNASATeamSumSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concBootstrpWinNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concBootstrpSumNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concBootstrpWinSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concBootstrpSumSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thickonNH = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thickfmNH = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thickonSH = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thickfmSH = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be

--- a/configs/lanl/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
+++ b/configs/lanl/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
@@ -121,18 +121,18 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
-concNASATeamWinNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concNASATeamSumNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concNASATeamWinSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concNASATeamSumSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
-concBootstrpWinNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concBootstrpSumNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concBootstrpWinSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concBootstrpSumSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
-thickonNH = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
-thickfmNH = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
-thickonSH = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
-thickfmSH = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
+concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be

--- a/configs/lanl/config.20170120.beta0.GMPAS-QU240.wolf
+++ b/configs/lanl/config.20170120.beta0.GMPAS-QU240.wolf
@@ -121,6 +121,18 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
+concNASATeamWinNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concNASATeamSumNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concNASATeamWinSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concNASATeamSumSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concBootstrpWinNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concBootstrpSumNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concBootstrpWinSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concBootstrpSumSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thickonNH = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thickfmNH = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thickonSH = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thickfmSH = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be

--- a/configs/lanl/config.20170120.beta0.GMPAS-QU240.wolf
+++ b/configs/lanl/config.20170120.beta0.GMPAS-QU240.wolf
@@ -121,18 +121,18 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
-concNASATeamWinNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concNASATeamSumNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concNASATeamWinSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concNASATeamSumSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
-concBootstrpWinNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concBootstrpSumNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concBootstrpWinSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concBootstrpSumSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
-thickonNH = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
-thickfmNH = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
-thickonSH = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
-thickfmSH = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
+concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be

--- a/configs/olcf/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
+++ b/configs/olcf/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
@@ -121,6 +121,18 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
+concNASATeamWinNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concNASATeamSumNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concNASATeamWinSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concNASATeamSumSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concBootstrpWinNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concBootstrpSumNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concBootstrpWinSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concBootstrpSumSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thickonNH = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thickfmNH = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thickonSH = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thickfmSH = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be

--- a/configs/olcf/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
+++ b/configs/olcf/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
@@ -121,18 +121,18 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
-concNASATeamWinNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concNASATeamSumNH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concNASATeamWinSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concNASATeamSumSH = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
-concBootstrpWinNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concBootstrpSumNH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concBootstrpWinSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concBootstrpSumSH = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
-thickonNH = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
-thickfmNH = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
-thickonSH = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
-thickfmSH = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
+concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be

--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -58,7 +58,6 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
     print 'Reading files {} through {}'.format(infiles[0], infiles[-1])
 
     plotsDirectory = buildConfigFullPath(config, 'output', 'plotsSubdirectory')
-    obsDirectory = config.get('seaIceObservations', 'baseDirectory')
 
     mainRunName = config.get('runs', 'mainRunName')
 
@@ -106,20 +105,32 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
 
     # Obs filenames
     obsIceConcFileNames = {}
-    obsIceConcFileNames['winNH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations', 'concNASATeamWinNH')
-    obsIceConcFileNames['sumNH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations', 'concNASATeamSumNH')
-    obsIceConcFileNames['winSH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations', 'concNASATeamWinSH')
-    obsIceConcFileNames['sumSH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations', 'concNASATeamSumSH')
-    obsIceConcFileNames['winNH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations', 'concBootstrpWinNH')
-    obsIceConcFileNames['sumNH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations', 'concBootstrpSumNH')
-    obsIceConcFileNames['winSH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations', 'concBootstrpWinSH')
-    obsIceConcFileNames['sumSH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations', 'concBootstrpSumSH')
+    obsIceConcFileNames['winNH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations', 
+                                             'concentrationNASATeamNH_JFM')
+    obsIceConcFileNames['sumNH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations',
+                                             'concentrationNASATeamNH_JAS')
+    obsIceConcFileNames['winSH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations',
+                                             'concentrationNASATeamSH_DJF')
+    obsIceConcFileNames['sumSH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations',
+                                             'concentrationNASATeamSH_JJA')
+    obsIceConcFileNames['winNH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations',
+                                              'concentrationBootstrapNH_JFM')
+    obsIceConcFileNames['sumNH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations',
+                                              'concentrationBootstrapNH_JAS')
+    obsIceConcFileNames['winSH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations',
+                                              'concentrationBootstrapSH_DJF')
+    obsIceConcFileNames['sumSH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations',
+                                              'concentrationBootstrapSH_JJA')
 
     obsIceThickFileNames = {}
-    obsIceThickFileNames['onNH'] = buildConfigFullPath(config, 'seaIceObservations', 'thickonNH')
-    obsIceThickFileNames['fmNH'] = buildConfigFullPath(config, 'seaIceObservations', 'thickfmNH')
-    obsIceThickFileNames['onSH'] = buildConfigFullPath(config, 'seaIceObservations', 'thickonSH')
-    obsIceThickFileNames['fmSH'] = buildConfigFullPath(config, 'seaIceObservations', 'thickfmSH')
+    obsIceThickFileNames['onNH'] = buildConfigFullPath(config, 'seaIceObservations',
+                                    'thicknessNH_ON')
+    obsIceThickFileNames['fmNH'] = buildConfigFullPath(config, 'seaIceObservations',
+                                    'thicknessNH_FM')
+    obsIceThickFileNames['onSH'] = buildConfigFullPath(config, 'seaIceObservations',
+                                    'thicknessSH_ON')
+    obsIceThickFileNames['fmSH'] = buildConfigFullPath(config, 'seaIceObservations',
+                                    'thicknessSH_FM')
 
     # Checks on directory/files existence:
     for climName in obsIceConcFileNames:

--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -105,31 +105,43 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
 
     # Obs filenames
     obsIceConcFileNames = {}
-    obsIceConcFileNames['winNH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations', 
+    obsIceConcFileNames['winNH_NASATeam'] = buildConfigFullPath(
+                                             config, 'seaIceObservations',
                                              'concentrationNASATeamNH_JFM')
-    obsIceConcFileNames['sumNH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceConcFileNames['sumNH_NASATeam'] = buildConfigFullPath(
+                                             config, 'seaIceObservations',
                                              'concentrationNASATeamNH_JAS')
-    obsIceConcFileNames['winSH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceConcFileNames['winSH_NASATeam'] = buildConfigFullPath(
+                                             config, 'seaIceObservations',
                                              'concentrationNASATeamSH_DJF')
-    obsIceConcFileNames['sumSH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceConcFileNames['sumSH_NASATeam'] = buildConfigFullPath(
+                                             config, 'seaIceObservations',
                                              'concentrationNASATeamSH_JJA')
-    obsIceConcFileNames['winNH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceConcFileNames['winNH_Bootstrap'] = buildConfigFullPath(
+                                              config, 'seaIceObservations',
                                               'concentrationBootstrapNH_JFM')
-    obsIceConcFileNames['sumNH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceConcFileNames['sumNH_Bootstrap'] = buildConfigFullPath(
+                                              config, 'seaIceObservations',
                                               'concentrationBootstrapNH_JAS')
-    obsIceConcFileNames['winSH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceConcFileNames['winSH_Bootstrap'] = buildConfigFullPath(
+                                              config, 'seaIceObservations',
                                               'concentrationBootstrapSH_DJF')
-    obsIceConcFileNames['sumSH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceConcFileNames['sumSH_Bootstrap'] = buildConfigFullPath(
+                                              config, 'seaIceObservations',
                                               'concentrationBootstrapSH_JJA')
 
     obsIceThickFileNames = {}
-    obsIceThickFileNames['onNH'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceThickFileNames['onNH'] = buildConfigFullPath(
+                                    config, 'seaIceObservations',
                                     'thicknessNH_ON')
-    obsIceThickFileNames['fmNH'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceThickFileNames['fmNH'] = buildConfigFullPath(
+                                    config, 'seaIceObservations',
                                     'thicknessNH_FM')
-    obsIceThickFileNames['onSH'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceThickFileNames['onSH'] = buildConfigFullPath(
+                                    config, 'seaIceObservations',
                                     'thicknessSH_ON')
-    obsIceThickFileNames['fmSH'] = buildConfigFullPath(config, 'seaIceObservations',
+    obsIceThickFileNames['fmSH'] = buildConfigFullPath(
+                                    config, 'seaIceObservations',
                                     'thicknessSH_FM')
 
     # Checks on directory/files existence:

--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -106,39 +106,20 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
 
     # Obs filenames
     obsIceConcFileNames = {}
-    obsIceConcFileNames['winNH_NASATeam'] = \
-        "{}/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_" \
-        "jfm.interp0.5x0.5.nc".format(obsDirectory)
-    obsIceConcFileNames['sumNH_NASATeam'] = \
-        "{}/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_" \
-        "jas.interp0.5x0.5.nc".format(obsDirectory)
-    obsIceConcFileNames['winSH_NASATeam'] = \
-        "{}/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_" \
-        "djf.interp0.5x0.5.nc".format(obsDirectory)
-    obsIceConcFileNames['sumSH_NASATeam'] = \
-        "{}/SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_" \
-        "jja.interp0.5x0.5.nc".format(obsDirectory)
-    obsIceConcFileNames['winNH_Bootstrap'] = \
-        "{}/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_" \
-        "NH_jfm.interp0.5x0.5.nc".format(obsDirectory)
-    obsIceConcFileNames['sumNH_Bootstrap'] = \
-        "{}/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_" \
-        "NH_jas.interp0.5x0.5.nc".format(obsDirectory)
-    obsIceConcFileNames['winSH_Bootstrap'] = \
-        "{}/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_" \
-        "SH_djf.interp0.5x0.5.nc".format(obsDirectory)
-    obsIceConcFileNames['sumSH_Bootstrap'] = \
-        "{}/SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_" \
-        "SH_jja.interp0.5x0.5.nc".format(obsDirectory)
+    obsIceConcFileNames['winNH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations', 'concNASATeamWinNH')
+    obsIceConcFileNames['sumNH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations', 'concNASATeamSumNH')
+    obsIceConcFileNames['winSH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations', 'concNASATeamWinSH')
+    obsIceConcFileNames['sumSH_NASATeam'] = buildConfigFullPath(config, 'seaIceObservations', 'concNASATeamSumSH')
+    obsIceConcFileNames['winNH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations', 'concBootstrpWinNH')
+    obsIceConcFileNames['sumNH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations', 'concBootstrpSumNH')
+    obsIceConcFileNames['winSH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations', 'concBootstrpWinSH')
+    obsIceConcFileNames['sumSH_Bootstrap'] = buildConfigFullPath(config, 'seaIceObservations', 'concBootstrpSumSH')
+
     obsIceThickFileNames = {}
-    obsIceThickFileNames['onNH'] = "{}/ICESat/ICESat_gridded_mean_" \
-        "thickness_NH_on.interp0.5x0.5.nc".format(obsDirectory)
-    obsIceThickFileNames['fmNH'] = "{}/ICESat/ICESat_gridded_mean_" \
-        "thickness_NH_fm.interp0.5x0.5.nc".format(obsDirectory)
-    obsIceThickFileNames['onSH'] = "{}/ICESat/ICESat_gridded_mean_" \
-        "thickness_SH_on.interp0.5x0.5.nc".format(obsDirectory)
-    obsIceThickFileNames['fmSH'] = "{}/ICESat/ICESat_gridded_mean_" \
-        "thickness_SH_fm.interp0.5x0.5.nc".format(obsDirectory)
+    obsIceThickFileNames['onNH'] = buildConfigFullPath(config, 'seaIceObservations', 'thickonNH')
+    obsIceThickFileNames['fmNH'] = buildConfigFullPath(config, 'seaIceObservations', 'thickfmNH')
+    obsIceThickFileNames['onSH'] = buildConfigFullPath(config, 'seaIceObservations', 'thickonSH')
+    obsIceThickFileNames['fmSH'] = buildConfigFullPath(config, 'seaIceObservations', 'thickfmSH')
 
     # Checks on directory/files existence:
     for climName in obsIceConcFileNames:


### PR DESCRIPTION
I have moved the definition of the seaice concentration and thickness observational filenames from the main routine (modelvsobs) to the config file.
I have also updated all example config files to reflect this change.

This PR addresses #106.