### PR TITLE
Replace the Time coordinate in MPAS xarray datasets to days since 0001-01-01

### DIFF
--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -8,3 +8,6 @@ dependencies:
   - xarray
   - matplotlib
   - dask
+  - netcdf4
+  - hdf5
+  - hdf4

--- a/config.template
+++ b/config.template
@@ -97,6 +97,15 @@ sstSubdirectory = SST
 sssSubdirectory = SSS
 mldSubdirectory = MLD
 
+# first and last year of SST observational climatology (preferably one of the
+# two ranges given below)
+# values for preindustrial
+sstClimatologyStartYear = 1870
+sstClimatologyEndYear = 1900
+# alternative values for present day
+#sstClimatologyStartYear = 1990
+#sstClimatologyEndYear = 2011
+
 [oceanReference]
 ## options related to ocean reference run with which the results will be
 ## compared
@@ -147,14 +156,6 @@ baseDirectory = /dir/to/seaice/reference
 
 # directory where ocean reference simulation results are stored
 baseDirectory = /dir/to/seaice/reference
-
-[time]
-## options related to dates and times for all runs (main, reference and
-## preprocessed)
-
-# the offset in years to be added to simulation years to prevent xarray
-# calendar problems.  (Hopefully, this will be removed soon.)
-yearOffset = 1849
 
 [remapping]
 ## options related to horizontal remapping

--- a/configs/edison/config.20161117.beta0.A_WCYCL1850.ne30_oEC.edison
+++ b/configs/edison/config.20161117.beta0.A_WCYCL1850.ne30_oEC.edison
@@ -97,6 +97,15 @@ sstSubdirectory = global/project/projectdirs/acme/observations/Ocean/SST
 sssSubdirectory = global/homes/l/lvroekel
 mldSubdirectory = /global/project/projectdirs/acme/observations/Ocean/MLD
 
+# first and last year of SST observational climatology (preferably one of the
+# two ranges given below)
+# values for preindustrial
+sstClimatologyStartYear = 1870
+sstClimatologyEndYear = 1900
+# alternative values for present day
+#sstClimatologyStartYear = 1990
+#sstClimatologyEndYear = 2011
+
 [oceanReference]
 ## options related to ocean reference run with which the results will be
 ## compared
@@ -147,14 +156,6 @@ baseDirectory = /dir/to/seaice/reference
 
 # directory where ocean reference simulation results are stored
 baseDirectory = /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[time]
-## options related to dates and times for all runs (main, reference and
-## preprocessed)
-
-# the offset in years to be added to simulation years to prevent xarray
-# calendar problems.  (Hopefully, this will be removed soon.)
-yearOffset = 1849
 
 [remapping]
 ## options related to horizontal remapping

--- a/configs/lanl/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
+++ b/configs/lanl/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
@@ -97,6 +97,15 @@ sstSubdirectory = SST
 sssSubdirectory = SSS
 mldSubdirectory = MLD
 
+# first and last year of SST observational climatology (preferably one of the
+# two ranges given below)
+# values for preindustrial
+sstClimatologyStartYear = 1870
+sstClimatologyEndYear = 1900
+# alternative values for present day
+#sstClimatologyStartYear = 1990
+#sstClimatologyEndYear = 2011
+
 [oceanReference]
 ## options related to ocean reference run with which the results will be
 ## compared
@@ -147,14 +156,6 @@ baseDirectory = /dir/to/seaice/reference
 
 # directory where ocean reference simulation results are stored
 baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[time]
-## options related to dates and times for all runs (main, reference and
-## preprocessed)
-
-# the offset in years to be added to simulation years to prevent xarray
-# calendar problems.  (Hopefully, this will be removed soon.)
-yearOffset = 1849
 
 [remapping]
 ## options related to horizontal remapping

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -3,7 +3,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = 20170120.beta0.GMPAS-QU240.wolf
+mainRunName = MPAS-SeaIce.QU60km_polar
 # referenceRunName is the name of a reference run to compare against (or None
 # to turn off comparison with a reference, e.g. if no reference case is
 # available)
@@ -19,11 +19,11 @@ preprocessedReferenceRunName = B1850C5_ne30_v0.4
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /lustre/scratch2/turquoise/xylar/ACME/cases/GMPAS-QU240/run
+baseDirectory = /net/scratch2/akt/MPAS/rundirs/rundir_QU60km_polar
 # names of namelist and streams files.  If not in baseDirectory, give full path
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = namelist.ocean
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
+seaIceNamelistFileName = namelist.cice
 seaIceStreamsFileName = streams.cice
 
 [output]
@@ -58,7 +58,7 @@ climatologySubdirectory = clim
 # option:
 #    ./run_analysis.py config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
+generate = ['timeSeriesSeaIceAreaVol']
 
 # alternative examples that would perform all analysis except
 #   'timeSeriesOHC'
@@ -74,9 +74,9 @@ generate = ['all']
 ## observations and previous runs
 
 # the first year over which to average climatalogies
-startYear = 1
+startYear = 1960
 # the last year over which to average climatalogies
-endYear = 3
+endYear = 1961
 
 [timeSeries]
 ## options related to producing time series plots, often to compare against
@@ -85,8 +85,8 @@ endYear = 3
 # start and end years for timeseries analysis. Using out-of-bounds values
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
-startYear = 1
-endYear = 3
+startYear = 1960
+endYear = 1961
 
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
@@ -130,18 +130,6 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
-concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
-concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
-thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
-thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
-thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
-thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be
@@ -161,7 +149,7 @@ baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_
 ## options related to horizontal remapping
 
 # paths to mapping files (which will hopefully be eliminated soon)
-mpasRemapFile = /usr/projects/climate/milena/mapping_files/rmp_QU240_to_0.5x0.5_conserve.nc
+mpasRemapFile = None
 
 [timeSeriesOHC]
 ## options related to plotting time series of ocean heat content (OHC)

--- a/configs/olcf/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
+++ b/configs/olcf/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
@@ -97,6 +97,15 @@ sstSubdirectory = SST
 sssSubdirectory = SSS
 mldSubdirectory = MLD
 
+# first and last year of SST observational climatology (preferably one of the
+# two ranges given below)
+# values for preindustrial
+sstClimatologyStartYear = 1870
+sstClimatologyEndYear = 1900
+# alternative values for present day
+#sstClimatologyStartYear = 1990
+#sstClimatologyEndYear = 2011
+
 [oceanReference]
 ## options related to ocean reference run with which the results will be
 ## compared
@@ -147,14 +156,6 @@ baseDirectory = /dir/to/seaice/reference
 
 # directory where ocean reference simulation results are stored
 baseDirectory = /lustre/atlas/proj-shared/cli115/milena/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[time]
-## options related to dates and times for all runs (main, reference and
-## preprocessed)
-
-# the offset in years to be added to simulation years to prevent xarray
-# calendar problems.  (Hopefully, this will be removed soon.)
-yearOffset = 1849
 
 [remapping]
 ## options related to horizontal remapping

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -18,7 +18,7 @@ import os.path
 
 from ..containers import ReadOnlyDict
 from .utility import paths
-from ..timekeeping.utility import stringToDatetime, stringToRelativeDelta
+from ..timekeeping.utility import string_to_datetime, string_to_relative_delta
 
 
 def convert_namelist_to_dict(fname, readonly=True):
@@ -225,16 +225,16 @@ class StreamsFile:
         if output_interval is None:
             # There's no file interval, so hard to know what to do
             # let's put a buffer of a year on each side to be safe
-            offsetDate = stringToRelativeDelta(dateString='0001-00-00',
-                                               calendar=calendar)
+            offsetDate = string_to_relative_delta(dateString='0001-00-00',
+                                                  calendar=calendar)
         else:
-            offsetDate = stringToRelativeDelta(dateString=output_interval,
-                                               calendar=calendar)
+            offsetDate = string_to_relative_delta(dateString=output_interval,
+                                                  calendar=calendar)
 
         if startDate is not None:
             # read one extra file before the start date to be on the safe side
             if isinstance(startDate, str):
-                startDate = stringToDatetime(startDate)
+                startDate = string_to_datetime(startDate)
             try:
                 startDate -= offsetDate
             except (ValueError, OverflowError):
@@ -245,7 +245,7 @@ class StreamsFile:
         if endDate is not None:
             # read one extra file after the end date to be on the safe side
             if isinstance(endDate, str):
-                endDate = stringToDatetime(endDate)
+                endDate = string_to_datetime(endDate)
             try:
                 endDate += offsetDate
             except (ValueError, OverflowError):
@@ -268,7 +268,7 @@ class StreamsFile:
             baseName = os.path.basename(fileName)
             dateEndIndex = len(baseName) - dateEndOffset
             fileDateString = baseName[dateStartIndex:dateEndIndex]
-            fileDate = stringToDatetime(fileDateString)
+            fileDate = string_to_datetime(fileDateString)
             add = True
             if startDate is not None and startDate > fileDate:
                 add = False

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -7,14 +7,64 @@ Xylar Asay-Davis
 
 Last Modified
 -------------
-02/06/2017
+02/11/2017
 """
 
 import datetime
+import netCDF4
+import numpy
+
 from .MpasRelativeDelta import MpasRelativeDelta
 
 
-def stringToDatetime(dateString):  # {{{
+def get_simulation_start_time(streams):
+    """
+    Given a StreamsFile object, returns the simulation start time parsed from
+    a restart file.
+
+    Parameters
+    ----------
+    steams : StreamsFile object
+        For parsing an MPAS streams file
+
+    Returns
+    -------
+    simulation_start_time : string
+        The start date of the simulation parsed from a restart file identified
+        by the contents of `streams`.
+
+    Raises
+    ------
+    IOError
+        If no restart file can be found.
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/11/2017
+    """
+
+    try:
+        restartFile = streams.readpath('restart')[0]
+    except ValueError:
+        raise IOError('No MPAS restart file found: need at least one '
+                      'restart file for analysis to work correctly')
+
+    ncFile = netCDF4.Dataset(restartFile, mode='r')
+    simulationStartTime = ncFile.variables['simulationStartTime'][:]
+    # convert from character array to str
+    simulationStartTime = ''.join(simulationStartTime).strip()
+    # replace underscores so it works as a CF-compliant reference date
+    simulationStartTime = simulationStartTime.replace('_', ' ')
+    ncFile.close()
+
+    return simulationStartTime
+
+
+def string_to_datetime(dateString):  # {{{
     """
     Given a date string and a calendar, returns a `datetime.datetime`
 
@@ -56,13 +106,13 @@ def stringToDatetime(dateString):  # {{{
     """
 
     (year, month, day, hour, minute, second) = \
-        _parseDateString(dateString, isInterval=False)
+        _parse_date_string(dateString, isInterval=False)
 
     return datetime.datetime(year=year, month=month, day=day, hour=hour,
                              minute=minute, second=second)  # }}}
 
 
-def stringToRelativeDelta(dateString, calendar='gregorian'):  # {{{
+def string_to_relative_delta(dateString, calendar='gregorian'):  # {{{
     """
     Given a date string and a calendar, returns an instance of
     `MpasRelativeDelta`
@@ -108,7 +158,7 @@ def stringToRelativeDelta(dateString, calendar='gregorian'):  # {{{
     """
 
     (years, months, days, hours, minutes, seconds) = \
-        _parseDateString(dateString, isInterval=True)
+        _parse_date_string(dateString, isInterval=True)
 
     return MpasRelativeDelta(years=years, months=months, days=days,
                              hours=hours, minutes=minutes, seconds=seconds,
@@ -116,26 +166,232 @@ def stringToRelativeDelta(dateString, calendar='gregorian'):  # {{{
     # }}}
 
 
-def clampToNumpyDatetime64(date, yearOffset):
+def string_to_days_since_date(dateString, calendar='gregorian',
+                              referenceDate='0001-01-01'):
     """
-    Temporary function for adding an offset year and clamping a datetime to
-    range supported by `numpy.datetime64`.
+    Given a date string or an array-like of date strings, a reference date
+    string, and a calendar, returns the number of days (as a float or
+    numpy.array of floats) since the reference date
+
+    Parameters
+    ----------
+    dateStrings : str or array-like of str
+        A date and time (or array of date/times) in one of the following
+        formats:
+        - YYYY-MM-DD hh:mm:ss
+        - YYYY-MM-DD hh.mm.ss
+        - YYYY-MM-DD SSSSS
+        - DDD hh:mm:ss
+        - DDD hh.mm.ss
+        - DDD SSSSS
+        - hh.mm.ss
+        - hh:mm:ss
+        - YYYY-MM-DD
+        - YYYY-MM
+        - SSSSS
+
+        Note: either underscores or spaces can be used to separate the date
+        from the time portion of the string.
+
+    calendar: {'gregorian', 'gregorian_noleap'}, optional
+        The name of one of the calendars supported by MPAS cores
+
+    referenceDate : str, optional
+        A reference date of the form:
+            - 0001-01-01
+            - 0001-01-01 00:00:00
+
+    Returns
+    -------
+    days : float or numpy.array of floats
+        The number of days since `referenceDate` for each date in dateString
+
+    Raises
+    ------
+    ValueError
+        If an invalid `dateString` or `calendar` is supplied.
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/04/2017
     """
 
-    year = date.year + yearOffset
-    if year < 1678:
-        return datetime.datetime(year=1678, month=1, day=1, hour=0,
-                                 minute=0, second=0)
+    isSingleString = isinstance(dateString, str)
 
-    if year >= 2262:
-        return datetime.datetime(year=2262, month=1, day=1, hour=0,
-                                 minute=0, second=0)
+    if isSingleString:
+        dateString = [dateString]
 
-    return datetime.datetime(year, date.month, date.day,
-                             date.hour, date.minute, date.second)
+    dates = [string_to_datetime(string) for string in dateString]
+    days = datetime_to_days(dates, calendar=calendar,
+                            referenceDate=referenceDate)
+
+    if isSingleString:
+        days = days[0]
+    else:
+        days = numpy.array(days)
+    return days
 
 
-def _parseDateString(dateString, isInterval=False):  # {{{
+def days_to_datetime(days, calendar='gregorian', referenceDate='0001-01-01'):
+    """
+    Covert days to `datetime.datetime` objects given a reference date and an
+    MPAS calendar (either 'gregorian' or 'gregorian_noleap').
+
+    Parameters
+    ----------
+    days : float or array-like of floats
+        The number of days since the reference date.
+
+    calendar : {'gregorian', 'gregorian_noleap'}, optinal
+        A calendar to be used to convert days to a `datetime.datetime` object.
+
+    referenceDate : str, optional
+        A reference date of the form:
+            - 0001-01-01
+            - 0001-01-01 00:00:00
+
+    Returns
+    -------
+    datetime : An instance of `datetime.datetime` (or array-like of datetimes)
+        The days since `referenceDate` on the given `calendar`.
+
+    Raises
+    ------
+    ValueError
+        If an invalid `days`, `referenceDate` or `calendar` is supplied.
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/04/2017
+    """
+
+    datetimes = netCDF4.num2date(days,
+                                 'days since {}'.format(referenceDate),
+                                 calendar=_mpas_to_netcdf_calendar(calendar))
+
+    # convert to datetime.datetime
+    if isinstance(datetimes, numpy.ndarray):
+        newDateTimes = []
+        for date in datetimes.flat:
+            newDateTimes.append(_round_datetime(date))
+        if len(newDateTimes) > 0:
+            datetimes = numpy.reshape(numpy.array(newDateTimes),
+                                      datetimes.shape)
+
+    else:
+        datetimes = _round_datetime(datetimes)
+
+    return datetimes
+
+
+def datetime_to_days(dates, calendar='gregorian', referenceDate='0001-01-01'):
+    """
+    Given date(s), a calendar and a reference date, returns the days since
+    the reference date, either as a single float or an array of floats.
+
+    Parameters
+    ----------
+    datetime : instance or array-like of datetime.datetime
+        The date(s) to be converted to days since `referenceDate` on the
+        given `calendar`.
+
+    calendar : {'gregorian', 'gregorian_noleap'}, optional
+        A calendar to be used to convert days to a `datetime.datetime` object.
+
+    referenceDate : str, optional
+        A reference date of the form:
+            - 0001-01-01
+            - 0001-01-01 00:00:00
+
+    Returns
+    -------
+    days : float or array of floats
+        The days since `referenceDate` on the given `calendar`.
+
+    Raises
+    ------
+    ValueError
+        If an invalid `datetimes`, `referenceDate` or `calendar` is supplied.
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/11/2017
+    """
+
+    isSingleDate = False
+    if isinstance(dates, datetime.datetime):
+        dates = [dates]
+        isSingleDate = True
+
+    days = netCDF4.date2num(dates, 'days since {}'.format(referenceDate),
+                            calendar=_mpas_to_netcdf_calendar(calendar))
+
+    if isSingleDate:
+        days = days[0]
+
+    return days
+
+
+def date_to_days(year=1, month=1, day=1, hour=0, minute=0, second=0,
+                 calendar='gregorian', referenceDate='0001-01-01'):
+    """
+    Given a date in the form of year, month, day, etc.; a calendar; and a
+    reference date, returns the days since the reference date.
+
+    Parameters
+    ----------
+    year, month, day, hour, minute, second : int, optional
+        The date to be converted to days since `referenceDate` on the
+        given `calendar`.
+
+    calendar : {'gregorian', 'gregorian_noleap'}, optional
+        A calendar to be used to convert days to a `datetime.datetime` object.
+
+    referenceDate : str, optional
+        A reference date of the form:
+            - 0001-01-01
+            - 0001-01-01 00:00:00
+
+    Returns
+    -------
+    days : float
+        The days since `referenceDate` on the given `calendar`.
+
+    Raises
+    ------
+    ValueError
+        If an invalid `referenceDate` or `calendar` is supplied.
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    Last modified
+    -------------
+    02/11/2017
+    """
+
+    calendar = _mpas_to_netcdf_calendar(calendar)
+
+    date = datetime.datetime(year, month, day, hour, minute, second)
+
+    return netCDF4.date2num(date, 'days since {}'.format(referenceDate),
+                            calendar=calendar)
+
+
+def _parse_date_string(dateString, isInterval=False):  # {{{
     """
     Given a string containing a date, returns a tuple defining a date of the
     form (year, month, day, hour, minute, second) appropriate for constructing
@@ -225,5 +481,33 @@ def _parseDateString(dateString, isInterval=False):  # {{{
         hour = 0
     return (year, month, day, hour, minute, second)  # }}}
 
+
+def _mpas_to_netcdf_calendar(calendar):
+    """
+    Convert from MPAS calendar to NetCDF4 calendar names.
+    """
+
+    if calendar == 'gregorian_noleap':
+        calendar = 'noleap'
+    elif calendar != 'gregorian':
+        raise ValueError('Unsupported calendar {}'.format(calendar))
+    return calendar
+
+
+def _round_datetime(date):
+    """Round a datetime object to nearest second
+    date : datetime.datetime or similar objet object.
+    """
+    (year, month, day, hour, minute, second, microsecond) = \
+        (date.year, date.month, date.day, date.hour, date.minute, date.second,
+         date.microsecond)
+
+    date = datetime.datetime(year=year, month=month, day=day,
+                             hour=hour, minute=minute,
+                             second=second)
+
+    add_seconds = int(1e-6*microsecond+0.5)
+
+    return date + datetime.timedelta(0, add_seconds)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_generalized_reader.py
+++ b/mpas_analysis/test/test_generalized_reader.py
@@ -2,7 +2,7 @@
 Unit test infrastructure for the generalized_reader.
 
 Xylar Asay-Davis
-02/15/20167
+02/16/2017
 """
 
 import pytest
@@ -14,8 +14,9 @@ from mpas_analysis.shared.generalized_reader.generalized_reader \
 @pytest.mark.usefixtures("loaddatadir")
 class TestGeneralizedReader(TestCase):
 
-    def test_variable_map(self):
+    def test_variableMap(self):
         fileName = str(self.datadir.join('example_jan.nc'))
+        simulationStartTime = '0001-01-01'
         variableMap = {
             'avgSurfaceTemperature':
                 ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature',
@@ -39,12 +40,13 @@ class TestGeneralizedReader(TestCase):
             # preprocess_mpas will use variableMap to map the variable names
             # from their values in the file to the desired values in
             # variableList
-            ds = open_multifile_dataset(fileNames=fileName,
-                                        calendar=calendar,
-                                        timeVariableName='Time',
-                                        variableList=variableList,
-                                        variableMap=variableMap,
-                                        yearOffset=1850)
+            ds = open_multifile_dataset(
+                fileNames=fileName,
+                calendar=calendar,
+                simulationStartTime=simulationStartTime,
+                timeVariableName='Time',
+                variableList=variableList,
+                variableMap=variableMap)
 
             # make sure the remapping happened as expected
             self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
@@ -56,11 +58,11 @@ class TestGeneralizedReader(TestCase):
             ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
 
         for calendar in ['gregorian', 'gregorian_noleap']:
-            ds = open_multifile_dataset(fileNames=fileName,
-                                        calendar=calendar,
-                                        timeVariableName=timestr,
-                                        variableList=variableList,
-                                        yearOffset=1850)
+            ds = open_multifile_dataset(
+                fileNames=fileName,
+                calendar=calendar,
+                timeVariableName=timestr,
+                variableList=variableList)
             self.assertEqual(ds.data_vars.keys(), variableList)
 
     def test_start_end(self):
@@ -71,33 +73,33 @@ class TestGeneralizedReader(TestCase):
 
         for calendar in ['gregorian', 'gregorian_noleap']:
             # all dates
-            ds = open_multifile_dataset(fileNames=fileName,
-                                        calendar=calendar,
-                                        timeVariableName=timestr,
-                                        variableList=variableList,
-                                        startDate='0001-01-01',
-                                        endDate='9999-12-31',
-                                        yearOffset=1850)
+            ds = open_multifile_dataset(
+                fileNames=fileName,
+                calendar=calendar,
+                timeVariableName=timestr,
+                variableList=variableList,
+                startDate='0001-01-01',
+                endDate='9999-12-31')
             self.assertEqual(len(ds.Time), 2)
 
             # just the first date
-            ds = open_multifile_dataset(fileNames=fileName,
-                                        calendar=calendar,
-                                        timeVariableName=timestr,
-                                        variableList=variableList,
-                                        startDate='0005-01-01',
-                                        endDate='0005-02-01',
-                                        yearOffset=1850)
+            ds = open_multifile_dataset(
+                fileNames=fileName,
+                calendar=calendar,
+                timeVariableName=timestr,
+                variableList=variableList,
+                startDate='0005-01-01',
+                endDate='0005-02-01')
             self.assertEqual(len(ds.Time), 1)
 
             # just the second date
-            ds = open_multifile_dataset(fileNames=fileName,
-                                        calendar=calendar,
-                                        timeVariableName=timestr,
-                                        variableList=variableList,
-                                        startDate='0005-02-01',
-                                        endDate='0005-03-01',
-                                        yearOffset=1850)
+            ds = open_multifile_dataset(
+                fileNames=fileName,
+                calendar=calendar,
+                timeVariableName=timestr,
+                variableList=variableList,
+                startDate='0005-02-01',
+                endDate='0005-03-01')
             self.assertEqual(len(ds.Time), 1)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -8,7 +8,8 @@ Xylar Asay-Davis, Phillip J. Wolfram
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.mpas_xarray import mpas_xarray
-import pandas as pd
+from mpas_analysis.shared.timekeeping.utility import days_to_datetime, \
+    string_to_datetime
 
 
 @pytest.mark.usefixtures("loaddatadir")
@@ -16,6 +17,7 @@ class TestMpasXarray(TestCase):
 
     def test_subset_variables(self):
         fileName = str(self.datadir.join('example_jan.nc'))
+        calendar = 'gregorian_noleap'
         timestr = ['xtime_start', 'xtime_end']
         variableList = \
             ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
@@ -23,71 +25,84 @@ class TestMpasXarray(TestCase):
         # first, test loading the whole data set and then calling
         # subset_variables explicitly
         ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
-                                                timeVariableName=timestr,
-                                                yearOffset=1850)
+                                                calendar=calendar,
+                                                timeVariableName=timestr)
         ds = mpas_xarray.subset_variables(ds, variableList)
         self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
-        self.assertEqual(pd.Timestamp(ds.Time.values[0]),
-                         pd.Timestamp('1855-01-16 12:22:30'))
-
+        self.assertEqual(days_to_datetime(days=ds.Time.values,
+                                          referenceDate='0001-01-01',
+                                          calendar=calendar),
+                         string_to_datetime('0005-01-16 12:22:30'))
         # next, test the same with the onlyvars argument
         ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                                calendar=calendar,
                                                 timeVariableName=timestr,
-                                                variableList=variableList,
-                                                yearOffset=1850)
+                                                variableList=variableList)
         self.assertEqual(ds.data_vars.keys(), variableList)
 
         with self.assertRaisesRegexp(ValueError,
                                      'Empty dataset is returned.'):
             missingvars = ['foo', 'bar']
             ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
+                                                    calendar=calendar,
                                                     timeVariableName=timestr,
-                                                    variableList=missingvars,
-                                                    yearOffset=1850)
+                                                    variableList=missingvars)
 
     def test_iselvals(self):
         fileName = str(self.datadir.join('example_jan.nc'))
+        calendar = 'gregorian_noleap'
+        simulationStartTime = '0001-01-01'
         timestr = 'time_avg_daysSinceStartOfSim'
         variableList = \
             ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
              'refBottomDepth']
 
         iselvals = {'nVertLevels': slice(0, 3)}
-        ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
-                                                timeVariableName=timestr,
-                                                variableList=variableList,
-                                                iselValues=iselvals,
-                                                yearOffset=1850)
+        ds = mpas_xarray.open_multifile_dataset(
+            fileNames=fileName,
+            calendar=calendar,
+            simulationStartTime=simulationStartTime,
+            timeVariableName=timestr,
+            variableList=variableList,
+            iselValues=iselvals)
 
         self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
         self.assertEqual(ds[variableList[0]].shape, (1, 7, 3))
         self.assertEqual(ds['refBottomDepth'].shape, (3,))
         self.assertApproxEqual(ds['refBottomDepth'][-1],
                                4.882000207901)
-        date = pd.Timestamp(ds.Time.values[0])
-        # round to nearest second
-        date = pd.Timestamp(long(round(date.value, -9)))
-        self.assertEqual(date, pd.Timestamp('1855-01-13 12:24:14'))
+
+        self.assertEqual(days_to_datetime(days=ds.Time.values[0],
+                                          referenceDate='0001-01-01',
+                                          calendar=calendar),
+                         string_to_datetime('0005-01-14 12:24:14'))
 
     def test_no_units(self):
         fileName = str(self.datadir.join('example_no_units_jan.nc'))
+        calendar = 'gregorian_noleap'
+        simulationStartTime = '0001-01-01'
         timestr = 'time_avg_daysSinceStartOfSim'
         variableList = \
             ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
              'refBottomDepth']
 
-        ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
-                                                timeVariableName=timestr,
-                                                variableList=variableList,
-                                                yearOffset=1850)
+        ds = mpas_xarray.open_multifile_dataset(
+            fileNames=fileName,
+            calendar=calendar,
+            simulationStartTime=simulationStartTime,
+            timeVariableName=timestr,
+            variableList=variableList)
         self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
-        date = pd.Timestamp(ds.Time.values[0])
-        # round to nearest second
-        date = pd.Timestamp(long(round(date.value, -9)))
-        self.assertEqual(date, pd.Timestamp('1855-01-13 12:24:14'))
+
+        self.assertEqual(days_to_datetime(days=ds.Time.values[0],
+                                          referenceDate='0001-01-01',
+                                          calendar=calendar),
+                         string_to_datetime('0005-01-14 12:24:14'))
 
     def test_bad_selvals(self):
         fileName = str(self.datadir.join('example_jan.nc'))
+        calendar = 'gregorian_noleap'
+        simulationStartTime = '0001-01-01'
         timestr = 'time_avg_daysSinceStartOfSim'
         variableList = \
             ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
@@ -97,32 +112,40 @@ class TestMpasXarray(TestCase):
         with self.assertRaisesRegexp(AssertionError,
                                      'not a dimension in the dataset that '
                                      'can be used for selection'):
-            mpas_xarray.open_multifile_dataset(fileNames=fileName,
-                                               timeVariableName=timestr,
-                                               variableList=variableList,
-                                               selValues=selvals,
-                                               yearOffset=1850)
+            mpas_xarray.open_multifile_dataset(
+                fileNames=fileName,
+                calendar=calendar,
+                simulationStartTime=simulationStartTime,
+                timeVariableName=timestr,
+                variableList=variableList,
+                selValues=selvals)
 
     def test_selvals(self):
         fileName = str(self.datadir.join('example_jan.nc'))
+        calendar = 'gregorian_noleap'
+        simulationStartTime = '0001-01-01'
         timestr = 'time_avg_daysSinceStartOfSim'
         variableList = \
             ['time_avg_avgValueWithinOceanLayerRegion_avgLayerTemperature',
              'refBottomDepth']
 
-        dsRef = mpas_xarray.open_multifile_dataset(fileNames=fileName,
-                                                   timeVariableName=timestr,
-                                                   variableList=variableList,
-                                                   selValues=None,
-                                                   yearOffset=1850)
+        dsRef = mpas_xarray.open_multifile_dataset(
+            fileNames=fileName,
+            calendar=calendar,
+            simulationStartTime=simulationStartTime,
+            timeVariableName=timestr,
+            variableList=variableList,
+            selValues=None)
 
         for vertIndex in range(0, 11):
             selvals = {'nVertLevels': vertIndex}
-            ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
-                                                    timeVariableName=timestr,
-                                                    variableList=variableList,
-                                                    selValues=selvals,
-                                                    yearOffset=1850)
+            ds = mpas_xarray.open_multifile_dataset(
+                fileNames=fileName,
+                calendar=calendar,
+                simulationStartTime=simulationStartTime,
+                timeVariableName=timestr,
+                variableList=variableList,
+                selValues=selvals)
 
             self.assertEqual(ds.data_vars.keys(), variableList)
             self.assertEqual(ds[variableList[0]].shape, (1, 7))
@@ -131,15 +154,17 @@ class TestMpasXarray(TestCase):
 
     def test_remove_repeated_time_index(self):
         fileName = str(self.datadir.join('example_jan*.nc'))
+        calendar = 'gregorian_noleap'
         timestr = ['xtime_start', 'xtime_end']
         variableList = \
             ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
 
         # repeat time indices are removed in openMultifileDataSet
-        ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
-                                                timeVariableName=timestr,
-                                                variableList=variableList,
-                                                yearOffset=1850)
+        ds = mpas_xarray.open_multifile_dataset(
+            fileNames=fileName,
+            calendar=calendar,
+            timeVariableName=timestr,
+            variableList=variableList)
 
         self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
         # There would be 3 time indices if repeat indices had not been removed.

--- a/mpas_analysis/test/test_timekeeping.py
+++ b/mpas_analysis/test/test_timekeeping.py
@@ -7,7 +7,7 @@ Xylar Asay-Davis
 
 Last Modified
 -------------
-02/09/2017
+02/17/2017
 """
 
 import pytest
@@ -15,8 +15,9 @@ import datetime
 from mpas_analysis.shared.timekeeping.MpasRelativeDelta \
     import MpasRelativeDelta
 from mpas_analysis.test import TestCase
-from mpas_analysis.shared.timekeeping.utility import stringToDatetime, \
-    stringToRelativeDelta, clampToNumpyDatetime64
+from mpas_analysis.shared.timekeeping.utility import string_to_datetime, \
+    string_to_relative_delta, string_to_days_since_date, days_to_datetime, \
+    datetime_to_days, date_to_days
 
 
 class TestTimekeeping(TestCase):
@@ -37,116 +38,93 @@ class TestTimekeeping(TestCase):
         for calendar in ['gregorian', 'gregorian_noleap']:
             # test datetime.datetime
             # YYYY-MM-DD_hh:mm:ss
-            date1 = stringToDatetime('0001-01-01_00:00:00')
+            date1 = string_to_datetime('0001-01-01_00:00:00')
             date2 = datetime.datetime(year=1, month=1, day=1, hour=0, minute=0,
                                       second=0)
             self.assertEqual(date1, date2)
 
-            delta1 = stringToRelativeDelta('0001-00-00_00:00:00',
-                                           calendar=calendar)
+            delta1 = string_to_relative_delta('0001-00-00_00:00:00',
+                                              calendar=calendar)
             delta2 = MpasRelativeDelta(years=1, months=0, days=0, hours=0,
                                        minutes=0, seconds=0, calendar=calendar)
             self.assertEqual(delta1, delta2)
 
             # YYYY-MM-DD_hh.mm.ss
-            date1 = stringToDatetime('0001-01-01_00.00.00')
+            date1 = string_to_datetime('0001-01-01_00.00.00')
             date2 = datetime.datetime(year=1, month=1, day=1, hour=0, minute=0,
                                       second=0)
             self.assertEqual(date1, date2)
 
             # YYYY-MM-DD_SSSSS
-            date1 = stringToDatetime('0001-01-01_00002')
+            date1 = string_to_datetime('0001-01-01_00002')
             date2 = datetime.datetime(year=1, month=1, day=1, hour=0, minute=0,
                                       second=2)
             self.assertEqual(date1, date2)
 
             # DDD_hh:mm:ss
-            delta1 = stringToRelativeDelta('0001_00:00:01',
-                                           calendar=calendar)
+            delta1 = string_to_relative_delta('0001_00:00:01',
+                                              calendar=calendar)
             delta2 = MpasRelativeDelta(years=0, months=0, days=1, hours=0,
                                        minutes=0, seconds=1, calendar=calendar)
             self.assertEqual(delta1, delta2)
 
             # DDD_hh.mm.ss
-            delta1 = stringToRelativeDelta('0002_01.00.01',
-                                           calendar=calendar)
+            delta1 = string_to_relative_delta('0002_01.00.01',
+                                              calendar=calendar)
             delta2 = MpasRelativeDelta(years=0, months=0, days=2, hours=1,
                                        minutes=0, seconds=1, calendar=calendar)
             self.assertEqual(delta1, delta2)
 
             # DDD_SSSSS
-            delta1 = stringToRelativeDelta('0002_00003',
-                                           calendar=calendar)
+            delta1 = string_to_relative_delta('0002_00003',
+                                              calendar=calendar)
             delta2 = MpasRelativeDelta(years=0, months=0, days=2, hours=0,
                                        minutes=0, seconds=3, calendar=calendar)
             self.assertEqual(delta1, delta2)
 
             # hh:mm:ss
-            date1 = stringToDatetime('00:00:01')
+            date1 = string_to_datetime('00:00:01')
             date2 = datetime.datetime(year=1, month=1, day=1, hour=0, minute=0,
                                       second=1)
             self.assertEqual(date1, date2)
 
             # hh.mm.ss
-            delta1 = stringToRelativeDelta('00.00.01',
-                                           calendar=calendar)
+            delta1 = string_to_relative_delta('00.00.01',
+                                              calendar=calendar)
             delta2 = MpasRelativeDelta(years=0, months=0, days=0, hours=0,
                                        minutes=0, seconds=1, calendar=calendar)
             self.assertEqual(delta1, delta2)
 
             # YYYY-MM-DD
-            date1 = stringToDatetime('0001-01-01')
+            date1 = string_to_datetime('0001-01-01')
             date2 = datetime.datetime(year=1, month=1, day=1, hour=0, minute=0,
                                       second=0)
             self.assertEqual(date1, date2)
 
             # SSSSS
-            delta1 = stringToRelativeDelta('00005',
-                                           calendar=calendar)
+            delta1 = string_to_relative_delta('00005',
+                                              calendar=calendar)
             delta2 = MpasRelativeDelta(years=0, months=0, days=0, hours=0,
                                        minutes=0, seconds=5, calendar=calendar)
             self.assertEqual(delta1, delta2)
 
-            date1 = stringToDatetime('1996-01-15')
-            delta = stringToRelativeDelta('0005-00-00',
-                                          calendar=calendar)
+            date1 = string_to_datetime('1996-01-15')
+            delta = string_to_relative_delta('0005-00-00',
+                                             calendar=calendar)
             date2 = date1-delta
-            self.assertEqual(date2, stringToDatetime('1991-01-15'))
+            self.assertEqual(date2, string_to_datetime('1991-01-15'))
 
-            date1 = stringToDatetime('1996-01-15')
-            delta = stringToRelativeDelta('0000-02-00',
-                                          calendar=calendar)
+            date1 = string_to_datetime('1996-01-15')
+            delta = string_to_relative_delta('0000-02-00',
+                                             calendar=calendar)
             date2 = date1-delta
-            self.assertEqual(date2, stringToDatetime('1995-11-15'))
+            self.assertEqual(date2, string_to_datetime('1995-11-15'))
 
-            date1 = stringToDatetime('1996-01-15')
-            delta = stringToRelativeDelta('0000-00-20',
-                                          calendar=calendar)
+            date1 = string_to_datetime('1996-01-15')
+            delta = string_to_relative_delta('0000-00-20',
+                                             calendar=calendar)
             date2 = date1-delta
-            self.assertEqual(date2, stringToDatetime('1995-12-26'))
-
-        # since pandas and xarray use the numpy type 'datetime[ns]`, which
-        # has a limited range of dates, the date 0001-01-01 gets increased
-        # to the minimum allowed year boundary, 1678-01-01 to avoid invalid
-        # dates.
-        date1 = clampToNumpyDatetime64(stringToDatetime('0001-01-01'),
-                                       yearOffset=0)
-        date2 = datetime.datetime(year=1678, month=1, day=1)
-        self.assertEqual(date1, date2)
-
-        date1 = clampToNumpyDatetime64(stringToDatetime('0001-01-01'),
-                                       yearOffset=1849)
-        date2 = datetime.datetime(year=1850, month=1, day=1)
-        self.assertEqual(date1, date2)
-
-        # since pandas and xarray use the numpy type 'datetime[ns]`, which
-        # has a limited range of dates, the date 9999-01-01 gets decreased
-        # to the maximum allowed year boundary, 2262-01-01 to avoid invalid
-        # dates.
-        date1 = clampToNumpyDatetime64(stringToDatetime('9999-01-01'),
-                                       yearOffset=0)
-        date2 = datetime.datetime(year=2262, month=1, day=1)
-        self.assertEqual(date1, date2)
+            self.assertEqual(date2, string_to_datetime('1995-12-26'))
 
     def test_MpasRelativeDeltaOps(self):
         # test if the calendars behave as they should close to leap day
@@ -155,77 +133,160 @@ class TestTimekeeping(TestCase):
         # both calendars with adding one day
         for calendar, expected in zip(['gregorian', 'gregorian_noleap'],
                                       ['2016-02-29', '2016-03-01']):
-            self.assertEqual(stringToDatetime('2016-02-28') +
-                             stringToRelativeDelta('0000-00-01',
-                                                   calendar=calendar),
-                             stringToDatetime(expected))
+            self.assertEqual(string_to_datetime('2016-02-28') +
+                             string_to_relative_delta('0000-00-01',
+                                                      calendar=calendar),
+                             string_to_datetime(expected))
 
         # both calendars with subtracting one day
         for calendar, expected in zip(['gregorian', 'gregorian_noleap'],
                                       ['2016-02-29', '2016-02-28']):
-            self.assertEqual(stringToDatetime('2016-03-01') -
-                             stringToRelativeDelta('0000-00-01',
-                                                   calendar=calendar),
-                             stringToDatetime(expected))
+            self.assertEqual(string_to_datetime('2016-03-01') -
+                             string_to_relative_delta('0000-00-01',
+                                                      calendar=calendar),
+                             string_to_datetime(expected))
 
         # both calendars with adding one month
         for calendar, expected in zip(['gregorian', 'gregorian_noleap'],
                                       ['2016-02-29', '2016-02-28']):
-            self.assertEqual(stringToDatetime('2016-01-31') +
-                             stringToRelativeDelta('0000-01-00',
-                                                   calendar=calendar),
-                             stringToDatetime(expected))
+            self.assertEqual(string_to_datetime('2016-01-31') +
+                             string_to_relative_delta('0000-01-00',
+                                                      calendar=calendar),
+                             string_to_datetime(expected))
 
         # both calendars with subtracting one month
         for calendar, expected in zip(['gregorian', 'gregorian_noleap'],
                                       ['2016-02-29', '2016-02-28']):
-            self.assertEqual(stringToDatetime('2016-03-31') -
-                             stringToRelativeDelta('0000-01-00',
-                                                   calendar=calendar),
-                             stringToDatetime(expected))
+            self.assertEqual(string_to_datetime('2016-03-31') -
+                             string_to_relative_delta('0000-01-00',
+                                                      calendar=calendar),
+                             string_to_datetime(expected))
 
         for calendar in ['gregorian', 'gregorian_noleap']:
 
-            delta1 = stringToRelativeDelta('0000-01-00',  calendar=calendar)
-            delta2 = stringToRelativeDelta('0000-00-01',  calendar=calendar)
-            deltaSum = stringToRelativeDelta('0000-01-01',  calendar=calendar)
+            delta1 = string_to_relative_delta('0000-01-00',  calendar=calendar)
+            delta2 = string_to_relative_delta('0000-00-01',  calendar=calendar)
+            deltaSum = string_to_relative_delta('0000-01-01',
+                                                calendar=calendar)
             # test MpasRelativeDelta + MpasRelativeDelta
             self.assertEqual(delta1 + delta2, deltaSum)
             # test MpasRelativeDelta - MpasRelativeDelta
             self.assertEqual(deltaSum - delta2, delta1)
 
             # test MpasRelativeDelta(date1, date2)
-            date1 = stringToDatetime('0002-02-02')
-            date2 = stringToDatetime('0001-01-01')
-            delta = stringToRelativeDelta('0001-01-01',  calendar=calendar)
+            date1 = string_to_datetime('0002-02-02')
+            date2 = string_to_datetime('0001-01-01')
+            delta = string_to_relative_delta('0001-01-01',  calendar=calendar)
             self.assertEqual(MpasRelativeDelta(dt1=date1, dt2=date2,
                                                calendar=calendar),
                              delta)
 
             # test MpasRelativeDelta + datetime.datetime (an odd order but
             # it's allowed...)
-            date1 = stringToDatetime('0001-01-01')
-            delta = stringToRelativeDelta('0001-01-01',  calendar=calendar)
-            date2 = stringToDatetime('0002-02-02')
+            date1 = string_to_datetime('0001-01-01')
+            delta = string_to_relative_delta('0001-01-01',  calendar=calendar)
+            date2 = string_to_datetime('0002-02-02')
             self.assertEqual(delta + date1, date2)
 
             # test multiplication/division by scalars
-            delta1 = stringToRelativeDelta('0001-01-01',  calendar=calendar)
-            delta2 = stringToRelativeDelta('0002-02-02',  calendar=calendar)
+            delta1 = string_to_relative_delta('0001-01-01',  calendar=calendar)
+            delta2 = string_to_relative_delta('0002-02-02',  calendar=calendar)
             self.assertEqual(2*delta1, delta2)
             self.assertEqual(delta2/2, delta1)
-
 
         # make sure there's an error when we try to add MpasRelativeDeltas
         # with different calendars
         with self.assertRaisesRegexp(ValueError,
                                      'MpasRelativeDelta objects can only be '
                                      'added if their calendars match.'):
-            delta1 = stringToRelativeDelta('0000-01-00',
-                                           calendar='gregorian')
-            delta2 = stringToRelativeDelta('0000-00-01',
-                                           calendar='gregorian_noleap')
+            delta1 = string_to_relative_delta('0000-01-00',
+                                              calendar='gregorian')
+            delta2 = string_to_relative_delta('0000-00-01',
+                                              calendar='gregorian_noleap')
             deltaSum = delta1 + delta2
 
+    def test_string_to_days_since_date(self):
+        referenceDate = '0001-01-01'
+        for calendar in ['gregorian', 'gregorian_noleap']:
+            for dateString, expected_days in [('0001-01-01', 0.),
+                                              ('0001-01-02', 1.),
+                                              ('0001-02-01', 31.),
+                                              ('0002-01-01', 365.)]:
+                days = string_to_days_since_date(dateString=dateString,
+                                                 calendar=calendar,
+                                                 referenceDate=referenceDate)
+                self.assertEqual(days, expected_days)
+
+        referenceDate = '2016-01-01'
+        for calendar, expected_days in [('gregorian', 366.),
+                                        ('gregorian_noleap', 365.)]:
+            days = string_to_days_since_date(dateString='2017-01-01',
+                                             calendar=calendar,
+                                             referenceDate=referenceDate)
+            self.assertEqual(days, expected_days)
+
+    def test_days_to_datetime(self):
+        referenceDate = '0001-01-01'
+        for calendar in ['gregorian', 'gregorian_noleap']:
+            for dateString, days in [('0001-01-01', 0.),
+                                     ('0001-01-02', 1.),
+                                     ('0001-02-01', 31.),
+                                     ('0002-01-01', 365.)]:
+                datetime = days_to_datetime(days=days,
+                                            calendar=calendar,
+                                            referenceDate=referenceDate)
+                self.assertEqual(datetime, string_to_datetime(dateString))
+
+        referenceDate = '2016-01-01'
+        for calendar, days in [('gregorian', 366.),
+                               ('gregorian_noleap', 365.)]:
+            datetime = days_to_datetime(days=days,
+                                        calendar=calendar,
+                                        referenceDate=referenceDate)
+            self.assertEqual(datetime, string_to_datetime('2017-01-01'))
+
+    def test_datetime_to_days(self):
+        referenceDate = '0001-01-01'
+        for calendar in ['gregorian', 'gregorian_noleap']:
+            for dateString, expected_days in [('0001-01-01', 0.),
+                                              ('0001-01-02', 1.),
+                                              ('0001-02-01', 31.),
+                                              ('0002-01-01', 365.)]:
+                days = datetime_to_days(dates=string_to_datetime(dateString),
+                                        calendar=calendar,
+                                        referenceDate=referenceDate)
+                self.assertEqual(days, expected_days)
+
+        referenceDate = '2016-01-01'
+        for calendar, expected_days in [('gregorian', 366.),
+                                        ('gregorian_noleap', 365.)]:
+            days = datetime_to_days(dates=string_to_datetime('2017-01-01'),
+                                    calendar=calendar,
+                                    referenceDate=referenceDate)
+            self.assertEqual(days, expected_days)
+
+    def test_date_to_days(self):
+        referenceDate = '0001-01-01'
+        for calendar in ['gregorian', 'gregorian_noleap']:
+            days = date_to_days(year=1, month=1, day=1, calendar=calendar,
+                                referenceDate=referenceDate)
+            self.assertEqual(days, 0.)
+            days = date_to_days(year=1, month=1, day=2, calendar=calendar,
+                                referenceDate=referenceDate)
+            self.assertEqual(days, 1.)
+            days = date_to_days(year=1, month=2, day=1, calendar=calendar,
+                                referenceDate=referenceDate)
+            self.assertEqual(days, 31.)
+            days = date_to_days(year=2, month=1, day=1, calendar=calendar,
+                                referenceDate=referenceDate)
+            self.assertEqual(days, 365.)
+
+        referenceDate = '2016-01-01'
+        for calendar, expected_days in [('gregorian', 366.),
+                                        ('gregorian_noleap', 365.)]:
+            days = date_to_days(year=2017, month=1, day=1,
+                                calendar=calendar,
+                                referenceDate=referenceDate)
+            self.assertEqual(days, expected_days)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
This merge modifies mpas_xarray and generalized_reader to produce a 'Time' coordinate that is the floating-point number of days since 0001-01-01.

This merge also updates some of the case/underscore conventions in the timekeeping module to use mixed case (CamelCase) for variable and function argument names.

The 5 analysis scripts have been updated to perform date computations by converting 'Time' coordinates to datetime objects (using `days_to_datetime`) and using the calendar-aware `MpasRelativeDelta` class for computations with offsets in time.

The `yearOffset` config option has been eliminated.  New confg options have been added for selecting a range of dates to be used to create an SST climatology.

A config file for an MPAS-SeaIce test case has been added, showing that a run with start date of 1958-01-01 can be accommodated.

Add NetCDF4 to dependencies of CI.