### PR TITLE
Add support for running tasks in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,13 @@ This analysis repository presumes that the following python packages are availab
  * lxml
  * nco >= 4.5.4
  * pyproj
- * fasteners
 
 You can easily install them via the conda command:
 
 ```
 conda config --add channels conda-forge
 conda install numpy scipy matplotlib netCDF4 xarray dask bottleneck basemap \
-    lxml nco pyproj fasteners
+    lxml nco pyproj
 ```
 
 ## Running the analysis

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ This analysis repository presumes that the following python packages are availab
  * scipy
  * matplotlib
  * netCDF4
- * xarray ≥ 0.9.1
+ * xarray >= 0.9.1
  * dask
  * bottleneck
  * basemap
  * lxml
- * nco
+ * nco >= 4.5.4
  * pyproj
  * fasteners
 
@@ -56,6 +56,26 @@ conda install numpy scipy matplotlib netCDF4 xarray dask bottleneck basemap \
      `generate` option under `[output]` in your config file or use the
      `--generate` flag on the command line.  See the comments in
      `config.default` for more details on this option.
+
+
+## Running in parallel
+  1. Copy the appropriate job script file from `configs/<machine_name>` to
+     the same directory as `run_analysis.py` (or another directory if preferred).
+     The default script, `configs/job_script.default.bash`, is appropriate for
+     a laptop or desktop computer with multiple cores.
+  2. Modify the number of nodes (equal to the number of parallel tasks), the
+     run name and optionally the output directory and the path to the config
+     file for the run (default: `./configs/<machine_name>/config.<run_name>`)
+     Note: in `job_script.default.bash`, the number of parallel tasks is set
+     manually, since there are no nodes.
+  3. Note: the number of parallel tasks can be anything between 1 and the number
+     of analysis tasks to be performed.  If there are more tasks than parallel
+     tasks, later tasks will simply wait until earlier tasks have finished.
+  4. Submit the job using the modified job script
+
+If a job script for your machine is not available, try modifying the default
+job script in `configs/job_script.default.bash` or one of the job scripts for
+another machine to fit your needs.
 
 
 ## Instructions for creating a new analysis task

--- a/README.md
+++ b/README.md
@@ -20,12 +20,14 @@ This analysis repository presumes that the following python packages are availab
  * lxml
  * nco
  * pyproj
+ * fasteners
 
 You can easily install them via the conda command:
 
 ```
 conda config --add channels conda-forge
-conda install numpy scipy matplotlib netCDF4 xarray dask bottleneck basemap lxml nco pyproj
+conda install numpy scipy matplotlib netCDF4 xarray dask bottleneck basemap \
+    lxml nco pyproj fasteners
 ```
 
 ## Running the analysis

--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -15,3 +15,4 @@ dependencies:
   - hdf4
   - nco
   - pyproj
+  - fasteners

--- a/ci/requirements-py27.yml
+++ b/ci/requirements-py27.yml
@@ -15,4 +15,3 @@ dependencies:
   - hdf4
   - nco
   - pyproj
-  - fasteners

--- a/config.default
+++ b/config.default
@@ -33,6 +33,16 @@ referenceRunName = None
 # MPAS-Analysis)
 preprocessedReferenceRunName = None
 
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 1
+
+# Prefix on the commnd line before a parallel task (e.g. 'srun -n 1 python')
+# Default is no prefix (run_analysis.py is executed directly)
+commandPrefix = 
+
 [input]
 ## options related to reading in the results to be analyzed
 

--- a/config.default
+++ b/config.default
@@ -154,7 +154,6 @@ comparisonLonResolution = 0.5
 # mpasMappingFile = /path/to/mapping/file
 
 # overwrite files when building climatologies?
-overwriteMapping = False
 overwriteMpasClimatology = False
 
 # interpolation order for model and observation results. Likely values are

--- a/configs/README.md
+++ b/configs/README.md
@@ -7,3 +7,6 @@ MPAS-Analysis (where `run_analysis.py` is located) before modifying them
 (e.g. setting the output `baseDirectory`) and using them to run the
 analysis.
 
+To run tasks in parallel, instead copy and modify the machine-specific job 
+script or the default job script.
+

--- a/configs/edison/job_script.edison.bash
+++ b/configs/edison/job_script.edison.bash
@@ -1,0 +1,68 @@
+#!/bin/bash -l
+
+# comment out if using debug queue
+#SBATCH --partition=regular
+# comment in to get premium queue
+##SBATCH --qos=premium
+# comment in to get the debug queue
+##SBATCH --partition=debug
+# change number of nodes to change the number of parallel tasks
+# (anything between 1 and the total number of tasks to run)
+#SBATCH --nodes=10
+#SBATCH --time=1:00:00
+#SBATCH --account=acme
+#SBATCH --job-name=mpas_analysis
+#SBATCH --output=mpas_analysis.o%j
+#SBATCH --error=mpas_analysis.e%j
+#SBATCH -L cscratch1,SCRATCH,project
+
+cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
+
+export OMP_NUM_THREADS=1
+
+module unload python python/base
+module use /global/project/projectdirs/acme/software/modulefiles/all
+module load python/anaconda-2.7-acme
+
+# MPAS/ACME job to be analyzed, including paths to simulation data and
+# observations. Change this name and path as needed
+run_config_file="config.run_name_here"
+# prefix to run a serial job on a single node on edison
+command_prefix="srun -N 1 -n 1"
+# change this if not submitting this script from the directory
+# containing run_analysis.py
+mpas_analysis_dir="."
+# one parallel task per node by default
+parallel_task_count=$SLURM_JOB_NUM_NODES
+
+if [ ! -f $run_config_file ]; then
+    echo "File $run_config_file not found!"
+    exit 1
+fi
+if [ ! -f $mpas_analysis_dir/run_analysis.py ]; then
+    echo "run_analysis.py not found in $mpas_analysis_dir!"
+    exit 1
+fi
+
+
+# This is a config file generated just for this job with the output directory,
+# command prefix and parallel task count from above.
+job_config_file=config.output.$SLURM_JOB_ID
+
+# write out the config file specific to this job
+cat <<EOF > $job_config_file
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = $parallel_task_count
+
+# Prefix on the commnd line before a parallel task (e.g. 'srun -n 1 python')
+# Default is no prefix (run_analysis.py is executed directly)
+commandPrefix = $command_prefix
+
+EOF
+
+$mpas_analysis_dir/run_analysis.py $run_config_file \
+    $job_config_file
+

--- a/configs/job_script.default.bash
+++ b/configs/job_script.default.bash
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# MPAS/ACME job to be analyzed, including paths to simulation data and
+# observations. Change this name and path as needed
+run_config_file="config.run_name_here"
+# no prefix is needed for jobs running on a laptop or desktop computer
+command_prefix=""
+# change this if not submitting this script from the directory
+# containing run_analysis.py
+mpas_analysis_dir="."
+# the number of parallel tasks (anything between 1 and the total number
+# of tasks to run)
+parallel_task_count=8
+
+if [ ! -f $run_config_file ]; then
+    echo "File $run_config_file not found!"
+    exit 1
+fi
+if [ ! -f $mpas_analysis_dir/run_analysis.py ]; then
+    echo "run_analysis.py not found in $mpas_analysis_dir!"
+    exit 1
+fi
+
+# This is a config file generated just for this job with the output directory,
+# command prefix and parallel task count from above.
+job_config_file=config.output.$RANDOM
+
+# write out the config file specific to this job
+cat <<EOF > $job_config_file
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = $parallel_task_count
+
+# Prefix on the commnd line before a parallel task (e.g. 'srun -n 1 python')
+# Default is no prefix (run_analysis.py is executed directly)
+commandPrefix = $command_prefix
+
+EOF
+
+$mpas_analysis_dir/run_analysis.py $run_config_file \
+    $job_config_file
+
+# commend this out if you want to keep the config file, e.g. for debugging
+rm $job_config_file
+

--- a/configs/lanl/config.20170120.beta0.GMPAS-QU240.wolf
+++ b/configs/lanl/config.20170120.beta0.GMPAS-QU240.wolf
@@ -81,7 +81,7 @@ mpasMappingFile = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/m
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
 startYear = 1
-endYear = 3
+endYear = 2
 
 [index]
 ## options related to producing nino index.
@@ -131,4 +131,4 @@ polarPlot = False
 ## circulation (MOC)
 
 # Mask file for ocean basin regional computation
-regionMaskFiles = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/region_masks/QU240v1_SingleRegionAtlanticWTransportTransects_masks.nc
+regionMaskFiles = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/region_masks/oQU240v1_Atlantic_region_and_southern_transect.nc

--- a/configs/lanl/job_script.lanl.bash
+++ b/configs/lanl/job_script.lanl.bash
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# change number of nodes to change the number of parallel tasks
+# (anything between 1 and the total number of tasks to run)
+#SBATCH --nodes=10
+#SBATCH --time=1:00:00
+#SBATCH --account=climateacme
+#SBATCH --job-name=mpas_analysis
+#SBATCH --output=mpas_analysis.o%j
+#SBATCH --error=mpas_analysis.e%j
+#SBATCH --qos=interactive
+
+cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
+
+module unload python
+module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all/
+module load python/anaconda-2.7-climate
+
+# MPAS/ACME job to be analyzed, including paths to simulation data and
+# observations. Change this name and path as needed
+run_config_file="config.run_name_here"
+# prefix to run a serial job on a single node on edison
+command_prefix=""
+# change this if not submitting this script from the directory
+# containing run_analysis.py
+mpas_analysis_dir="."
+# one parallel task per node by default
+parallel_task_count=$SLURM_JOB_NUM_NODES
+
+if [ ! -f $run_config_file ]; then
+    echo "File $run_config_file not found!"
+    exit 1
+fi
+if [ ! -f $mpas_analysis_dir/run_analysis.py ]; then
+    echo "run_analysis.py not found in $mpas_analysis_dir!"
+    exit 1
+fi
+
+
+# This is a config file generated just for this job with the output directory,
+# command prefix and parallel task count from above.
+job_config_file=config.output.$SLURM_JOB_ID
+
+# write out the config file specific to this job
+cat <<EOF > $job_config_file
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = $parallel_task_count
+
+# Prefix on the commnd line before a parallel task (e.g. 'srun -n 1 python')
+# Default is no prefix (run_analysis.py is executed directly)
+commandPrefix = $command_prefix
+
+EOF
+
+$mpas_analysis_dir/run_analysis.py $run_config_file \
+    $job_config_file
+

--- a/configs/olcf/job_script.olcf.bash
+++ b/configs/olcf/job_script.olcf.bash
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# comment out if using debug queue
+#PBS -q batch
+# comment in to get the debug queue (only available on Titan)
+##PBS -q debug
+# change number of nodes to change the number of parallel tasks
+# (anything between 1 and the total number of tasks to run)
+#PBS -l nodes=10
+#PBS -l walltime=1:00:00
+#PBS -A cli115
+#PBS -N mpas_analysis
+#PBS -o mpas_analysis.o$PBS_JOBID
+#PBS -e mpas_analysis.e$PBS_JOBID
+
+cd $PBS_O_WORKDIR
+
+module unload python
+module use /ccs/proj/cli115/pwolfram/modulefiles/all
+module load python/anaconda-2.7-climate
+
+# MPAS/ACME job to be analyzed, including paths to simulation data and
+# observations. Change this name and path as needed
+run_config_file="config.run_name_here"
+# prefix to run a serial job on a single node on edison
+command_prefix="aprun -b -N 1 -n 1"
+# change this if not submitting this script from the directory
+# containing run_analysis.py
+mpas_analysis_dir="."
+# one parallel task per node by default
+parallel_task_count=$PBS_NUM_NODES
+
+if [ ! -f $run_config_file ]; then
+    echo "File $run_config_file not found!"
+    exit 1
+fi
+if [ ! -f $mpas_analysis_dir/run_analysis.py ]; then
+    echo "run_analysis.py not found in $mpas_analysis_dir!"
+    exit 1
+fi
+
+
+# This is a config file generated just for this job with the output directory,
+# command prefix and parallel task count from above.
+job_config_file=config.output.$PBS_JOBID
+
+# write out the config file specific to this job
+cat <<EOF > $job_config_file
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = $parallel_task_count
+
+# Prefix on the commnd line before a parallel task (e.g. 'srun -n 1 python')
+# Default is no prefix (run_analysis.py is executed directly)
+commandPrefix = $command_prefix
+
+EOF
+
+$mpas_analysis_dir/run_analysis.py $run_config_file \
+    $job_config_file
+

--- a/mpas_analysis/ocean/climatology_map.py
+++ b/mpas_analysis/ocean/climatology_map.py
@@ -146,12 +146,19 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
         mpasDescriptor = MpasMeshDescriptor(
             restartFileName, meshName=config.get('input', 'mpasMeshName'))
 
+        parallel = self.config.getint('execute', 'parallelTaskCount') > 1
+        if parallel:
+            # avoid writing the same mapping file from multiple processes
+            mappingFilePrefix = 'map_{}'.format(self.taskName)
+        else:
+            mappingFilePrefix = 'map'
+
         mpasRemapper = get_remapper(
             config=config, sourceDescriptor=mpasDescriptor,
             comparisonDescriptor=comparisonDescriptor,
             mappingFileSection='climatology',
             mappingFileOption='mpasMappingFile',
-            mappingFilePrefix='map',
+            mappingFilePrefix=mappingFilePrefix,
             method=config.get('climatology', 'mpasInterpolationMethod'))
 
         obsDescriptor = LatLonGridDescriptor()

--- a/mpas_analysis/sea_ice/climatology_map.py
+++ b/mpas_analysis/sea_ice/climatology_map.py
@@ -127,12 +127,19 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
 
         comparisonDescriptor = get_lat_lon_comparison_descriptor(self.config)
 
+        parallel = self.config.getint('execute', 'parallelTaskCount') > 1
+        if parallel:
+            # avoid writing the same mapping file from multiple processes
+            mappingFilePrefix = 'map_{}'.format(self.taskName)
+        else:
+            mappingFilePrefix = 'map'
+
         self.mpasRemapper = get_remapper(
             config=self.config, sourceDescriptor=mpasDescriptor,
             comparisonDescriptor=comparisonDescriptor,
             mappingFileSection='climatology',
             mappingFileOption='mpasMappingFile',
-            mappingFilePrefix='map',
+            mappingFilePrefix=mappingFilePrefix,
             method=self.config.get('climatology', 'mpasInterpolationMethod'))
 
         self._compute_and_plot_concentration()

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -227,6 +227,15 @@ def run_analysis(config, analyses):  # {{{
             print "ERROR: analysis module {} failed during run".format(
                 analysisTask.taskName)
 
+        # write out a copy of the configuration to document the run
+        logsDirectory = build_config_full_path(config, 'output',
+                                               'logsSubdirectory')
+        configFileName = '{}/config.{}'.format(logsDirectory,
+                                               analysisTask.taskName)
+        configFile = open(configFileName, 'w')
+        config.write(configFile)
+        configFile.close()
+
     if config.getboolean('plot', 'displayToScreen'):
         import matplotlib.pyplot as plt
         plt.show()

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -16,6 +16,7 @@ import traceback
 import sys
 import warnings
 import subprocess
+import time
 
 from mpas_analysis.configuration.MpasAnalysisConfigParser \
     import MpasAnalysisConfigParser
@@ -215,8 +216,16 @@ def run_analysis(config, analyses):  # {{{
     # run each analysis task
     lastException = None
     for analysisTask in analyses:
+        # write out a copy of the configuration to document the run
+        logsDirectory = build_config_full_path(config, 'output',
+                                               'logsSubdirectory')
         try:
+            startTime = time.clock()
             analysisTask.run()
+            runDuration = time.clock() - startTime
+            m, s = divmod(runDuration, 60)
+            h, m = divmod(int(m), 60)
+            print 'Execution time: {}:{:02d}:{:05.2f}'.format(h, m, s)
         except (Exception, BaseException) as e:
             if isinstance(e, KeyboardInterrupt):
                 raise e
@@ -225,9 +234,6 @@ def run_analysis(config, analyses):  # {{{
                 analysisTask.taskName)
             lastException = e
 
-        # write out a copy of the configuration to document the run
-        logsDirectory = build_config_full_path(config, 'output',
-                                               'logsSubdirectory')
         configFileName = '{}/configs/config.{}'.format(logsDirectory,
                                                        analysisTask.taskName)
         configFile = open(configFileName, 'w')

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -228,8 +228,8 @@ def run_analysis(config, analyses):  # {{{
         # write out a copy of the configuration to document the run
         logsDirectory = build_config_full_path(config, 'output',
                                                'logsSubdirectory')
-        configFileName = '{}/config.{}'.format(logsDirectory,
-                                               analysisTask.taskName)
+        configFileName = '{}/configs/config.{}'.format(logsDirectory,
+                                                       analysisTask.taskName)
         configFile = open(configFileName, 'w')
         config.write(configFile)
         configFile.close()
@@ -278,6 +278,7 @@ if __name__ == "__main__":
     logsDirectory = build_config_full_path(config, 'output',
                                            'logsSubdirectory')
     make_directories(logsDirectory)
+    make_directories('{}/configs/'.format(logsDirectory))
 
     analyses = build_analysis_list(config)
 


### PR DESCRIPTION
Parallel task are controlled with the `parallelTaskCount` and `commandPrefix` options in the new `execute` section of the config file.  By default `parallelTaskCount = 1` (serial execution) and `commandPrefix=` (i.e. no prefix). `commndPrefix` can be used to add a prefix such as `srun -n 1` or a path to python if needed.

If there is more than one task to run and `parallelTaskCount > 1`, several tasks run in parallel, and their output is stored in log files instead of being output to stdout/stderr.

The configuration after each task is complete (whether run serially or in parallel) is written out to a config file named `config.<taskName>` in the log folder.  This documents the configuration (though not in a terribly user-friendly way, since config option names are case insensitive and comments are lost) used and also could be used to re-run the analysis with the identical configuration. 
