### PR TITLE
Adds capability for NINO34 index and spectra plots

### DIFF
--- a/config.default
+++ b/config.default
@@ -132,6 +132,16 @@ mpasInterpolationMethod = bilinear
 startYear = 1
 endYear = 9999
 
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1 
+endYear = 9999
+
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
 
@@ -278,15 +288,13 @@ regionIndicesToPlot = [6]
 # window)
 movingAveragePoints = 12
 
-[timeSeriesNino34]
+[indexNino34]
 ## options related to plotting time series of the El Nino 3.4 index
 
-## compare to output from another model run?
-#compareWithModel = True
-# compare to observations?
-compareWithObservations = True
-# list of region indices to plot from the region list in [regions] below
-regionIndex = 5
+# Specified region for the Nino Index, 5 = Nino34, 3 = Nino3, 4 = Nino4
+# The indexNino34 routine only accepts one value at a time, 
+# regionIndicesToPlot should be an integer
+regionIndicesToPlot = 5
 
 [timeSeriesMHT]
 ## options related to plotting time series of meridional heat transport (MHT)

--- a/config.default
+++ b/config.default
@@ -21,7 +21,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = runName
+mainRunName = JwolfeTest
 # referenceRunName is the name of a reference run to compare against (or None
 # to turn off comparison with a reference, e.g. if no reference case is
 # available)
@@ -37,7 +37,7 @@ preprocessedReferenceRunName = None
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /dir/to/model/output
+baseDirectory = /Volumes/HDD1/Jwolfe_new_case
 # names of namelist and streams files.  If not in baseDirectory, give full path
 oceanNamelistFileName = mpas-o_in
 oceanStreamsFileName = streams.ocean
@@ -52,7 +52,7 @@ mpasMeshName = mesh
 ## etc.
 
 # directory where analysis should be written
-baseDirectory = /dir/to/analysis/output
+baseDirectory = /Users/lvanroekel/NINOTest
 
 # subdirectories within baseDirectory for analysis output
 scratchSubdirectory = scratch
@@ -82,7 +82,7 @@ timeSeriesSubdirectory = timeseries
 # option:
 #    ./run_analysis.py config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
+generate = ['timeSeriesNino34']
 
 # alternative examples that would perform all analysis except
 #   'timeSeriesOHC'
@@ -129,8 +129,8 @@ mpasInterpolationMethod = bilinear
 # start and end years for timeseries analysis. Using out-of-bounds values
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
-startYear = 1
-endYear = 9999
+startYear = 9 
+endYear = 10 
 
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
@@ -286,11 +286,11 @@ movingAveragePoints = 12
 # compare to observations?
 compareWithObservations = True
 # list of region indices to plot from the region list in [regions] below
-regionIndicesToPlot = [6]
+regionIndex = 5
 # Number of points over which to compute moving average (e.g., for monthly
 # output, movingAveragePoints=12 corresponds to a 12-month moving average
 # window)
-movingAveragePoints = 12
+movingAveragePoints = 5
 
 [timeSeriesMHT]
 ## options related to plotting time series of meridional heat transport (MHT)

--- a/config.default
+++ b/config.default
@@ -21,7 +21,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = JwolfeTest
+mainRunName = runName
 # referenceRunName is the name of a reference run to compare against (or None
 # to turn off comparison with a reference, e.g. if no reference case is
 # available)
@@ -37,7 +37,7 @@ preprocessedReferenceRunName = None
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /Volumes/HDD1/Jwolfe_new_case
+baseDirectory = /dir/to/model/output
 # names of namelist and streams files.  If not in baseDirectory, give full path
 oceanNamelistFileName = mpas-o_in
 oceanStreamsFileName = streams.ocean
@@ -52,7 +52,7 @@ mpasMeshName = mesh
 ## etc.
 
 # directory where analysis should be written
-baseDirectory = /Users/lvanroekel/NINOTest
+baseDirectory = /dir/to/analysis/output
 
 # subdirectories within baseDirectory for analysis output
 scratchSubdirectory = scratch
@@ -82,7 +82,7 @@ timeSeriesSubdirectory = timeseries
 # option:
 #    ./run_analysis.py config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['timeSeriesNino34']
+generate = ['all']
 
 # alternative examples that would perform all analysis except
 #   'timeSeriesOHC'
@@ -129,8 +129,8 @@ mpasInterpolationMethod = bilinear
 # start and end years for timeseries analysis. Using out-of-bounds values
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
-startYear = 9 
-endYear = 10 
+startYear = 1
+endYear = 9999
 
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
@@ -287,10 +287,6 @@ movingAveragePoints = 12
 compareWithObservations = True
 # list of region indices to plot from the region list in [regions] below
 regionIndex = 5
-# Number of points over which to compute moving average (e.g., for monthly
-# output, movingAveragePoints=12 corresponds to a 12-month moving average
-# window)
-movingAveragePoints = 5
 
 [timeSeriesMHT]
 ## options related to plotting time series of meridional heat transport (MHT)

--- a/configs/edison/config.20161006bugfix.alpha8.A_WCYCL1850S.ne30_oEC_ICG.edison
+++ b/configs/edison/config.20161006bugfix.alpha8.A_WCYCL1850S.ne30_oEC_ICG.edison
@@ -82,6 +82,16 @@ mpasMappingFile = /global/project/projectdirs/acme/mapping/maps/map_oEC60to30_TO
 startYear = 1
 endYear = 51
 
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
 

--- a/configs/edison/config.20161117.beta0.A_WCYCL1850.ne30_oEC.edison
+++ b/configs/edison/config.20161117.beta0.A_WCYCL1850.ne30_oEC.edison
@@ -83,6 +83,16 @@ mpasMappingFile = /global/project/projectdirs/acme/mapping/maps/map_oEC60to30_TO
 startYear = 1
 endYear = 51
 
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
 

--- a/configs/edison/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -83,6 +83,16 @@ mpasMappingFile = /global/project/projectdirs/acme/mapping/maps/map_oEC60to30v3_
 startYear = 1
 endYear = 22
 
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
 

--- a/configs/lanl/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
+++ b/configs/lanl/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
@@ -76,6 +76,16 @@ endYear = 3
 startYear = 2
 endYear = 3
 
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
 

--- a/configs/lanl/config.20170120.beta0.GMPAS-QU240.wolf
+++ b/configs/lanl/config.20170120.beta0.GMPAS-QU240.wolf
@@ -76,6 +76,16 @@ endYear = 3
 startYear = 1
 endYear = 3
 
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
 

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -76,6 +76,16 @@ endYear = 1961
 startYear = 1960
 endYear = 1961
 
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
 

--- a/configs/olcf/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.titan
+++ b/configs/olcf/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.titan
@@ -83,6 +83,16 @@ endYear = 140
 startYear = 131
 endYear = 140
 
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
 

--- a/mpas_analysis/ocean/nino34_index.py
+++ b/mpas_analysis/ocean/nino34_index.py
@@ -1,11 +1,23 @@
+"""
+Computes NINO34 index and plots the time series and power spectra
+
+Author
+------
+Luke Van Roekel
+
+Last Modified
+-------------
+03/21/2017
+"""
 from ..shared.plot.plotting import nino34_timeseries_plot, nino34_spectra_plot
+import xarray as xr
 import pandas as pd
 import numpy as np
-from scipy import signal, stats
 
 from ..shared.io import NameList, StreamsFile
 from ..shared.io.utility import buildConfigFullPath
 from ..shared.climatology import climatology
+from ..shared.constants import constants
 
 from ..shared.generalized_reader.generalized_reader \
     import open_multifile_dataset
@@ -14,18 +26,19 @@ from ..shared.timekeeping.utility import get_simulation_start_time, \
     date_to_days, days_to_datetime
 
 
-def nino34_timeseries(config, streamMap=None, variableMap=None, SSTregions=None):
+def nino34_index(config, streamMap=None, variableMap=None):
+    # {{{
     """
-    Computes NINO34 index and plots the time series and power spectrum with 
+    Computes NINO34 index and plots the time series and power spectrum with
     95 and 99% confidence bounds
 
-    Parameters    
+    Parameters
     ----------
     config: Instance of MpasAnalysisConfigParser containing configuration
     options.
 
     streamMap: dict, optional
-        a dictionary of MPAS-O variable names that map to their 
+        a dictionary of MPAS-O variable names that map to their
         mpas_analysis counterparts.
 
     variableMap : dict, optional
@@ -35,10 +48,10 @@ def nino34_timeseries(config, streamMap=None, variableMap=None, SSTregions=None)
     Author
     ------
     Luke Van Roekel
-    
+
     Last Modified
     -------------
-    03/21/2017
+    03/22/2017
     """
 
     # Define/read in general variables
@@ -57,8 +70,8 @@ def nino34_timeseries(config, streamMap=None, variableMap=None, SSTregions=None)
 
     # get a list of timeSeriesStats output files from the streams file,
     # reading only those that are between the start and end dates
-    startDate = config.get('timeSeries', 'startDate')
-    endDate = config.get('timeSeries', 'endDate')
+    startDate = config.get('index', 'startDate')
+    endDate = config.get('index', 'endDate')
     streamName = streams.find_stream(streamMap['timeSeriesStats'])
     fileNames = streams.readpath(streamName, startDate=startDate,
                                  endDate=endDate,  calendar=calendar)
@@ -68,11 +81,10 @@ def nino34_timeseries(config, streamMap=None, variableMap=None, SSTregions=None)
     plotsDirectory = buildConfigFullPath(config, 'output', 'plotsSubdirectory')
 
     plotTitles = config.getExpression('regions', 'plotTitles')
-#   regionIndex should correspond to NINO34 in surface weighted Average AM
-    regionIndex = config.getint('timeSeriesNino34', 'regionIndex')
+    # regionIndex should correspond to NINO34 in surface weighted Average AM
+    regionIndex = config.getint('indexNino34', 'regionIndicesToPlot')
 
-#   Load data:
-
+    # Load data:
     varList = ['avgSurfaceTemperature']
     ds = open_multifile_dataset(fileNames=fileNames,
                                 calendar=calendar,
@@ -88,61 +100,74 @@ def nino34_timeseries(config, streamMap=None, variableMap=None, SSTregions=None)
     nino34 = compute_nino34_index(SSTregions[:, regionIndex], config)
 
     print ' Computing NINO3.4 power spectra...'
-#   NOTE: first 2 and last two values ommitted due to rolling mean
     f, spectra, conf99, conf95, redNoise = compute_nino34_spectra(nino34, config)
 
     start = days_to_datetime(np.amin(ds.Time.min()), calendar=calendar)
     end = days_to_datetime(np.amax(ds.Time.max()), calendar=calendar)
 
-#   Convert frequencies to period in years
-    f = 1.0 / (1E-9 + f*86400.*365)
+    # Convert frequencies to period in years
+    f = 1.0 / (constants.eps + f*constants.sec_per_year)
     print ' Plot NINO3.4 index and spectra...'
-    xLabel = 'Time [years]'
-    yLabel = '[$^\circ$ C]'
 
     figureName = '{}/NINO34_{}.png'.format(plotsDirectory, mainRunName)
     nino34_timeseries_plot(config, nino34, 'NINO 3.4 Index',
-    			   xLabel, yLabel, figureName, linewidths=3, calendar=calendar)
+                           figureName, linewidths=2, calendar=calendar)
 
-    xLabel = 'Period (years)'
-    yLabel = 'Power Spectrum'
     figureName = '{}/NINO34_spectra_{}.png'.format(plotsDirectory, mainRunName)
     nino34_spectra_plot(config, f, spectra, conf95, conf99, redNoise,
-			'NINO3.4 power spectrum', xLabel,
-			yLabel, figureName, linewidths=3)
+                        'NINO3.4 power spectrum', figureName, linewidths=2)
 
- 
+
+# }}}
 def compute_nino34_index(regionSST, config):
+    # {{{
     """
     Computes nino34 index time series.  It follow the standard nino34 algorithm, i.e.,
 
     1) Compute monthly average SST in the region
     2) Computes anomalous SST
-    3) Performs a 5 point running mean over the anomalies
+    3) Performs a 5 month running mean over the anomalies
 
     This routine requires regionSST to be the SSTs in the nino3.4 region ONLY.
     It is defined as lat > -5S and lat < 5N and lon > 190E and lon < 240E.
 
-    Further, regionSST must be a dataArray
+    Parameters
+    ----------
+    regionSST : xarray.dataArray object
+       values of SST in the nino region
 
-    Author: Luke Van Roekel
-    Last Modified: 03/20/2017
+    config : instance of the MPAS configParser
+
+    Returns
+    -------
+    xarray.DataArray object containing the nino34index
+
+    Author
+    ------
+    Luke Van Roekel
+
+    Last Modified
+    -------------
+    03/22/2017
     """
+
+    assert isinstance(regionSST, xr.core.dataarray.DataArray)
 
     inDirectory = config.get('input', 'baseDirectory')
     namelistFileName = config.get('input', 'oceanNamelistFileName')
     namelist = NameList(namelistFileName, path=inDirectory)
     calendar = namelist.get('config_calendar_type')
 
-    # Compute monthly average climatology of SST
+    # Compute monthly average and anomaly of climatology of SST
     monthlyClimatology = climatology.compute_monthly_climatology(regionSST, calendar)
-
     anomalySST = regionSST.groupby('month') - monthlyClimatology
 
     return _running_mean(anomalySST.to_pandas())
 
 
+# }}}
 def compute_nino34_spectra(nino34Index, config):
+    # {{{
     """
     Computes power spectra of Nino34 index.
 
@@ -151,59 +176,123 @@ def compute_nino34_spectra(nino34Index, config):
     The algorithm follows the NCL cvdp package see
     http://www.cesm.ucar.edu/working_groups/CVC/cvdp/code.html
 
-    NOTE: this routine requires the signal and stats module from scipy
+    Parameters
+    ----------
+    nino34Index : xarray.DataArray object
+        nino34Index for analysis
 
-    Author: Luke Van Roekel
-    Last Modified: 03/21/2017
+    config : instance of the MPAS configParser
+
+    Returns
+    -------
+    pxxSmooth : xarray.DataArray object
+        nino34Index power spectra that has been smoothed with a 5-point
+        running mean
+
+    f : numpy.array
+        array of frequencies corresponding to the center of the spectral
+        bins resulting from the analysis
+
+    mkov*scale : numpy.array
+        Red noise fit to pxxSmooth
+
+    mkov*scale*xLow : numpy.array
+        95% confidence threshold from chi-squared test
+
+    mkov*scale*xHigh : numpy.array
+        99% confidence threshold from chi-squared test
+
+    Author
+    ------
+    Luke Van Roekel
+
+    Last Modified
+    -------------
+    03/22/2017
     """
+
+    from scipy import signal, stats
 
     detrendedNino34 = signal.detrend(nino34Index.values)
 
-    f, Pxx = signal.periodogram(nino34Index.values, 1.0 / (86400.*30.), 
-				window='hamming', scaling='spectrum')
+    window = signal.tukey(len(detrendedNino34), alpha=0.1)
+    f, Pxx = signal.periodogram(window * detrendedNino34,
+                                1.0 / constants.sec_per_month,
+                                scaling='spectrum')
 
-#   computes power spectra, smoothed with 5 point running mean
+    # computes power spectra, smoothed with 5 point running mean
     pxxSmooth = _running_mean(pd.Series(Pxx))
-    
-#   compute 99 and 95% confidence intervals and red-noise process
-#   Uses Chi squared test
+
+    # compute 99 and 95% confidence intervals and red-noise process
+    # Uses Chi squared test
 
     r = _autocorr(detrendedNino34)[0, 1]
     r2 = 2.*r
     rsq = r**2
 
-#   In the temp2 variable, f is converted to give wavenumber i.e., 0,1,2,...,N/2
-    temp2 = r2*np.cos(2.*np.pi*f*86400.*30.)
+    # In the temp2 variable, f is converted to give wavenumber, i.e.
+    # 0,1,2,...,N/2
+    temp2 = r2*np.cos(2.*np.pi*f*constants.sec_per_month)
     mkov = 1. / (1. + rsq - temp2)
 
     sum1 = np.sum(mkov)
-    sum2 = np.sum(pxxSmooth)
+    sum2 = np.sum(pxxSmooth.values)
     scale = sum2 / sum1
 
-    xLow = stats.chi2.interval(0.95, 2)[1]/2.
-    xHigh = stats.chi2.interval(0.99, 2)[1]/2.
+    xLow = stats.chi2.interval(0.95, 4)[1]/4.
+    xHigh = stats.chi2.interval(0.99, 4)[1]/4.
 
-#   return Spectra, 99% confidence level, 95% confidence level, and Red-noise fit
+    # return Spectra, 99% confidence level, 95% confidence level,
+    #        and Red-noise fit
     return f, pxxSmooth, mkov*scale*xHigh, mkov*scale*xLow, mkov*scale
 
 
+# }}}
 def _autocorr(x, t=1):
+    # {{{
     """
     Computes lag one auto-correlation for the NINO34 spectra calculation
 
-    Author: Luke Van Roekel
-    Last Modified: 03/20/2017
+    Parameters
+    ----------
+    x : numpy 1-D array
+       time series array
+
+    Returns
+    -------
+    Single value giving the lag one auto-correlation
+        If t != 1, this is no longer a lag one auto-correlation
+
+    Author
+    ------
+    Luke Van Roekel
+
+    Last Modified
+    -------------
+    03/22/2017
     """
 
     return np.corrcoef(np.array([x[0:len(x)-t], x[t:len(x)]]))
 
 
+# }}}
 def _running_mean(inputData):
+    # {{{
     """
-    Calculates 5-point running mean for NINO index and the spectra
+    Calculates 5-month running mean for NINO index and the spectra
 
-    Author: Luke Van Roekel
-    Last Modified: 03/20/2017
+    Author
+    ------
+    Luke Van Roekel
+
+    Last Modified
+    -------------
+    03/22/2017
     """
 
-    return pd.Series.rolling(inputData, 5, center=True, min_periods=1).mean()
+    runningMean = pd.Series.rolling(inputData, 5, center=True, min_periods=1).mean()
+    return xr.DataArray.from_series(runningMean)
+
+
+# }}}
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/ocean/nino34_timeseries.py
+++ b/mpas_analysis/ocean/nino34_timeseries.py
@@ -1,6 +1,7 @@
-from ..shared.plot.plotting import nino34_timeseries_plot
+from ..shared.plot.plotting import nino34_timeseries_plot, nino34_spectra_plot
 import pandas as pd
 import numpy as np
+from scipy import signal, stats
 
 from ..shared.io import NameList, StreamsFile
 from ..shared.io.utility import buildConfigFullPath
@@ -15,27 +16,36 @@ from ..shared.timekeeping.utility import get_simulation_start_time, \
 
 def nino34_timeseries(config, streamMap=None, variableMap=None, SSTregions=None):
     """
-    Performs analysis of the time-series output of sea-surface temperature
-    (SST).
+    Computes NINO34 index and plots the time series and power spectrum with 
+    95 and 99% confidence bounds
 
-    config is an instance of MpasAnalysisConfigParser containing configuration
+    Parameters    
+    ----------
+    config: Instance of MpasAnalysisConfigParser containing configuration
     options.
 
-    If present, streamMap is a dictionary of MPAS-O stream names that map to
-    their mpas_analysis counterparts.
+    streamMap: dict, optional
+        a dictionary of MPAS-O variable names that map to their 
+        mpas_analysis counterparts.
 
-    If present, variableMap is a dictionary of MPAS-O variable names that map
-    to their mpas_analysis counterparts.
+    variableMap : dict, optional
+        a dictionary of MPAS-O variable names that map
+        to their mpas_analysis counterparts.
 
-    Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 02/11/2017
+    Author
+    ------
+    Luke Van Roekel
+    
+    Last Modified
+    -------------
+    03/21/2017
     """
 
     # Define/read in general variables
     print '  Load SST data...'
     # read parameters from config file
     inDirectory = config.get('input', 'baseDirectory')
-    
+
     streamsFileName = config.get('input', 'oceanStreamsFileName')
     streams = StreamsFile(streamsFileName, streamsdir=inDirectory)
 
@@ -58,12 +68,11 @@ def nino34_timeseries(config, streamMap=None, variableMap=None, SSTregions=None)
     plotsDirectory = buildConfigFullPath(config, 'output', 'plotsSubdirectory')
 
     plotTitles = config.getExpression('regions', 'plotTitles')
-    #regionIndex should correspond to NINO34 in surface weighted Average AM
-    regionIndex = config.getint('timeSeriesNino34', 'regionIndex')   
-    
+#   regionIndex should correspond to NINO34 in surface weighted Average AM
+    regionIndex = config.getint('timeSeriesNino34', 'regionIndex')
 
-    # Load data:
-    
+#   Load data:
+
     varList = ['avgSurfaceTemperature']
     ds = open_multifile_dataset(fileNames=fileNames,
                                 calendar=calendar,
@@ -73,114 +82,128 @@ def nino34_timeseries(config, streamMap=None, variableMap=None, SSTregions=None)
                                 variableMap=variableMap,
                                 startDate=startDate,
                                 endDate=endDate)
-    
+
     SSTregions = ds.avgSurfaceTemperature
     print '  Compute NINO3.4 index...'
-    nino34 = compute_nino34_index(SSTregions[:,regionIndex],config)
-    
+    nino34 = compute_nino34_index(SSTregions[:, regionIndex], config)
+
     print ' Computing NINO3.4 power spectra...'
-    spectra, conf99, conf95, redNoise = compute_nino34_spectra(nino34, config)
-    
+#   NOTE: first 2 and last two values ommitted due to rolling mean
+    f, spectra, conf99, conf95, redNoise = compute_nino34_spectra(nino34, config)
+
+    start = days_to_datetime(np.amin(ds.Time.min()), calendar=calendar)
+    end = days_to_datetime(np.amax(ds.Time.max()), calendar=calendar)
+
+#   Convert frequencies to period in years
+    f = 1.0 / (1E-9 + f*86400.*365)
     print ' Plot NINO3.4 index and spectra...'
     xLabel = 'Time [years]'
     yLabel = '[$^\circ$ C]'
-        
-    figureName = '{}/NINO34_{}.png'.format(plotsDirectory, mainRunName)
-    nino34_timeseries_plot(config, nino34, ds.Time.values, 'NINO 3.4 Index', xLabel, yLabel, 
-                           figureName, linewidths=3, calendar=calendar)
-    
 
-def compute_nino34_index(regionSST,config):
+    figureName = '{}/NINO34_{}.png'.format(plotsDirectory, mainRunName)
+    nino34_timeseries_plot(config, nino34, 'NINO 3.4 Index',
+    			   xLabel, yLabel, figureName, linewidths=3, calendar=calendar)
+
+    xLabel = 'Period (years)'
+    yLabel = 'Power Spectrum'
+    figureName = '{}/NINO34_spectra_{}.png'.format(plotsDirectory, mainRunName)
+    nino34_spectra_plot(config, f, spectra, conf95, conf99, redNoise,
+			'NINO3.4 power spectrum', xLabel,
+			yLabel, figureName, linewidths=3)
+
+ 
+def compute_nino34_index(regionSST, config):
     """
     Computes nino34 index time series.  It follow the standard nino34 algorithm, i.e.,
 
     1) Compute monthly average SST in the region
     2) Computes anomalous SST
     3) Performs a 5 point running mean over the anomalies
-        
-    This routine requires regionSST to be the SSTs in the nino3.4 region ONLY.  It is 
-    defined as lat > -5S and lat < 5N and lon > 190E and lon < 240E.
-    
+
+    This routine requires regionSST to be the SSTs in the nino3.4 region ONLY.
+    It is defined as lat > -5S and lat < 5N and lon > 190E and lon < 240E.
+
     Further, regionSST must be a dataArray
-    
+
     Author: Luke Van Roekel
-    Last Modified: 03/20/2017    
+    Last Modified: 03/20/2017
     """
- 
+
     inDirectory = config.get('input', 'baseDirectory')
     namelistFileName = config.get('input', 'oceanNamelistFileName')
     namelist = NameList(namelistFileName, path=inDirectory)
     calendar = namelist.get('config_calendar_type')
-    
+
     # Compute monthly average climatology of SST
     monthlyClimatology = climatology.compute_monthly_climatology(regionSST, calendar)
-    
-#    months = [date.month for date in days_to_datetime(regionSST.Time,
-#                                                      calendar=calendar)]
-#    regionSST.coords['month'] = ('Time', months)
+
     anomalySST = regionSST.groupby('month') - monthlyClimatology
-            
-    return _running_mean(anomalySST.to_pandas())                           
-                                  
+
+    return _running_mean(anomalySST.to_pandas())
+
+
 def compute_nino34_spectra(nino34Index, config):
     """
     Computes power spectra of Nino34 index.
-    
-    nino34Index is the NINO index computed by compute_nino34_index
-    
-    The algorithm follows the NCL cvdp package
-    
-    NOTE: this routine requires the signal module from scipy
-    
-    Author: Luke Van Roekel
-    Last Modified: 03/20/2017
-    """
-    
-    from scipy import signal,stats
-    
-    window = signal.tukey(len(nino34Index.values),alpha=0.1)
-    f,Pxx = signal.periodogram(window*nino34Index.values,1.)
-    
-    #computes power spectra, smoothed with 5 point running mean
-    pxxSmooth = _running_mean(pd.Series(Pxx))
 
-    # compute 99 and 95% confidence intervals and red-noise process
-    # Uses Chi squared test
+    nino34Index is the NINO index computed by compute_nino34_index
+
+    The algorithm follows the NCL cvdp package see
+    http://www.cesm.ucar.edu/working_groups/CVC/cvdp/code.html
+
+    NOTE: this routine requires the signal and stats module from scipy
+
+    Author: Luke Van Roekel
+    Last Modified: 03/21/2017
+    """
+
+    detrendedNino34 = signal.detrend(nino34Index.values)
+
+    f, Pxx = signal.periodogram(nino34Index.values, 1.0 / (86400.*30.), 
+				window='hamming', scaling='spectrum')
+
+#   computes power spectra, smoothed with 5 point running mean
+    pxxSmooth = _running_mean(pd.Series(Pxx))
     
-    r = _autocorr(nino34Index.values)[0,1];
+#   compute 99 and 95% confidence intervals and red-noise process
+#   Uses Chi squared test
+
+    r = _autocorr(detrendedNino34)[0, 1]
     r2 = 2.*r
     rsq = r**2
-    
-    temp2 = r2*np.cos(2.*np.pi*f)
+
+#   In the temp2 variable, f is converted to give wavenumber i.e., 0,1,2,...,N/2
+    temp2 = r2*np.cos(2.*np.pi*f*86400.*30.)
     mkov = 1. / (1. + rsq - temp2)
-    
+
     sum1 = np.sum(mkov)
     sum2 = np.sum(pxxSmooth)
     scale = sum2 / sum1
-    
-    xLow = stats.chi2.interval(0.95,10)[1]/10.
-    xHigh = stats.chi2.interval(0.99,10)[1]/10.
-                     
-    #return Spectra, 99% confidence level, 95% confidence level, and Red-noise fit
-    return pxxSmooth, mkov*scale*xHigh, mkov*scale*xLow, mkov*scale                    
-                           
+
+    xLow = stats.chi2.interval(0.95, 2)[1]/2.
+    xHigh = stats.chi2.interval(0.99, 2)[1]/2.
+
+#   return Spectra, 99% confidence level, 95% confidence level, and Red-noise fit
+    return f, pxxSmooth, mkov*scale*xHigh, mkov*scale*xLow, mkov*scale
+
+
 def _autocorr(x, t=1):
     """
     Computes lag one auto-correlation for the NINO34 spectra calculation
-    
-    Autho: Luke Van Roekel
+
+    Author: Luke Van Roekel
     Last Modified: 03/20/2017
     """
-    
-    
+
     return np.corrcoef(np.array([x[0:len(x)-t], x[t:len(x)]]))
+
 
 def _running_mean(inputData):
     """
     Calculates 5-point running mean for NINO index and the spectra
-    
+
     Author: Luke Van Roekel
     Last Modified: 03/20/2017
     """
-    
-    return pd.Series.rolling(inputData, 5, center=True).mean()
+
+    return pd.Series.rolling(inputData, 5, center=True, min_periods=1).mean()

--- a/mpas_analysis/ocean/nino34_timeseries.py
+++ b/mpas_analysis/ocean/nino34_timeseries.py
@@ -1,0 +1,186 @@
+from ..shared.plot.plotting import nino34_timeseries_plot
+import pandas as pd
+import numpy as np
+
+from ..shared.io import NameList, StreamsFile
+from ..shared.io.utility import buildConfigFullPath
+from ..shared.climatology import climatology
+
+from ..shared.generalized_reader.generalized_reader \
+    import open_multifile_dataset
+
+from ..shared.timekeeping.utility import get_simulation_start_time, \
+    date_to_days, days_to_datetime
+
+
+def nino34_timeseries(config, streamMap=None, variableMap=None, SSTregions=None):
+    """
+    Performs analysis of the time-series output of sea-surface temperature
+    (SST).
+
+    config is an instance of MpasAnalysisConfigParser containing configuration
+    options.
+
+    If present, streamMap is a dictionary of MPAS-O stream names that map to
+    their mpas_analysis counterparts.
+
+    If present, variableMap is a dictionary of MPAS-O variable names that map
+    to their mpas_analysis counterparts.
+
+    Author: Xylar Asay-Davis, Milena Veneziani
+    Last Modified: 02/11/2017
+    """
+
+    # Define/read in general variables
+    print '  Load SST data...'
+    # read parameters from config file
+    inDirectory = config.get('input', 'baseDirectory')
+    
+    streamsFileName = config.get('input', 'oceanStreamsFileName')
+    streams = StreamsFile(streamsFileName, streamsdir=inDirectory)
+
+    namelistFileName = config.get('input', 'oceanNamelistFileName')
+    namelist = NameList(namelistFileName, path=inDirectory)
+
+    calendar = namelist.get('config_calendar_type')
+    simulationStartTime = get_simulation_start_time(streams)
+
+    # get a list of timeSeriesStats output files from the streams file,
+    # reading only those that are between the start and end dates
+    startDate = config.get('timeSeries', 'startDate')
+    endDate = config.get('timeSeries', 'endDate')
+    streamName = streams.find_stream(streamMap['timeSeriesStats'])
+    fileNames = streams.readpath(streamName, startDate=startDate,
+                                 endDate=endDate,  calendar=calendar)
+    print 'Reading files {} through {}'.format(fileNames[0], fileNames[-1])
+
+    mainRunName = config.get('runs', 'mainRunName')
+    plotsDirectory = buildConfigFullPath(config, 'output', 'plotsSubdirectory')
+
+    plotTitles = config.getExpression('regions', 'plotTitles')
+    #regionIndex should correspond to NINO34 in surface weighted Average AM
+    regionIndex = config.getint('timeSeriesNino34', 'regionIndex')   
+    
+
+    # Load data:
+    
+    varList = ['avgSurfaceTemperature']
+    ds = open_multifile_dataset(fileNames=fileNames,
+                                calendar=calendar,
+                                simulationStartTime=simulationStartTime,
+                                timeVariableName='Time',
+                                variableList=varList,
+                                variableMap=variableMap,
+                                startDate=startDate,
+                                endDate=endDate)
+    
+    SSTregions = ds.avgSurfaceTemperature
+    print '  Compute NINO3.4 index...'
+    nino34 = compute_nino34_index(SSTregions[:,regionIndex],config)
+    
+    print ' Computing NINO3.4 power spectra...'
+    spectra, conf99, conf95, redNoise = compute_nino34_spectra(nino34, config)
+    
+    print ' Plot NINO3.4 index and spectra...'
+    xLabel = 'Time [years]'
+    yLabel = '[$^\circ$ C]'
+        
+    figureName = '{}/NINO34_{}.png'.format(plotsDirectory, mainRunName)
+    nino34_timeseries_plot(config, nino34, ds.Time.values, 'NINO 3.4 Index', xLabel, yLabel, 
+                           figureName, linewidths=3, calendar=calendar)
+    
+
+def compute_nino34_index(regionSST,config):
+    """
+    Computes nino34 index time series.  It follow the standard nino34 algorithm, i.e.,
+
+    1) Compute monthly average SST in the region
+    2) Computes anomalous SST
+    3) Performs a 5 point running mean over the anomalies
+        
+    This routine requires regionSST to be the SSTs in the nino3.4 region ONLY.  It is 
+    defined as lat > -5S and lat < 5N and lon > 190E and lon < 240E.
+    
+    Further, regionSST must be a dataArray
+    
+    Author: Luke Van Roekel
+    Last Modified: 03/20/2017    
+    """
+ 
+    inDirectory = config.get('input', 'baseDirectory')
+    namelistFileName = config.get('input', 'oceanNamelistFileName')
+    namelist = NameList(namelistFileName, path=inDirectory)
+    calendar = namelist.get('config_calendar_type')
+    
+    # Compute monthly average climatology of SST
+    monthlyClimatology = climatology.compute_monthly_climatology(regionSST, calendar)
+    
+#    months = [date.month for date in days_to_datetime(regionSST.Time,
+#                                                      calendar=calendar)]
+#    regionSST.coords['month'] = ('Time', months)
+    anomalySST = regionSST.groupby('month') - monthlyClimatology
+            
+    return _running_mean(anomalySST.to_pandas())                           
+                                  
+def compute_nino34_spectra(nino34Index, config):
+    """
+    Computes power spectra of Nino34 index.
+    
+    nino34Index is the NINO index computed by compute_nino34_index
+    
+    The algorithm follows the NCL cvdp package
+    
+    NOTE: this routine requires the signal module from scipy
+    
+    Author: Luke Van Roekel
+    Last Modified: 03/20/2017
+    """
+    
+    from scipy import signal,stats
+    
+    window = signal.tukey(len(nino34Index.values),alpha=0.1)
+    f,Pxx = signal.periodogram(window*nino34Index.values,1.)
+    
+    #computes power spectra, smoothed with 5 point running mean
+    pxxSmooth = _running_mean(pd.Series(Pxx))
+
+    # compute 99 and 95% confidence intervals and red-noise process
+    # Uses Chi squared test
+    
+    r = _autocorr(nino34Index.values)[0,1];
+    r2 = 2.*r
+    rsq = r**2
+    
+    temp2 = r2*np.cos(2.*np.pi*f)
+    mkov = 1. / (1. + rsq - temp2)
+    
+    sum1 = np.sum(mkov)
+    sum2 = np.sum(pxxSmooth)
+    scale = sum2 / sum1
+    
+    xLow = stats.chi2.interval(0.95,10)[1]/10.
+    xHigh = stats.chi2.interval(0.99,10)[1]/10.
+                     
+    #return Spectra, 99% confidence level, 95% confidence level, and Red-noise fit
+    return pxxSmooth, mkov*scale*xHigh, mkov*scale*xLow, mkov*scale                    
+                           
+def _autocorr(x, t=1):
+    """
+    Computes lag one auto-correlation for the NINO34 spectra calculation
+    
+    Autho: Luke Van Roekel
+    Last Modified: 03/20/2017
+    """
+    
+    
+    return np.corrcoef(np.array([x[0:len(x)-t], x[t:len(x)]]))
+
+def _running_mean(inputData):
+    """
+    Calculates 5-point running mean for NINO index and the spectra
+    
+    Author: Luke Van Roekel
+    Last Modified: 03/20/2017
+    """
+    
+    return pd.Series.rolling(inputData, 5, center=True).mean()

--- a/mpas_analysis/shared/constants/constants.py
+++ b/mpas_analysis/shared/constants/constants.py
@@ -41,4 +41,13 @@ rad_to_deg = 180./np.pi
 # conversion factor from degrees to radians
 deg_to_rad = np.pi/180.
 
+# seconds in a year
+sec_per_year = 86400. * 365.
+
+# seconds per month (approximate)
+sec_per_month = 86400. * 30.
+
+# small value to prevent division by zero
+eps = 1.E-10
+
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -30,9 +30,9 @@ from ..constants import constants
 
 
 def nino34_spectra_plot(config, f, ninoSpectra, confidence95, confidence99,
-			redNoiseSpectra, title, xlabel, ylabel,
-                        fileout, linewidths, titleFontSize=None,
-			figsize=(15, 6), dpi=300):
+                        redNoiseSpectra, title, fileout, linewidths,
+                        xlabel='Period (years)', ylabel='Power Spectrum',
+                        titleFontSize=None, figsize=(15, 6), dpi=300):
     """
     Plots the nino34 time series and power spectra in an image file
     Parameters
@@ -41,20 +41,25 @@ def nino34_spectra_plot(config, f, ninoSpectra, confidence95, confidence99,
         the configuration, containing a [plot] section with options that
         control plotting
 
-	f : frequencies to plot on x-axis
+    f : numpy.array
+        periods to plot on x-axis
 
-    ninoSpectra : nino34 power spectra
+    ninoSpectra : xarray.dataArray object
+        nino34 power spectra
 
-    confidence95 : 95% confidence level based on chi squared test
+    confidence95 : numpy.array
+        95% confidence level based on chi squared test
 
-    confidence99 : 99% confidence level based on chi squared test
+    confidence99 : numpy.array
+        99% confidence level based on chi squared test
 
-    redNoiseSpectra : red noise fit to the ninoSpectra
+    redNoiseSpectra : numpy.array
+        red noise fit to the ninoSpectra
 
     title : str
         the title of the plot
 
-    xlabelTimeSeries, ylabelTimeSeries, xlabelSpectra, ylabelSpectra : str
+    xLabel, yLabel : str
         axis labels
 
     fileout : str
@@ -71,15 +76,44 @@ def nino34_spectra_plot(config, f, ninoSpectra, confidence95, confidence99,
     dpi : int, optional
         the number of dots per inch of the figure
 
-    Author: Luke Van Roekel
-    Last Modified: 03/21/2017
+    Author
+    ------
+    Luke Van Roekel
+
+    Last Modified
+    -------------
+    03/22/2017
     """
 
-    plt.plot(f[2:-3], ninoSpectra[2:-3], 'k', linewidth=linewidths)
-    plt.plot(f[2:-3], redNoiseSpectra[2:-3], 'r', linewidth=linewidths)
-    plt.plot(f[2:-3], confidence95[2:-3], 'b', linewidth=linewidths)
-    plt.plot(f[2:-3], confidence99[2:-3], 'g', linewidth=linewidths)
-    plt.xlim(15, 1)
+    fig, ax = plt.subplots()
+
+    ax.plot(f[2:-3], ninoSpectra[2:-3], 'k', linewidth=linewidths)
+    ax.plot(f[2:-3], redNoiseSpectra[2:-3], 'r', linewidth=linewidths)
+    ax.plot(f[2:-3], confidence95[2:-3], 'b', linewidth=linewidths)
+    ax.plot(f[2:-3], confidence99[2:-3], 'g', linewidth=linewidths)
+    ax.set_xlim(15, 1)
+
+    # add legend
+    ax.legend(['Nino34 index spectra', 'Red noise fit',
+               '95% confidence threshold', '99% confidence threshold'],
+               loc='upper right')
+
+    # automatically size y-axis
+    xmin = ax.get_xlim()[0]
+    xmax = ax.get_xlim()[1]
+
+    # find period/frequency bounds for chosen xmin/xmax
+    minIndex = np.abs(f-xmin).argmin()
+    maxIndex = np.abs(f-xmax).argmin()
+
+    # find maximum value of three curves plotted
+    # The confidence95 curve is by definition less than confidence99
+    maxValueNinoSpectra = ninoSpectra[minIndex:maxIndex].values.max()
+    maxValueRedNoise = redNoiseSpectra[minIndex:maxIndex].max()
+    maxValueConf99 = confidence99[minIndex:maxIndex].max()
+    # Set ylim max to be 1.1*max(maxValueNino,maxRed,maxCon)
+    ax.set_ylim(0,0.9*max(maxValueNinoSpectra, maxValueRedNoise,
+                          maxValueConf99))
 
     if titleFontSize is None:
         titleFontSize = config.get('plot', 'titleFontSize')
@@ -89,43 +123,45 @@ def nino34_spectra_plot(config, f, ninoSpectra, confidence95, confidence99,
                   'color': config.get('plot', 'titleFontColor'),
                   'weight': config.get('plot', 'titleFontWeight')}
     if title is not None:
-        plt.title(title, **title_font)
+        ax.set_title(title, **title_font)
     if xlabel is not None:
-        plt.xlabel(xlabel, **axis_font)
+        ax.set_xlabel(xlabel, **axis_font)
     if ylabel is not None:
-        plt.ylabel(ylabel, **axis_font)
+        ax.set_ylabel(ylabel, **axis_font)
     if fileout is not None:
-        plt.savefig(fileout, dpi=dpi, bbox_inches='tight', pad_inches=0.1)
+        fig.savefig(fileout, dpi=dpi, bbox_inches='tight', pad_inches=0.1)
 
     if not config.getboolean('plot', 'displayToScreen'):
         plt.close()
 
 
-def nino34_timeseries_plot(config, nino34Index, title, xlabel, ylabel,
-                           fileout, linewidths, calendar,
+def nino34_timeseries_plot(config, nino34Index, title, fileout, linewidths,
+                           calendar, xlabel='Time [years]', ylabel='[$^\circ$C]',
                            titleFontSize=None, figsize=(15, 6), dpi=300,
                            maxXTicks=20):
     """
     Plots the nino34 time series and power spectra in an image file
-     Parameters
+
+    Parameters
     ----------
     config : instance of ConfigParser
         the configuration, containing a [plot] section with options that
         control plotting
 
-    nino34 : nino34 timeseries to plot
+    nino34Index : xarray.dataArray
+        nino34 timeseries to plot
 
     title : str
         the title of the plot
 
-    xlabelTimeSeries, ylabelTimeSeries, xlabelSpectra, ylabelSpectra : str
+    xLabel, yLabel : str
         axis labels
 
     fileout : str
         the file name to be written
 
-    lineStyles, lineWidths : list of str
-        control line style/width
+    lineWidths : list of str
+        control line width
 
     titleFontSize : int, optional
         the size of the title font
@@ -141,53 +177,35 @@ def nino34_timeseries_plot(config, nino34Index, title, xlabel, ylabel,
         This may need to be adjusted depending on the figure size and aspect
         ratio.
 
-    Author: Luke Van Roekel
-    Last Modified: 03/21/2017
+    Author
+    ------
+    Luke Van Roekel
+
+    Last Modified
+    -------------
+    03/22/2017
     """
     plt.figure(figsize=figsize, dpi=dpi)
 
-    nino34Index = xr.DataArray.from_series(nino34Index)
-    y1 = nino34Index[2:-3]
-    nt = np.size(nino34Index[2:-3])
+    nino34Index = nino34Index[2:-3]
+    y1 = nino34Index.values
+    nt = np.size(nino34Index)
+    time = nino34Index.Time.values
 
-    minDays = nino34Index.Time[2].values
-    maxDays = nino34Index.Time[-3].values
+    minDays = nino34Index.Time.values.min()
+    maxDays = nino34Index.Time.values.max()
     y2 = np.zeros(nt)
 
-    plt.plot(nino34Index.Time[2:-3].values, 0.4*np.ones(nt), '--k',
-	     linewidth=linewidths)
-    plt.plot(nino34Index.Time[2:-3].values, -0.4*np.ones(nt), '--k',
+    plt.plot(time, 0.4*np.ones(nt), '--k',
              linewidth=linewidths)
-    plt.fill_between(nino34Index.Time[2:-3].values, y1, y2, where=y1>y2,
-                     facecolor='red', linewidth=0)
-    plt.fill_between(nino34Index.Time[2:-3].values, y1, y2, where=y1<y2,
-                     facecolor='blue', linewidth=0)
+    plt.plot(time, -0.4*np.ones(nt), '--k',
+             linewidth=linewidths)
+    plt.fill_between(time, y1, y2, where=y1 > y2,
+                     facecolor='red', interpolate=True, linewidth=0)
+    plt.fill_between(time, y1, y2, where=y1 < y2,
+                     facecolor='blue', interpolate=True, linewidth=0)
 
-    ax = plt.gca()
-    start = days_to_datetime(np.amin(minDays), calendar=calendar)
-    end = days_to_datetime(np.amax(maxDays), calendar=calendar)
-
-    if (end.year - start.year > maxXTicks/2):
-        major = [date_to_days(year=year, calendar=calendar)
-                 for year in np.arange(start.year, end.year+1)]
-        formatterFun = partial(_date_tick, calendar=calendar,
-                               includeMonth=False)
-    else:
-        # add ticks for months
-        major = []
-        for year in range(start.year, end.year+1):
-            for month in range(1, 13):
-                major.append(date_to_days(year=year, month=month,
-                                          calendar=calendar))
-        formatterFun = partial(_date_tick, calendar=calendar,
-                               includeMonth=True)
-
-    ax.xaxis.set_major_locator(FixedLocator(major, maxXTicks))
-    ax.xaxis.set_major_formatter(FuncFormatter(formatterFun))
-
-    plt.setp(ax.get_xticklabels(), rotation=30)
-
-    plt.autoscale(enable=True, axis='x', tight=True)
+    _plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)
 
     if titleFontSize is None:
         titleFontSize = config.get('plot', 'titleFontSize')
@@ -279,40 +297,15 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
         plt.plot(mean['Time'], mean,
                  lineStyles[dsIndex],
                  linewidth=lineWidths[dsIndex])
-
     ax = plt.gca()
-
     # Add a y=0 line if y ranges between positive and negative values
     yaxLimits = ax.get_ylim()
     if yaxLimits[0]*yaxLimits[1] < 0:
         indgood = np.where(np.logical_not(np.isnan(mean)))
-        x = mean['Time'][indgood]
+        x  = mean['Time'][indgood]
         plt.plot(x, np.zeros(np.size(x)), 'k-', linewidth=1.2)
 
-    start = days_to_datetime(np.amin(minDays), calendar=calendar)
-    end = days_to_datetime(np.amax(maxDays), calendar=calendar)
-
-    if (end.year - start.year > maxXTicks/2):
-        major = [date_to_days(year=year, calendar=calendar)
-                 for year in np.arange(start.year, end.year+1)]
-        formatterFun = partial(_date_tick, calendar=calendar,
-                               includeMonth=False)
-    else:
-        # add ticks for months
-        major = []
-        for year in range(start.year, end.year+1):
-            for month in range(1, 13):
-                major.append(date_to_days(year=year, month=month,
-                                          calendar=calendar))
-        formatterFun = partial(_date_tick, calendar=calendar,
-                               includeMonth=True)
-
-    ax.xaxis.set_major_locator(FixedLocator(major, maxXTicks))
-    ax.xaxis.set_major_formatter(FuncFormatter(formatterFun))
-
-    plt.setp(ax.get_xticklabels(), rotation=30)
-
-    plt.autoscale(enable=True, axis='x', tight=True)
+    _plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)
 
     if titleFontSize is None:
         titleFontSize = config.get('plot', 'titleFontSize')
@@ -394,8 +387,8 @@ def timeseries_analysis_plot_polar(config, dsvalues, N, title,
         minDays.append(mean.Time.min())
         maxDays.append(mean.Time.max())
         plt.polar((mean['Time']/365.0)*np.pi*2.0, mean,
-                 lineStyles[dsIndex],
-                 linewidth=lineWidths[dsIndex])
+                   lineStyles[dsIndex],
+                   linewidth=lineWidths[dsIndex])
 
     ax = plt.gca()
 
@@ -916,5 +909,52 @@ def setup_colormap(config, configSectionName, suffix=''):
     colormap.set_under(underColor)
     colormap.set_over(overColor)
     return (colormap, colorbarLevels)
+
+def _plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks):
+    '''
+    Formats tick labels and positions along the x-axis for time series 
+    / index plots
+
+    Parameters
+    ----------
+    plt : plt handle on which to change ticks
+
+    calendar : specified calendar for the plot
+
+    minDays : start time for labels
+
+    maxDays : end time for labels
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    '''
+    ax = plt.gca()
+
+    start = days_to_datetime(np.amin(minDays), calendar=calendar)
+    end = days_to_datetime(np.amax(maxDays), calendar=calendar)
+
+    if (end.year - start.year > maxXTicks/2):
+        major = [date_to_days(year=year, calendar=calendar)
+                 for year in np.arange(start.year, end.year+1)]
+        formatterFun = partial(_date_tick, calendar=calendar,
+                               includeMonth=False)
+    else:
+        # add ticks for months
+        major = []
+        for year in range(start.year, end.year+1):
+            for month in range(1, 13):
+                major.append(date_to_days(year=year, month=month,
+                                          calendar=calendar))
+        formatterFun = partial(_date_tick, calendar=calendar,
+                               includeMonth=True)
+
+    ax.xaxis.set_major_locator(FixedLocator(major, maxXTicks))
+    ax.xaxis.set_major_formatter(FuncFormatter(formatterFun))
+
+    plt.setp(ax.get_xticklabels(), rotation=30)
+
+    plt.autoscale(enable=True, axis='x', tight=True)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -149,12 +149,13 @@ def analysis(config):  # {{{
         sst_timeseries(config, streamMap=oceanStreamMap,
                        variableMap=oceanVariableMap)
 
-#     if checkGenerate(config, analysisName='timeSeriesNino34',
-#                     mpasCore='ocean', analysisCategory='timeSeries'):
-#         print ""
-#         print "Plotting Nino3.4 time series..."
-#         from mpas_analysis.ocean.nino34_timeseries import nino34_timeseries
-#         nino34_timeseries(config)
+    if checkGenerate(config, analysisName='timeSeriesNino34',
+                     mpasCore='ocean', analysisCategory='timeSeries'):
+         print ""
+         print "Plotting Nino3.4 time series..."
+         from mpas_analysis.ocean.nino34_timeseries import nino34_timeseries
+         nino34_timeseries(config, streamMap=oceanStreamMap,
+                       variableMap=oceanVariableMap)
 
 #    if checkGenerate(config, analysisName='timeSeriesMHT', mpasCore='ocean',
 #                     analysisCategory='timeSeries'):

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -85,8 +85,8 @@ def checkGenerate(config, analysisName, mpasCore, analysisCategory=None):
 
 def analysis(config):  # {{{
     # set default values of start and end dates for climotologies and
-    # timeseries
-    for section in ['climatology', 'timeSeries']:
+    # timeseries and indices
+    for section in ['climatology', 'timeSeries','index']:
         startDate = '{:04d}-01-01_00:00:00'.format(
             config.getint(section, 'startYear'))
         if not config.has_option(section, 'startDate'):
@@ -149,12 +149,12 @@ def analysis(config):  # {{{
         sst_timeseries(config, streamMap=oceanStreamMap,
                        variableMap=oceanVariableMap)
 
-    if checkGenerate(config, analysisName='timeSeriesNino34',
-                     mpasCore='ocean', analysisCategory='timeSeries'):
+    if checkGenerate(config, analysisName='indexNino34',
+                     mpasCore='ocean', analysisCategory='index'):
          print ""
-         print "Plotting Nino3.4 time series..."
-         from mpas_analysis.ocean.nino34_timeseries import nino34_timeseries
-         nino34_timeseries(config, streamMap=oceanStreamMap,
+         print "Plotting Nino3.4 time series and power spectrum...."
+         from mpas_analysis.ocean.nino34_index import nino34_index
+         nino34_index(config, streamMap=oceanStreamMap,
                        variableMap=oceanVariableMap)
 
 #    if checkGenerate(config, analysisName='timeSeriesMHT', mpasCore='ocean',


### PR DESCRIPTION
This adds NINO34 functionality.  It computes the NINO34 index following the standard algorithm (e.g. Trenberth 1997) it also computes the power spectra, along with the 95 and 99% confidence intervals (using a chi-squared test).  A red noise best-fit is also included.  This algorithm follows closely what is used in NCL.  

It has been tested on a g-case on anvil and beta0 and beta1 on edison.