### PR TITLE
Fix handling of bool in config parser getWithDefault

### DIFF
--- a/mpas_analysis/configuration/MpasAnalysisConfigParser.py
+++ b/mpas_analysis/configuration/MpasAnalysisConfigParser.py
@@ -5,7 +5,7 @@ the capabilities to get an option including a default value
 that are lists, tuples, dicts, etc (`getExpression(section, option)`).
 
 Author: Xylar Asay-Davis, Phillip J. Wolfram
-Last Modified: 01/31/2017
+Last Modified: 02/27/2017
 """
 
 import numbers
@@ -13,8 +13,10 @@ import ast
 import numpy as np
 from ConfigParser import ConfigParser
 
-npallow = dict(linspace=np.linspace, xrange=xrange, range=range, arange=np.arange,
-               pi=np.pi, Pi=np.pi, __builtins__=None)
+
+npallow = dict(linspace=np.linspace, xrange=xrange, range=range,
+               arange=np.arange, pi=np.pi, Pi=np.pi, __builtins__=None)
+
 
 class MpasAnalysisConfigParser(ConfigParser):
 
@@ -27,16 +29,16 @@ class MpasAnalysisConfigParser(ConfigParser):
         is present in the config file.
 
         Author: Xylar Asay-Davis
-        Last Modified: 12/03/2016
+        Last Modified: 02/27/2017
         """
         if self.has_section(section):
             if self.has_option(section, option):
-                if isinstance(default, numbers.Integral):
+                if isinstance(default, bool):
+                    return self.getboolean(section, option)
+                elif isinstance(default, numbers.Integral):
                     return self.getint(section, option)
                 elif isinstance(default, numbers.Real):
                     return self.getfloat(section, option)
-                elif isinstance(default, bool):
-                    return self.getboolean(section, option)
                 elif isinstance(default, (list, tuple, dict)):
                     return self.getExpression(section, option)
                 else:
@@ -46,7 +48,8 @@ class MpasAnalysisConfigParser(ConfigParser):
         self.set(section, option, str(default))
         return default
 
-    def getExpression(self, section, option, elementType=None, usenumpyfunc=False):
+    def getExpression(self, section, option, elementType=None,
+                      usenumpyfunc=False):
         """
         Get an option as an expression (typically a list, though tuples and
         dicts should also work).  `section` and `option` work as in `get(...)`.
@@ -58,8 +61,8 @@ class MpasAnalysisConfigParser(ConfigParser):
         useful for ensuring that all elements in a list of numbers are of type
         float, rather than int, when the distinction is important.
 
-        If `usenumpyfunc` is True, expression is evaluated within the context of
-        having selected numpy and / or np functionality available.
+        If `usenumpyfunc` is True, expression is evaluated within the context
+        of having selected numpy and / or np functionality available.
 
         Author: Xylar Asay-Davis, Phillip J. Wolfram
         Last Modified: 01/31/2017
@@ -70,11 +73,11 @@ class MpasAnalysisConfigParser(ConfigParser):
                     "'__' is not allowed in {} "\
                     "for `usenumpyfunc=True`".format(expressionString)
             sanitizedstr = expressionString.replace('np.', '')\
-                                           .replace('numpy.','')\
-                                           .replace('__','')
+                                           .replace('numpy.', '')\
+                                           .replace('__', '')
             result = eval(sanitizedstr, npallow)
         else:
-            result =  ast.literal_eval(expressionString)
+            result = ast.literal_eval(expressionString)
 
         if elementType is not None:
             if isinstance(result, (list, tuple)):

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -72,14 +72,42 @@ class TestMPASAnalysisConfigParser(TestCase):
         # tests numpy evaluation capability
         import numpy as np
         for testname in ['testNumpyarange' + str(ii) for ii in np.arange(3)]:
-            self.assertArrayEqual(self.config.getExpression('TestNumpy', testname, usenumpyfunc=True),
+            self.assertArrayEqual(self.config.getExpression('TestNumpy',
+                                                            testname,
+                                                            usenumpyfunc=True),
                                   np.arange(0, 1, 10))
         for testname in ['testNumpylinspace' + str(ii) for ii in np.arange(3)]:
-            self.assertArrayEqual(self.config.getExpression('TestNumpy', testname, usenumpyfunc=True),
+            self.assertArrayEqual(self.config.getExpression('TestNumpy',
+                                                            testname,
+                                                            usenumpyfunc=True),
                                   np.linspace(0, 1, 10))
-        for testNumpy in ['testNumpypi' + str(ii) for ii in np.arange(3)] + ['testNumpyPi']:
-            self.assertEqual(self.config.getExpression('TestNumpy', testNumpy, usenumpyfunc=True), np.pi)
-        with self.assertRaisesRegexp(AssertionError, "'__' is not allowed in .* for `usenumpyfunc=True`"):
-            self.config.getExpression('TestNumpy', 'testBadStr', usenumpyfunc=True),
+        for testNumpy in ['testNumpypi' + str(ii) for ii in np.arange(3)] + \
+                ['testNumpyPi']:
+            self.assertEqual(self.config.getExpression('TestNumpy', testNumpy,
+                                                       usenumpyfunc=True),
+                             np.pi)
+        with self.assertRaisesRegexp(
+                AssertionError,
+                "'__' is not allowed in .* for `usenumpyfunc=True`"):
+            self.config.getExpression('TestNumpy', 'testBadStr',
+                                      usenumpyfunc=True),
+
+    def test_get_with_default(self):
+        self.setup_config()
+
+        def check_get_with_default(name, value, dtype):
+            # test an options that doesn't exist using getWithDefault
+            var = self.config.getWithDefault('sst_modelvsobs', name, value)
+            assert isinstance(var, dtype)
+            self.assertEqual(var, value)
+
+        # test several types with getWithDefault
+        check_get_with_default(name='aBool', value=True, dtype=bool)
+        check_get_with_default(name='anInt', value=1, dtype=(int, long))
+        check_get_with_default(name='aFloat', value=1.0, dtype=float)
+        check_get_with_default(name='aList', value=[1, 2, 3], dtype=list)
+        check_get_with_default(name='aTuple', value=(1, 2, 3), dtype=tuple)
+        check_get_with_default(name='aDict', value={'blah': 1}, dtype=dict)
+        check_get_with_default(name='aStr', value='blah', dtype=str)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
Since data type bool is also part of `numbers.Integral`, `MpasAnalysisConfigParser.getWithDefault` was previously trying to treat bool types as integers.  This fix puts the check for bool type before that of integer types so bools will get handled correctly.

Also, this merge performs a small amount of PEP8 cleanup of `MpasAnalysisConfigParser`.

New unit tests have been added to ensure that `getWithDefault` behaves as expected.