### PR TITLE
Fix colorbars for ocean climatology bias maps

### DIFF
--- a/config.default
+++ b/config.default
@@ -347,17 +347,11 @@ resultColormapIndices = [0, 40, 80, 110, 140, 170, 200, 230, 255]
 resultContourValues = [-2, 0, 2, 6, 10, 16, 22, 26, 28, 32]
 
 # colormap for differences
-differenceColormap = coolwarm
+differenceColormap = RdBu_r
 # indices into differenceColormap for contour color
-differenceColormapIndices = [0, 40, 80, 120, 140, 170, 210, 255]
+differenceColormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
 differenceContourValues = [-5, -3, -2, -1, 0, 1, 2, 3, 5]
-
-# alternative colormap/index suggestions
-#resultColormap = viridis
-#differenceColormap = RdBu_r
-#differenceColormapIndices = [0, 40, 80, 127, 170, 210, 255]
-#differenceContourValues = [-3, -2, -1, -0.5, 0.5, 1, 2, 3]
 
 # Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 comparisonTimes =  ['JFM', 'JAS', 'ANN']
@@ -374,11 +368,11 @@ resultColormapIndices = [0, 40, 80, 110, 140, 170, 200, 230, 255]
 resultContourValues = [28, 29, 30, 31, 32, 33, 34, 35, 36, 38]
 
 # colormap for differences
-differenceColormap = coolwarm
+differenceColormap = RdBu_r
 # indices into differenceColormap for contour color
-differenceColormapIndices = [0, 40, 80, 120, 140, 170, 210, 255]
+differenceColormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-differenceContourValues = [-3, -2, -1, -0.5, 0.5, 1, 2, 3]
+differenceContourValues = [-3, -2, -1, -0.5, 0, 0.5, 1, 2, 3]
 
 # Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 comparisonTimes =  ['JFM', 'JAS', 'ANN']
@@ -394,14 +388,12 @@ resultColormapIndices = [0, 40, 80, 110, 140, 170, 200, 230, 255]
 # colormap levels/values for contour boundaries
 resultContourValues = [0, 20, 40, 60, 80, 100, 150, 200, 400, 800]
 
-###### Xylar's note: I think something is off here.  I think there should
-###### be one more contour value than there are indices but there are 2 in MLD
 # colormap for differences
 differenceColormap = RdBu_r
 # indices into differenceColormap for contour color
-differenceColormapIndices = [0, 40, 80, 120, 140, 170, 210, 255]
+differenceColormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-differenceContourValues = [-175, -125, -75, -25, -10, 10, 25, 75, 125, 175]
+differenceContourValues = [-150, -80, -30, -10, 0, 10, 30, 80, 150]
 
 # Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct, Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 comparisonTimes =  ['JFM', 'JAS', 'ANN']

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -184,8 +184,6 @@ def plot_polar_comparison(
     m.drawmeridians(np.arange(-180.,181.,20.),labels=[True,True,True,True])
     cs = m.contourf(x,y,modelArray,cmap=cmapModelObs,norm=normModelObs,spacing='uniform',levels=clevsModelObs)
     cbar = m.colorbar(cs,location='right',pad="15%",spacing='uniform',ticks=clevsModelObs,boundaries=clevsModelObs)
-    #cbar = m.colorbar(cs,location='right',pad="15%",spacing='uniform',extendfrac='auto',
-    #                  extendrect='True',ticks=clevsModelObs, boundaries=clevsModelObs)
     cbar.set_label(cbarlabel)
 
     plt.subplot(3,1,2)
@@ -196,8 +194,6 @@ def plot_polar_comparison(
     m.drawmeridians(np.arange(-180.,181.,20.),labels=[True,True,True,True])
     cs = m.contourf(x,y,obsArray,cmap=cmapModelObs,norm=normModelObs,spacing='uniform',levels=clevsModelObs)
     cbar = m.colorbar(cs,location='right',pad="15%",spacing='uniform',ticks=clevsModelObs,boundaries=clevsModelObs)
-    #cbar = m.colorbar(cs,location='right',pad="15%",spacing='uniform',extendfrac='auto',
-    #                  extendrect='True',ticks=clevsModelObs, boundaries=clevsModelObs)
     cbar.set_label(cbarlabel)
 
     plt.subplot(3,1,3)
@@ -208,8 +204,6 @@ def plot_polar_comparison(
     m.drawmeridians(np.arange(-180.,181.,20.),labels=[True,True,True,True])
     cs = m.contourf(x,y,diffArray,cmap=cmapDiff,norm=normDiff,spacing='uniform',levels=clevsDiff)
     cbar = m.colorbar(cs,location='right',pad="15%",spacing='uniform',ticks=clevsDiff,boundaries=clevsModelObs)
-    #cbar = m.colorbar(cs,location='right',pad="15%",spacing='uniform',extendfrac='auto',
-    #                  extendrect='True',ticks=clevsDiff, boundaries=clevsDiff)
     cbar.set_label(cbarlabel)
 
     if (fileout is not None):
@@ -278,7 +272,7 @@ def plot_global_comparison(
 
     Author: Xylar Asay-Davis
 
-    Last Modified: 02/02/2017
+    Last Modified: 03/09/2017
     """
     # set up figure
     fig = plt.figure(figsize=figsize, dpi=dpi)
@@ -292,7 +286,6 @@ def plot_global_comparison(
     axis_font = {'size':config.get('plot', 'axisFontSize')}
 
     m = Basemap(projection='cyl',llcrnrlat=-85,urcrnrlat=86,llcrnrlon=-180,urcrnrlon=181,resolution='l')
-    #m = Basemap(projection='robin',lon_0=200,resolution='l') # this doesn't work because lons are -180 to 180..
     x, y = m(Lons, Lats) # compute map proj coordinates
 
     normModelObs = cols.BoundaryNorm(clevsModelObs, cmapModelObs.N)
@@ -306,8 +299,6 @@ def plot_global_comparison(
     m.drawmeridians(np.arange(-180.,180.,60.),labels=[False,False,False,True])
     cs = m.contourf(x,y,modelArray,cmap=cmapModelObs,norm=normModelObs,spacing='uniform',levels=clevsModelObs,extend='both')
     cbar = m.colorbar(cs,location='right',pad="5%",spacing='uniform',ticks=clevsModelObs,boundaries=clevsModelObs)
-    #cbar = m.colorbar(cs,location='right',pad="5%",spacing='uniform',extendfrac='auto',
-    #                  extendrect='True',ticks=clevsModelObs, boundaries=clevsModelObs)
     cbar.set_label(cbarlabel)
 
     plt.subplot(3,1,2)
@@ -318,8 +309,6 @@ def plot_global_comparison(
     m.drawmeridians(np.arange(-180.,180.,40.),labels=[False,False,False,True])
     cs = m.contourf(x,y,obsArray,cmap=cmapModelObs,norm=normModelObs,spacing='uniform',levels=clevsModelObs,extend='both')
     cbar = m.colorbar(cs,location='right',pad="5%",spacing='uniform',ticks=clevsModelObs,boundaries=clevsModelObs)
-    #cbar = m.colorbar(cs,location='right',pad="5%",spacing='uniform',extendfrac='auto',
-    #                  extendrect='True',ticks=clevsModelObs, boundaries=clevsModelObs)
     cbar.set_label(cbarlabel)
 
     plt.subplot(3,1,3)
@@ -329,11 +318,7 @@ def plot_global_comparison(
     m.drawparallels(np.arange(-80.,80.,20.),labels=[True,False,False,False])
     m.drawmeridians(np.arange(-180.,180.,40.),labels=[False,False,False,True])
     cs = m.contourf(x,y,diffArray,cmap=cmapDiff,norm=normDiff,spacing='uniform',levels=clevsDiff,extend='both')
-    cbar = m.colorbar(cs,location='right',pad="5%",spacing='uniform',ticks=clevsDiff,boundaries=clevsModelObs)
-    #cbar = m.colorbar(cs,location='right',pad="5%",spacing='uniform',extendfrac='auto',
-    #                  extendrect='True',ticks=clevsDiff, boundaries=clevsDiff)
-    cs.cmap.set_over((1., 1., 1.))
-    cs.cmap.set_under((0., 0., 0.))
+    cbar = m.colorbar(cs,location='right',pad="5%",spacing='uniform',ticks=clevsDiff,boundaries=clevsDiff)
     cbar.set_label(cbarlabel)
 
     if (fileout is not None):


### PR DESCRIPTION
The over/under arrows now have a different color if additional indices into the color map are provided for these values.

A utility function has been created in ocean_modelvsobs for making the color maps (including under/over values).

A small bug has been fixed in plotting, and some old, commented-out code has been removed.

Previously, the under and over on the bias map were set to black and white respectively.  Now, the behavior is that the under and over for model, observations and bias mpas take the first and last colors in the color map.  If a sufficient number of indices into the colorbar are provided (the number of contour values + 1), the under and over have unique colors.  If fewer colors are provided (usually the number of contour values - 1), the under and over have the same color as the lowest and highest contours, respectively.

Also, some bias maps were not including zero as one of the contour values.  This seems to be a mistake, since values between, say, -10 and 10 were light blue, visually suggesting they were negative.  Now, the default contour values for all bias maps include 0 as the middle value. 