### PR TITLE
Improves error message for installation of nco

### DIFF
--- a/mpas_analysis/shared/interpolation/interpolate.py
+++ b/mpas_analysis/shared/interpolation/interpolate.py
@@ -103,7 +103,9 @@ def build_remap_weights(sourceFileName, outWeightFileName,
 
     if find_executable('ESMF_RegridWeightGen') is None:
         raise OSError('ESMF_RegridWeightGen not found. Make sure esmf package '
-                      'is installed via\nlatest nco: \n    conda install nco')
+                      'is installed via\nlatest nco: \n'
+                      'conda install nco\n'
+                      'Note: this presumes use of the conda-forge channel.')
 
     # two temporary SCRIP files, one for the MPAS mesh and one for the dest
     # grid


### PR DESCRIPTION
Previous error message of 

```
OSError: ESMF_RegridWeightGen not found. Make sure esmf package is installed via
latest nco: 
conda install nco
```
requires additional step of including conda-forge channel for conda install so that the error message needs to be instead:
```
OSError: ESMF_RegridWeightGen not found. Make sure esmf package is installed via
latest nco: 
conda install -c conda-forge nco
```
This is essentially a one-liner PR.