### PR TITLE
Fix bug in sea ice analysis with oceanStreams

### DIFF
--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -63,9 +63,9 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
     except IOError:
         # try the ocean stream instead
         oceanStreamsFileName = config.get('input', 'oceanStreamsFileName')
-        oceanStreams = StreamsFile(oceanStreamsFileName, streamsdir=inDirectory)
+        oceanStreams = StreamsFile(oceanStreamsFileName,
+                                   streamsdir=inDirectory)
         simulationStartTime = get_simulation_start_time(oceanStreams)
-        oceanStreams.close()
     # get a list of timeSeriesStatsMonthly output files from the streams file,
     # reading only those that are between the start and end dates
     startDate = config.get('climatology', 'startDate')
@@ -78,8 +78,16 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
     try:
         restartFileName = streams.readpath('restart')[0]
     except ValueError:
-        raise IOError('No MPAS-Sea Ice restart file found: need at least one '
-                      'restart file for modelvsobs calculation')
+        # get an ocean restart file, since no sea-ice restart exists
+        try:
+            oceanStreamsFileName = config.get('input', 'oceanStreamsFileName')
+            oceanStreams = StreamsFile(oceanStreamsFileName,
+                                       streamsdir=inDirectory)
+            restartFileName = oceanStreams.readpath('restart')[0]
+        except ValueError:
+            raise IOError('No MPAS-O or MPAS-Seaice restart file found: need '
+                          'at least one restart file for seaice_timeseries '
+                          'calculation')
 
     # Load data
     print "  Load sea-ice data..."

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -46,9 +46,9 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
     except IOError:
         # try the ocean stream instead
         oceanStreamsFileName = config.get('input', 'oceanStreamsFileName')
-        oceanStreams = StreamsFile(oceanStreamsFileName, streamsdir=inDirectory)
+        oceanStreams = StreamsFile(oceanStreamsFileName,
+                                   streamsdir=inDirectory)
         simulationStartTime = get_simulation_start_time(oceanStreams)
-        oceanStreams.close()
 
     # get a list of timeSeriesStatsMonthly output files from the streams file,
     # reading only those that are between the start and end dates
@@ -101,9 +101,9 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
         # get an ocean restart file, since no sea-ice restart exists
         try:
             oceanStreamsFileName = config.get('input', 'oceanStreamsFileName')
-            oceanStreams = StreamsFile(oceanStreamsFileName, streamsdir=inDirectory)
+            oceanStreams = StreamsFile(oceanStreamsFileName,
+                                       streamsdir=inDirectory)
             restartFile = oceanStreams.readpath('restart')[0]
-            oceanStreams.close()
         except ValueError:
             raise IOError('No MPAS-O or MPAS-Seaice restart file found: need '
                           'at least one restart file for seaice_timeseries '


### PR DESCRIPTION
`StreamsFile` has no `close` method, so calls have been removed.

`seaice_modelvsobs` now resorts to an ocean restart file if no sea-ice restart file is available.  This is similar to the behavior of `seaice_timeseries`.

Fixes PEP8 formatting in sea ice analysis.