### PR TITLE
Modularize ocean and sea ice climatology computations

### DIFF
--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -1,13 +1,23 @@
+"""
+General comparison of 2-d model fields against data.  Currently only supports
+sea ice concentration (sic) and sea ice thickness (sit)
+
+Author: Xylar Asay-Davis, Milena Veneziani
+Last Modified: 02/26/2017
+"""
+
 import os
 import os.path
-import subprocess
 import matplotlib.pyplot as plt
 import matplotlib.colors as cols
 
-import numpy as np
 import numpy.ma as ma
 
 import netCDF4
+
+from ..shared.constants import constants
+
+from ..shared.climatology import climatology
 
 from ..shared.plot.plotting import plot_polar_comparison
 
@@ -17,8 +27,7 @@ from ..shared.io.utility import buildConfigFullPath
 from ..shared.generalized_reader.generalized_reader \
     import open_multifile_dataset
 
-from ..shared.timekeeping.utility import get_simulation_start_time, \
-    days_to_datetime
+from ..shared.timekeeping.utility import get_simulation_start_time
 
 
 def seaice_modelvsobs(config, streamMap=None, variableMap=None):
@@ -36,7 +45,7 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
     to their mpas_analysis counterparts.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 02/02/2017
+    Last Modified: 02/26/2017
     """
 
     # read parameters from config file
@@ -66,103 +75,11 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
                                  endDate=endDate, calendar=calendar)
     print 'Reading files {} through {}'.format(fileNames[0], fileNames[-1])
 
-    plotsDirectory = buildConfigFullPath(config, 'output', 'plotsSubdirectory')
-
-    mainRunName = config.get('runs', 'mainRunName')
-
-    mpasRemapFile = config.get('remapping', 'mpasRemapFile')
-    climatologyDirectory = buildConfigFullPath(config, 'output',
-                                               'climatologySubdirectory')
-
-    startYear = config.getint('climatology', 'startYear')
-    endYear = config.getint('climatology', 'endYear')
-
-    # climatologyDirectory = "{}/{}".format(climatologyDirectory, mainRunName)
-    climatologyRegriddedDirectory = "{}/mpas_regridded".format(
-        climatologyDirectory)
-    if not os.path.isdir(climatologyDirectory):
-        print "\nClimatology directory does not exist. Create it...\n"
-        os.mkdir(climatologyDirectory)
-    if not os.path.isdir(climatologyRegriddedDirectory):
-        print "\nRegridded directory does not exist. Create it...\n"
-        os.mkdir(climatologyRegriddedDirectory)
-
-    # Model climatology (output) filenames
-    climatologyFiles = {}
-    climatologyFiles['winNH'] = \
-        "mpas-cice_climo.years{:04d}-{:04d}.jfm.nc".format(startYear, endYear)
-    climatologyFiles['sumNH'] = \
-        "mpas-cice_climo.years{:04d}-{:04d}.jas.nc".format(startYear, endYear)
-    climatologyFiles['winSH'] = \
-        "mpas-cice_climo.years{:04d}-{:04d}.djf.nc".format(startYear, endYear)
-    climatologyFiles['sumSH'] = \
-        "mpas-cice_climo.years{:04d}-{:04d}.jja.nc".format(startYear, endYear)
-    climatologyFiles['on'] = \
-        "mpas-cice_climo.years{:04d}-{:04d}.on.nc".format(startYear, endYear)
-    climatologyFiles['fm'] = \
-        "mpas-cice_climo.years{:04d}-{:04d}.fm.nc".format(startYear, endYear)
-
-    # make a dictionary of the months in each climotology
-    monthsInClim = {}
-    monthsInClim['winNH'] = [1, 2, 3]
-    monthsInClim['sumNH'] = [7, 8, 9]
-    monthsInClim['winSH'] = [12, 1, 2]
-    monthsInClim['sumSH'] = [6, 7, 8]
-    monthsInClim['on'] = [10, 11]
-    monthsInClim['fm'] = [2, 3]
-
-    # Obs filenames
-    obsIceConcFileNames = {}
-    obsIceConcFileNames['winNH_NASATeam'] = buildConfigFullPath(
-                                             config, 'seaIceObservations',
-                                             'concentrationNASATeamNH_JFM')
-    obsIceConcFileNames['sumNH_NASATeam'] = buildConfigFullPath(
-                                             config, 'seaIceObservations',
-                                             'concentrationNASATeamNH_JAS')
-    obsIceConcFileNames['winSH_NASATeam'] = buildConfigFullPath(
-                                             config, 'seaIceObservations',
-                                             'concentrationNASATeamSH_DJF')
-    obsIceConcFileNames['sumSH_NASATeam'] = buildConfigFullPath(
-                                             config, 'seaIceObservations',
-                                             'concentrationNASATeamSH_JJA')
-    obsIceConcFileNames['winNH_Bootstrap'] = buildConfigFullPath(
-                                              config, 'seaIceObservations',
-                                              'concentrationBootstrapNH_JFM')
-    obsIceConcFileNames['sumNH_Bootstrap'] = buildConfigFullPath(
-                                              config, 'seaIceObservations',
-                                              'concentrationBootstrapNH_JAS')
-    obsIceConcFileNames['winSH_Bootstrap'] = buildConfigFullPath(
-                                              config, 'seaIceObservations',
-                                              'concentrationBootstrapSH_DJF')
-    obsIceConcFileNames['sumSH_Bootstrap'] = buildConfigFullPath(
-                                              config, 'seaIceObservations',
-                                              'concentrationBootstrapSH_JJA')
-
-    obsIceThickFileNames = {}
-    obsIceThickFileNames['onNH'] = buildConfigFullPath(
-                                    config, 'seaIceObservations',
-                                    'thicknessNH_ON')
-    obsIceThickFileNames['fmNH'] = buildConfigFullPath(
-                                    config, 'seaIceObservations',
-                                    'thicknessNH_FM')
-    obsIceThickFileNames['onSH'] = buildConfigFullPath(
-                                    config, 'seaIceObservations',
-                                    'thicknessSH_ON')
-    obsIceThickFileNames['fmSH'] = buildConfigFullPath(
-                                    config, 'seaIceObservations',
-                                    'thicknessSH_FM')
-
-    # Checks on directory/files existence:
-    for climName in obsIceConcFileNames:
-        obsFileNames = obsIceConcFileNames[climName]
-        if not os.path.isfile(obsFileNames):
-            raise SystemExit("Obs file {} not found. Exiting...".format(
-                obsFileNames))
-    for climName in obsIceThickFileNames:
-        obsFileNames = obsIceThickFileNames[climName]
-        if not os.path.isfile(obsFileNames):
-            raise SystemExit("Obs file {} not found. Exiting...".format(
-                obsFileNames))
+    try:
+        restartFileName = streams.readpath('restart')[0]
+    except ValueError:
+        raise IOError('No MPAS-Sea Ice restart file found: need at least one '
+                      'restart file for modelvsobs calculation')
 
     # Load data
     print "  Load sea-ice data..."
@@ -179,169 +96,193 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
     # Compute climatologies (first motnhly and then seasonally)
     print "  Compute seasonal climatologies..."
 
-    months = [date.month for date in days_to_datetime(ds.Time,
-                                                      calendar=calendar)]
+    monthlyClimatology = climatology.compute_monthly_climatology(ds, calendar)
 
-    ds.coords['month'] = ('Time', months)
-    monthlyClimatology = ds.groupby('month').mean('Time')
+    mpasInterolationData = \
+        climatology.init_model_interpolation(restartFileName)
 
-    daysInMonth = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
-    monthLetters = ['J', 'F', 'M', 'A', 'M', 'J', 'J', 'A', 'S', 'O', 'N', 'D']
+    _compute_and_plot_concentration(config, monthlyClimatology,
+                                    mpasInterolationData)
 
-    climatologies = {}
-    for climName in monthsInClim:
-        months = monthsInClim[climName]
-        month = months[0]
-        days = daysInMonth[month-1]
-        climatology = days*monthlyClimatology.sel(month=month)
-        totalDays = days
-        for month in months[1:]:
-            days = daysInMonth[month-1]
-            climatology += days*monthlyClimatology.sel(month=month)
-            totalDays += days
-        climatology /= totalDays
+    _compute_and_plot_thickness(config, monthlyClimatology,
+                                mpasInterolationData)
 
-        climatologies[climName] = climatology
 
-    print "  Regrid fields to regular grid..."
-    for climName in climatologies:
-        # Save to netcdf files
-        outFileName = "{}/{}".format(climatologyDirectory,
-                                     climatologyFiles[climName])
-        climatologies[climName].to_netcdf(outFileName)
-        args = ["ncremap", "-P", "mpas", "-i", outFileName,
-                "-m", mpasRemapFile, "-O", climatologyRegriddedDirectory]
-        try:
-            subprocess.check_call(args)
-        except subprocess.CalledProcessError, e:
-            print 'Error with call ', ' '.join(args)
-            print e
-            raise e
+def _compute_and_plot_concentration(config, monthlyClimatology,
+                                    mpasInterolationData):
+    """
+    Given a config file, monthly climatology on the mpas grid, and the data
+    necessary to perform horizontal interpolation to a comparison grid,
+    computes seasonal climatologies and plots model results, observations
+    and biases in sea-ice concentration.
+
+    Parameters
+    ----------
+    config : an instance of MpasConfigParser
+
+    monthlyClimatology : an xarray data set containing a monthly climatology
+
+    mpasInterolationData : a tuple returned by init_model_interpolation that
+        contains the information needed to interpolate from the MPAS mesh
+        to the comparison grid
+
+    Authors
+    -------
+    Xylar Asay-Davis, Milena Veneziani
+
+    Last Modified
+    -------------
+    02/26/2017
+    """
 
     print "  Make ice concentration plots..."
+
+    plotsDirectory = buildConfigFullPath(config, 'output', 'plotsSubdirectory')
+    mainRunName = config.get('runs', 'mainRunName')
+    startYear = config.getint('climatology', 'startYear')
+    endYear = config.getint('climatology', 'endYear')
+
     subtitle = "Ice concentration"
 
-    # interate over observations of sea-ice concentration
-    first = True
-    for season in ['Winter', 'Summer']:
-        for hemisphere in ['NH', 'SH']:
-            climName = '{}{}'.format(season[0:3].lower(), hemisphere)
+    hemisphereSeasons = {'JFM': ('NH', 'Winter'),
+                         'JAS': ('NH', 'Summer'),
+                         'DJF': ('SH', 'Winter'),
+                         'JJA': ('SH', 'Summer')}
 
-            if hemisphere == 'NH':
-                plotProjection = 'npstere'
-            else:
-                plotProjection = 'spstere'
+    lonTarg = mpasInterolationData[2]
+    latTarg = mpasInterolationData[3]
 
-            resultConcContourValues = config.getExpression(
-                'regriddedSeaIceConcThick',
-                'resultConc{}ContourValues'.format(season))
-            resultColormap = plt.get_cmap(config.get(
-                'regriddedSeaIceConcThick', 'resultColormap'))
-            resultColormapIndices = config.getExpression(
-                'regriddedSeaIceConcThick', 'resultColormapIndices')
-            resultColormap = cols.ListedColormap(
-                resultColormap(resultColormapIndices), "resultColormap")
+    for months in hemisphereSeasons:
+        hemisphere, season = hemisphereSeasons[months]
+        monthsValue = constants.monthDictionary[months]
 
-            differenceConcContourValues = config.getExpression(
-                'regriddedSeaIceConcThick',
-                'differenceConc{}ContourValues'.format(season))
-            differenceColormap = plt.get_cmap(config.get(
-                'regriddedSeaIceConcThick', 'differenceColormap'))
-            differenceColormapIndices = config.getExpression(
-                'regriddedSeaIceConcThick', 'differenceColormapIndices')
-            differenceColormap = cols.ListedColormap(
-                differenceColormap(differenceColormapIndices),
-                "differenceColormap")
+        iceConcentration = climatology.interpolate_model_climatology(
+            mpasInterolationData, monthlyClimatology, "iceAreaCell",
+            monthsValue)
 
-            referenceLongitude = config.getfloat(
-                'regriddedSeaIceConcThick',
-                'referenceLongitude{}'.format(hemisphere))
-            minimumLatitude = config.getfloat(
-                'regriddedSeaIceConcThick',
-                'minimumLatitude{}'.format(hemisphere))
+        if hemisphere == 'NH':
+            plotProjection = 'npstere'
+        else:
+            plotProjection = 'spstere'
 
-            # Load in sea-ice data
-            #  Model...
-            # ice concentrations
-            fileName = "{}/{}".format(climatologyRegriddedDirectory,
-                                      climatologyFiles[climName])
-            ncFile = netCDF4.Dataset(fileName, mode='r')
-            iceConcentration = ncFile.variables["iceAreaCell"][:]
-            if(first):
-                lons = ncFile.variables["lon"][:]
-                lats = ncFile.variables["lat"][:]
-                print "Min lon: ", np.amin(lons), "Max lon: ", np.amax(lons)
-                print "Min lat: ", np.amin(lats), "Max lat: ", np.amax(lats)
-                Lons, Lats = np.meshgrid(lons, lats)
-                first = False
+        resultConcContourValues = config.getExpression(
+            'regriddedSeaIceConcThick',
+            'resultConc{}ContourValues'.format(season))
+        resultColormap = plt.get_cmap(config.get(
+            'regriddedSeaIceConcThick', 'resultColormap'))
+        resultColormapIndices = config.getExpression(
+            'regriddedSeaIceConcThick', 'resultColormapIndices')
+        resultColormap = cols.ListedColormap(
+            resultColormap(resultColormapIndices), "resultColormap")
+
+        differenceConcContourValues = config.getExpression(
+            'regriddedSeaIceConcThick',
+            'differenceConc{}ContourValues'.format(season))
+        differenceColormap = plt.get_cmap(config.get(
+            'regriddedSeaIceConcThick', 'differenceColormap'))
+        differenceColormapIndices = config.getExpression(
+            'regriddedSeaIceConcThick', 'differenceColormapIndices')
+        differenceColormap = cols.ListedColormap(
+            differenceColormap(differenceColormapIndices),
+            "differenceColormap")
+
+        referenceLongitude = config.getfloat(
+            'regriddedSeaIceConcThick',
+            'referenceLongitude{}'.format(hemisphere))
+        minimumLatitude = config.getfloat(
+            'regriddedSeaIceConcThick',
+            'minimumLatitude{}'.format(hemisphere))
+
+        # ice concentrations from NASATeam (or Bootstrap) algorithm
+        for obsName in ['NASATeam', 'Bootstrap']:
+
+            obsFileNames = buildConfigFullPath(
+                config, 'seaIceObservations',
+                'concentration{}{}_{}'.format(obsName, hemisphere, months))
+
+            if not os.path.isfile(obsFileNames):
+                raise SystemExit("Obs file {} not found. Exiting...".format(
+                    obsFileNames))
+
+            ncFile = netCDF4.Dataset(obsFileNames, mode='r')
+            obsIceConcentration = ncFile.variables["AICE"][:].T
             ncFile.close()
 
-            #  ...and observations
-            # ice concentrations from NASATeam (or Bootstrap) algorithm
-            for obsName in ['NASATeam', 'Bootstrap']:
+            difference = iceConcentration - obsIceConcentration
 
-                fileName = obsIceConcFileNames[
-                    '{}_{}'.format(climName, obsName)]
-                ncFile = netCDF4.Dataset(fileName, mode='r')
-                obsIceConcentration = ncFile.variables["AICE"][:]
-                ncFile.close()
+            title = "{} ({}, years {:04d}-{:04d})".format(
+                subtitle, months, startYear, endYear)
+            fileout = "{}/iceconc{}{}_{}_{}_years{:04d}-{:04d}.png".format(
+                plotsDirectory, obsName, hemisphere, mainRunName,
+                months, startYear, endYear)
+            plot_polar_comparison(
+                config,
+                lonTarg,
+                latTarg,
+                iceConcentration,
+                obsIceConcentration,
+                difference,
+                resultColormap,
+                resultConcContourValues,
+                differenceColormap,
+                differenceConcContourValues,
+                title=title,
+                fileout=fileout,
+                plotProjection=plotProjection,
+                latmin=minimumLatitude,
+                lon0=referenceLongitude,
+                modelTitle=mainRunName,
+                obsTitle="Observations (SSM/I {})".format(obsName),
+                diffTitle="Model-Observations",
+                cbarlabel="fraction")
 
-                difference = iceConcentration - obsIceConcentration
 
-                monthsName = []
-                for month in monthsInClim[climName]:
-                    monthsName.append(monthLetters[month-1])
-                monthsName = ''.join(monthsName)
+def _compute_and_plot_thickness(config, monthlyClimatology,
+                                mpasInterolationData):
+    """
+    Given a config file, monthly climatology on the mpas grid, and the data
+    necessary to perform horizontal interpolation to a comparison grid,
+    computes seasonal climatologies and plots model results, observations
+    and biases in sea-ice thickness.
 
-                title = "{} ({}, years {:04d}-{:04d})".format(
-                    subtitle, monthsName, startYear, endYear)
-                fileout = "{}/iceconc{}{}_{}_{}_years{:04d}-{:04d}.png".format(
-                    plotsDirectory, obsName, hemisphere, mainRunName,
-                    monthsName, startYear, endYear)
-                plot_polar_comparison(
-                    config,
-                    Lons,
-                    Lats,
-                    iceConcentration,
-                    obsIceConcentration,
-                    difference,
-                    resultColormap,
-                    resultConcContourValues,
-                    differenceColormap,
-                    differenceConcContourValues,
-                    title=title,
-                    fileout=fileout,
-                    plotProjection=plotProjection,
-                    latmin=minimumLatitude,
-                    lon0=referenceLongitude,
-                    modelTitle=mainRunName,
-                    obsTitle="Observations (SSM/I {})".format(obsName),
-                    diffTitle="Model-Observations",
-                    cbarlabel="fraction")
+    Parameters
+    ----------
+    config : an instance of MpasConfigParser
+
+    monthlyClimatology : an xarray data set containing a monthly climatology
+
+    mpasInterolationData : a tuple returned by init_model_interpolation that
+        contains the information needed to interpolate from the MPAS mesh
+        to the comparison grid
+
+    Authors
+    -------
+    Xylar Asay-Davis, Milena Veneziani
+
+    Last Modified
+    -------------
+    02/26/2017
+    """
 
     print "  Make ice thickness plots..."
-    # Plot Northern Hemisphere FM sea-ice thickness
+
     subtitle = "Ice thickness"
-    # interate over observations of sea-ice thickness
-    for climName in ['fm', 'on']:
 
-        # Load in sea-ice data
-        #  Model...
-        # ice concentrations
-        fileName = "{}/{}".format(climatologyRegriddedDirectory,
-                                  climatologyFiles[climName])
-        ncFile = netCDF4.Dataset(fileName, mode='r')
-        iceThickness = ncFile.variables["iceVolumeCell"][:]
-        ncFile.close()
+    plotsDirectory = buildConfigFullPath(config, 'output', 'plotsSubdirectory')
+    mainRunName = config.get('runs', 'mainRunName')
+    startYear = config.getint('climatology', 'startYear')
+    endYear = config.getint('climatology', 'endYear')
 
-        monthsName = []
-        for month in monthsInClim[climName]:
-            monthsName.append(monthLetters[month-1])
-        monthsName = ''.join(monthsName)
+    lonTarg = mpasInterolationData[2]
+    latTarg = mpasInterolationData[3]
+
+    for months in ['FM', 'ON']:
+        monthsValue = constants.monthDictionary[months]
+        iceThickness = climatology.interpolate_model_climatology(
+            mpasInterolationData, monthlyClimatology, "iceVolumeCell",
+            monthsValue)
 
         for hemisphere in ['NH', 'SH']:
-            #  ...and observations
-            # ice concentrations from NASATeam (or Bootstrap) algorithm
 
             resultThickContourValues = config.getExpression(
                 'regriddedSeaIceConcThick',
@@ -371,32 +312,38 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
                 'regriddedSeaIceConcThick',
                 'minimumLatitude{}'.format(hemisphere))
 
-            fileName = obsIceThickFileNames['{}{}'.format(climName,
-                                                          hemisphere)]
-            ncFile = netCDF4.Dataset(fileName, mode='r')
-            obsIceThickness = ncFile.variables["HI"][:]
+            obsFileNames = buildConfigFullPath(
+                config, 'seaIceObservations',
+                'thickness{}_{}'.format(hemisphere, months))
+            if not os.path.isfile(obsFileNames):
+                raise SystemExit("Obs file {} not found. Exiting...".format(
+                    obsFileNames))
+
+            ncFile = netCDF4.Dataset(obsFileNames, mode='r')
+            obsIceThickness = ncFile.variables["HI"][:].T
             ncFile.close()
+
             # Mask thickness fields
             iceThickness[iceThickness == 0] = ma.masked
             obsIceThickness = ma.masked_values(obsIceThickness, 0)
             if hemisphere == 'NH':
                 # Obs thickness should be nan above 86 (ICESat data)
-                obsIceThickness[Lats > 86] = ma.masked
+                obsIceThickness[latTarg > 86] = ma.masked
                 plotProjection = 'npstere'
             else:
                 plotProjection = 'spstere'
 
             difference = iceThickness - obsIceThickness
 
-            title = "{} ({}, years {:04d}-{:04d})".format(subtitle, monthsName,
+            title = "{} ({}, years {:04d}-{:04d})".format(subtitle, months,
                                                           startYear, endYear)
             fileout = "{}/icethick{}_{}_{}_years{:04d}-{:04d}.png".format(
-                plotsDirectory, hemisphere, mainRunName, monthsName, startYear,
+                plotsDirectory, hemisphere, mainRunName, months, startYear,
                 endYear)
             plot_polar_comparison(
                 config,
-                Lons,
-                Lats,
+                lonTarg,
+                latTarg,
                 iceThickness,
                 obsIceThickness,
                 difference,
@@ -413,3 +360,6 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
                 obsTitle="Observations (ICESat)",
                 diffTitle="Model-Observations",
                 cbarlabel="m")
+
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -1,0 +1,274 @@
+"""
+Functions for creating climatologies from monthly time series data
+
+Authors
+-------
+Xylar Asay-Davis
+
+Last Modified
+-------------
+02/26/2017
+"""
+
+import numpy as np
+import netCDF4
+
+from ..interpolation.interpolate import interp_fields, init_tree
+from ..constants import constants
+
+from ..timekeeping.utility import days_to_datetime
+
+
+def compute_monthly_climatology(ds, calendar):
+    """
+    Compute a monthly climatology data set from a data set with Time expressed
+    as days since 0001-01-01 with the given calendar.
+
+    Parameters
+    ----------
+    ds : an xarray data set with a 'Time' coordinate expressed as days since
+        0001-01-01
+
+    calendar: {'gregorian', 'gregorian_noleap'}
+        The name of one of the calendars supported by MPAS cores
+
+    Returns
+    -------
+    monthlyClimatology : an xarray data set with a new 'month' coordinate,
+        containing monthly climatologies of all variables in ds
+
+    Authors
+    -------
+    Luke Van Roekel, Milena Veneziani, Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    02/25/2017
+    """
+    months = [date.month for date in days_to_datetime(ds.Time,
+                                                      calendar=calendar)]
+
+    ds.coords['month'] = ('Time', months)
+    monthlyClimatology = ds.groupby('month').mean('Time')
+    return monthlyClimatology
+
+
+def init_model_interpolation(mpasMeshFileName):
+    """
+    Given an MPAS mesh file, computes weight information needed to perform
+    climatology interpolation to a comparison grid.  The resolution of the
+    comparison grid is determined via the constants module.
+
+    Parameters
+    ----------
+    mpasMeshFileName : an MPAS file contining mesh information
+
+    Returns
+    -------
+    d : the distance to the nearest MPAS cell center from a given comparison
+        grid point
+
+    inds : the index of the nearest MPAS cell center to a given comparison
+        grid point
+
+    lonTarg, latTarg : the longitude and latitude coordinates (as 2D arrays)
+        of points on the default comparison grid
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    02/26/2017
+    """
+
+    ncFile = netCDF4.Dataset(mpasMeshFileName, mode='r')
+    lonCell = ncFile.variables["lonCell"][:]
+    latCell = ncFile.variables["latCell"][:]
+    ncFile.close()
+
+    return init_tree(np.rad2deg(lonCell),
+                     np.rad2deg(latCell),
+                     constants.lonmin,
+                     constants.lonmax,
+                     constants.latmin,
+                     constants.latmax,
+                     constants.dLongitude,
+                     constants.dLatitude)
+
+
+def init_observations_interpolation(dsObs):
+    """
+    Given monthly climatology from observations on a lat/lon grid, interpolates
+    the desired field over the desired months to a the default comparison grid.
+
+    Parameters
+    ----------
+    dsObs : an xarray data set containing longitude and latitude information
+        for the observations
+
+    Returns
+    -------
+    d : the distance to the nearest MPAS cell center from a given comparison
+        grid point
+
+    inds : the index of the nearest MPAS cell center to a given comparison
+        grid point
+
+    lonTarg, latTarg : the longitude and latitude coordinates (as 2D arrays)
+        of points on the default comparison grid
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    02/26/2017
+    """
+
+    latData, lonData = np.meshgrid(dsObs.lat.values,
+                                   dsObs.lon.values)
+    latData = latData.flatten()
+    lonData = lonData.flatten()
+
+    # initialize interpolation variables
+    return init_tree(lonData, latData,
+                     constants.lonmin,
+                     constants.lonmax,
+                     constants.latmin,
+                     constants.latmax,
+                     constants.dLongitude,
+                     constants.dLatitude)
+
+
+def interpolate_model_climatology(interpolationData, monthlyClimatology, field,
+                                  monthsValue):
+    """
+    Given a monthly climatology on the mpas grid, together with corresponding
+    interpolation weighting data, interpolates desired field over the desired
+    months to a the default comparison grid.
+
+    Parameters
+    ----------
+    interpolationData : a tuple returned by init_model_interpolation that
+        contains the information needed to interpolate from the MPAS mesh
+        to the comparison grid
+
+    monthlyClimatology : an xarray data set containing a monthly climatology
+
+    field : the name of a field in monthlyClimatology to be interpolated
+
+    monthsValue : a single month or an array of months to be averaged together
+        before interpolation
+
+    Returns
+    -------
+    modelOutput : a numpy array containing the field interpolated to the
+        default comparison grid
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    02/26/2017
+    """
+
+    d, inds, lonTarg, latTarg = interpolationData
+
+    nLon = lonTarg.shape[0]
+    nLat = lonTarg.shape[1]
+
+    modelOutput = np.zeros((nLon, nLat))
+
+    if isinstance(monthsValue, (int, long)):
+        modelData = monthlyClimatology.sel(month=monthsValue)[field].values
+    else:
+
+        modelData = (np.sum(
+            constants.daysInMonth[monthsValue-1] *
+            monthlyClimatology.sel(month=monthsValue)[field].values.T,
+            axis=1) /
+            np.sum(constants.daysInMonth[monthsValue-1]))
+
+    modelOutput = interp_fields(modelData, d, inds, lonTarg)
+
+    return modelOutput
+
+
+def interpolate_observation_climatology(interpolationData, dsObs,
+                                        obsFieldName, monthsValue):
+    """
+    Given monthly climatology from observations on a lat/lon grid, interpolates
+    the desired field over the desired months to a the default comparison grid.
+
+    Parameters
+    ----------
+    interpolationData : a tuple returned by init_observations_interpolation
+        that contains the information needed to interpolate from the
+        observation grid to the comparison grid
+
+    dsObs : an xarray data set containing a monthly climatology from
+        observations
+
+    obsFieldName : the name of a field in dsObs to be interpolated
+
+    monthsValue : a single month or an array of months to be averaged together
+        before interpolation
+
+    Returns
+    -------
+    observations : a numpy array containing the field interpolated to the
+        default comparison grid
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    02/26/2017
+    """
+
+    latData, lonData = np.meshgrid(dsObs.lat.values,
+                                   dsObs.lon.values)
+    latData = latData.flatten()
+    lonData = lonData.flatten()
+
+    daysarray = np.ones((12,
+                         dsObs[obsFieldName].values.shape[1],
+                         dsObs[obsFieldName].values.shape[2]))
+
+    for monthIndex, dval in enumerate(constants.daysInMonth):
+        daysarray[monthIndex, :, :] = dval
+        inds = np.where(np.isnan(
+                dsObs[obsFieldName][monthIndex, :, :].values))
+        daysarray[monthIndex, inds[0], inds[1]] = np.NaN
+
+    d, inds, lonTarg, latTarg = interpolationData
+
+    nLon = lonTarg.shape[0]
+    nLat = latTarg.shape[1]
+
+    observations = np.zeros((nLon, nLat))
+
+    # Interpolate and compute biases
+
+    if isinstance(monthsValue, (int, long)):
+        obsData = dsObs.sel(month=monthsValue)[obsFieldName].values
+    else:
+        obsData = \
+            (np.nansum(
+                    daysarray[monthsValue-1, :, :] *
+                    dsObs.sel(month=monthsValue)[obsFieldName].values,
+                    axis=0) /
+             np.nansum(daysarray[monthsValue-1, :, :], axis=0))
+
+    observations = interp_fields(obsData.flatten(), d, inds, lonTarg)
+
+    return observations
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/constants/constants.py
+++ b/mpas_analysis/shared/constants/constants.py
@@ -1,25 +1,28 @@
 import numpy as np
 
 """
-	Constants that are common to all ocean model vs observations analysis
+Constants that are common to all analysis tasks
 
-	Luke Van Roekel
-	10/21/2016
-
+Luke Van Roekel, Xylar Asay-Davis
+02/26/2017
 """
 
-#set parameters for interpolated grid
-dLongitude = 1.
-dLatitude = 1.
+# set parameters for interpolated grid
+dLongitude = 0.5
+dLatitude = 0.5
 lonmin = -180.
 lonmax = 180.
 latmin = -90.
 latmax = 90.
 
-monthdictionary={'Jan':1, 'Feb':2, 'Mar':3, 'Apr':4, 'May':5, 'Jun':6, 'Jul':7, 'Aug':8, 'Sep':9, 'Oct':10,
-                 'Nov':11, 'Dec':12, 'JFM':np.array([1,2,3]), 'AMJ':np.array([4,5,6]), 'JAS':np.array([7,8,9]),
-                 'OND':np.array([10,11,12]), 'ANN':np.arange(1,13)}
+monthDictionary = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
+                   'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11,
+                   'Dec': 12, 'JFM': np.array([1, 2, 3]),
+                   'AMJ': np.array([4, 5, 6]), 'JAS': np.array([7, 8, 9]),
+                   'OND': np.array([10, 11, 12]), 'ANN': np.arange(1, 13),
+                   'ON': np.array([10, 11]), 'FM': np.array([2, 3]),
+                   'DJF': np.array([12, 1, 2]), 'JJA': np.array([6, 7, 8])}
 
-dinmonth = np.array([31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31])
+daysInMonth = np.array([31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31])
 
-
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
This merge moves 5 blocks of code from `ocean_modelvsobs` into 5 functions in `shared/climatology/climatology.py`:
  * `compute_monthly_climatology`
 * `init_model_interpolation`
 * `init_observations_interpolation`
 * `interpolate_model_climatology`
 * `interpolate_observation_climatology`

The same code is now used to compute monthly and seasonal climatologies in `seaice_modelvsobs`.

This reorganization is also intended to make it easier to change the approach used for performing horizontal interpolation, which is not isolated to the shared climatology module.