### PR TITLE
Fix bounds of results from replicate_cycle

### DIFF
--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -416,4 +416,9 @@ def replicate_cycle(ds, dsToReplicate, calendar):
                                                  calendar=calendar))
         dsShift = xr.concat([dsShift, dsNew], dim='Time')
 
+    # clip dsShift to the range of ds
+    dsStartTime = dsShift.Time.sel(Time=ds.Time.min(), method='nearest').values
+    dsEndTime = dsShift.Time.sel(Time=ds.Time.max(), method='nearest').values
+    dsShift = dsShift.sel(Time=slice(dsStartTime, dsEndTime))
+
     return dsShift


### PR DESCRIPTION
Fixes a bug where replicate_cycle in seaice_timeseries was allowing extra copies of the replicated data set to extend as much as a year beyond the end of the data set it is meant to be compared with.  Now, the replicated data set is clipped to the time values that are closest to the beginning and end of the target data set.