### PR TITLE
Clarify usage in README and config.defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,28 +17,39 @@ This analysis repository presumes that the following python packages are availab
  * dask
  * bottleneck
  * basemap
- * nco with `conda install -c conda-forge nco`
+ * lxml
+ * nco
 
 You can easily install them via the conda command:
 
 ```
-conda install -c conda-forge numpy scipy matplotlib netCDF4 xarray dask bottleneck basemap nco
+conda config --add channels conda-forge
+conda install numpy scipy matplotlib netCDF4 xarray dask bottleneck basemap lxml nco
 ```
 
 ## Running the analysis
   1. Create and empty config file (say `config.myrun`) or copy one of the
      example files in the `configs` directory.
-  2. Copy and modify any config options you want to change from 
-     `config.default` into your new config file.  Make sure they have the right
-     section name (e.g. `[run]` or `[output]`).  If nothing esle, you will need
-     to set `baseDirectory` under `[output]` to the folder where output should
-     be stored.  Note: you should not alter `config.default` directly, since
-     this is intended to hold the default configuration that is modified by your
-     new config file.
+  2. Copy and modify any config options you want to change from
+     `config.default` into your new config file.
+
+     **Requirements for custom config files:**
+     * At minimum you should set `baseDirectory` under `[output]` to the folder
+       where output is stored.  **NOTE** this value should be a unique
+       directory for each run being analyzed.  If multiple runs are analyzed in
+       the same directory, cached results from a previous analysis will not be
+       updated correctly.
+     * Any options you copy into the config file **must** include the
+       appropriate section header (e.g. '[run]' or '[output]')
+     * The entire `config.default` does not need to be used.  This fill will
+       automatically be used for any options you do not include in your custom
+       config file.
+     * Given the automatic sourcing of `config.default` you should **not**
+       alter `config.default` directly.
   3. run: `./run_analysis.py config.myrun`.  This will read the configuraiton
      first from `config.default` and then replace that configuraiton with any
      changes from from `config.myrun`
-  4. If you want to run a subset of the analysis, you can either set the 
-     `generate` option under `[output]` in your config file or use the 
-     `--generate` flag on the command line.  See the comments in 
+  4. If you want to run a subset of the analysis, you can either set the
+     `generate` option under `[output]` in your config file or use the
+     `--generate` flag on the command line.  See the comments in
      `config.default` for more details on this option.

--- a/config.default
+++ b/config.default
@@ -52,6 +52,7 @@ mpasMeshName = mesh
 ## etc.
 
 # directory where analysis should be written
+# NOTE: This directory path must be specific to each test case.
 baseDirectory = /dir/to/analysis/output
 
 # subdirectories within baseDirectory for analysis output


### PR DESCRIPTION
Make clear that each test case should be given a unique output baseDirectory and that only config options different than the defaults need to be included in a custom config file.