### PR TITLE
Update MOC time series file caching

### DIFF
--- a/mpas_analysis/ocean/meridional_overturning_circulation.py
+++ b/mpas_analysis/ocean/meridional_overturning_circulation.py
@@ -513,7 +513,7 @@ def _compute_transport(maxEdgesInTransect, transectEdgeGlobalIDs,
             transectEdgeMaskSigns[iEdge, np.newaxis] * \
             dvEdge[iEdge, np.newaxis] * \
             refLayerThickness[np.newaxis, :]
-        transportZ = transportZEdge.sum(axis=1)
+    transportZ = transportZEdge.sum(axis=1)
     return transportZ  # }}}
 
 

--- a/mpas_analysis/ocean/meridional_overturning_circulation.py
+++ b/mpas_analysis/ocean/meridional_overturning_circulation.py
@@ -226,10 +226,14 @@ def _compute_moc_postprocess(config, streams, variableMap, calendar,
     for region in regionNames:
         print '\n  Reading region and transect mask for {}...'.format(region)
         ncFileRegional = netCDF4.Dataset(regionMaskFiles, mode='r')
-        maxEdgesInTransect = ncFileRegional.dimensions['maxEdgesInTransect'].size
-        transectEdgeMaskSigns = ncFileRegional.variables['transectEdgeMaskSigns'][:, iRegion]
-        transectEdgeGlobalIDs = ncFileRegional.variables['transectEdgeGlobalIDs'][iRegion, :]
-        regionCellMask = ncFileRegional.variables['regionCellMasks'][:, iRegion]
+        maxEdgesInTransect = \
+            ncFileRegional.dimensions['maxEdgesInTransect'].size
+        transectEdgeMaskSigns = \
+            ncFileRegional.variables['transectEdgeMaskSigns'][:, iRegion]
+        transectEdgeGlobalIDs = \
+            ncFileRegional.variables['transectEdgeGlobalIDs'][iRegion, :]
+        regionCellMask = \
+            ncFileRegional.variables['regionCellMasks'][:, iRegion]
         ncFileRegional.close()
         iRegion += 1
 
@@ -290,9 +294,12 @@ def _compute_moc_postprocess(config, streams, variableMap, calendar,
             if region == 'Global':
                 transportZ = np.zeros(nVertLevels)
             else:
-                maxEdgesInTransect = dictRegion['maxEdgesInTransect{}'.format(region)]
-                transectEdgeGlobalIDs = dictRegion['transectEdgeGlobalIDs{}'.format(region)]
-                transectEdgeMaskSigns = dictRegion['transectEdgeMaskSigns{}'.format(region)]
+                maxEdgesInTransect = \
+                    dictRegion['maxEdgesInTransect{}'.format(region)]
+                transectEdgeGlobalIDs = \
+                    dictRegion['transectEdgeGlobalIDs{}'.format(region)]
+                transectEdgeMaskSigns = \
+                    dictRegion['transectEdgeMaskSigns{}'.format(region)]
                 transportZ = _compute_transport(maxEdgesInTransect,
                                                 transectEdgeGlobalIDs,
                                                 transectEdgeMaskSigns,
@@ -450,7 +457,8 @@ def _compute_moc_postprocess(config, streams, variableMap, calendar,
                   ' from file...'
             ncFile = netCDF4.Dataset(outputFileTseries, mode='r')
             Time[ncount-12:ncount] = ncFile.variables['Time'][:]
-            mocAtlantic26[ncount-12:ncount] = ncFile.variables['mocRapidArrayMax'][:]
+            mocAtlantic26[ncount-12:ncount] = \
+                ncFile.variables['mocRapidArrayMax'][:]
             ncFile.close()
 
     # Store max Atlantic MOC at 26.5 to dictionary

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -475,37 +475,6 @@ def compute_seasonal_climatology(monthlyClimatology, monthValues,
     return seasonalClimatology
 
 
-def compute_annual_climatology(ds, calendar):
-    """
-    Compute an annual climatology data set from a data set with Time expressed
-    as days since 0001-01-01 with the given calendar.
-
-    Parameters
-    ----------
-    ds : an xarray data set with a 'Time' coordinate expressed as days since
-        0001-01-01
-
-    calendar: {'gregorian', 'gregorian_noleap'}
-        The name of one of the calendars supported by MPAS cores
-
-    Returns
-    -------
-    annualClimatology : an xarray data set containing annual climatologies 
-        of all variables in ds (time coordinate is squashed)
-
-    Authors
-    -------
-    Milena Veneziani
-
-    Last Modified
-    -------------
-    02/28/2017
-    """
-    monthlyClimatology = compute_monthly_climatology(ds, calendar)
-    annualClimatology = monthlyClimatology.mean('month')
-    return annualClimatology
-
-
 def _get_comparison_lat_lon(comparisonLatRes, comparisonLonRes):
     '''
     Returns the lat and lon arrays defining the corners of the comparison

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -28,7 +28,7 @@ def open_multifile_dataset(fileNames, calendar, simulationStartTime=None,
                            timeVariableName='Time',
                            variableList=None, selValues=None,
                            iselValues=None, variableMap=None,
-                           startDate=None, endDate=None):  # {{{
+                           startDate=None, endDate=None, **kwargs):  # {{{
     """
     Opens and returns an xarray data set given file name(s) and the MPAS
     calendar name.
@@ -86,6 +86,9 @@ def open_multifile_dataset(fileNames, calendar, simulationStartTime=None,
         If present, the first and last dates to be used in the data set.  The
         time variable is sliced to only include dates within this range.
 
+    kwargs : dict of keyword arguments
+        Keyword arguments passed to `xarray.open_mfdataset`
+
     Returns
     -------
     ds : An xarray data set.
@@ -123,7 +126,7 @@ def open_multifile_dataset(fileNames, calendar, simulationStartTime=None,
 
     ds = xarray.open_mfdataset(fileNames,
                                preprocess=preprocess_partial,
-                               decode_times=False, concat_dim='Time')
+                               decode_times=False, concat_dim='Time', **kwargs)
 
     ds = mpas_xarray.remove_repeated_time_index(ds)
 


### PR DESCRIPTION
This merge switches the file caching of the MOC time-series computation to use a single file instead of one file per year.  This makes it easier to continue the time series into incomplete years (as would often happen if one were running the analysis as the simulation is in progress). The cache file is written out each year to ensure that progress is not lost if the analysis gets interrupted, since the computation is relatively slow.

The merge also includes a few clean-up tasks:
  * some PEP8 compliance fixes
  * breaking the MOC postprocessing into 2 functions, one for climatology and one for time series
  * adding the ability to pass keyword arguments to `open_multifile_dataset`, which let me test if chunking would improve the MOC climatology's memory performance (it didn't)
  * removing the `annual_climatology` function, as this can be replaced with the more accurate and more efficient computation:
```
annualClimatology = ds.mean('Time')
```