### PR TITLE
Update start and end dates from climatology data set; issue a warning

### DIFF
--- a/mpas_analysis/ocean/meridional_overturning_circulation.py
+++ b/mpas_analysis/ocean/meridional_overturning_circulation.py
@@ -33,6 +33,7 @@ from ..shared.timekeeping.utility import get_simulation_start_time, \
     days_to_datetime
 
 from ..shared.analysis_task import setup_task
+from ..shared.climatology import climatology
 
 
 def moc_streamfunction(config):  # {{{
@@ -274,19 +275,17 @@ def _compute_moc_climo_postprocess(config, runStreams, variableMap, calendar,
             variableMap=variableMap,
             startDate=dictClimo['startDateClimo'],
             endDate=dictClimo['endDateClimo'])
-        startYear = days_to_datetime(ds.Time.min().values,
-                                     calendar=calendar).year
-        endYear = days_to_datetime(ds.Time.max().values,
-                                   calendar=calendar).year
-        config.set('climatology', 'startYear', str(startYear))
-        config.set('climatology', 'endYear', str(endYear))
 
-        # update the file name in case the start and end years changed
-        outputFileClimo = '{}/mocStreamfunction_years{:04d}-{:04d}.nc'.format(
-                           outputDirectory, startYear, endYear)
+        changed, startYear, endYear = \
+            climatology.update_start_end_year(ds, config, calendar)
+        if changed:
+            # update the file name in case the start and end years changed
+            outputFileClimo = \
+                '{}/mocStreamfunction_years{:04d}-{:04d}.nc'.format(
+                    outputDirectory, startYear, endYear)
 
-        dictClimo['startYearClimo'] = startYear
-        dictClimo['endYearClimo'] = endYear
+            dictClimo['startYearClimo'] = startYear
+            dictClimo['endYearClimo'] = endYear
 
         # Compute annual climatology
         annualClimatology = ds.mean('Time')

--- a/mpas_analysis/ocean/meridional_overturning_circulation.py
+++ b/mpas_analysis/ocean/meridional_overturning_circulation.py
@@ -274,6 +274,19 @@ def _compute_moc_climo_postprocess(config, runStreams, variableMap, calendar,
             variableMap=variableMap,
             startDate=dictClimo['startDateClimo'],
             endDate=dictClimo['endDateClimo'])
+        startYear = days_to_datetime(ds.Time.min().values,
+                                     calendar=calendar).year
+        endYear = days_to_datetime(ds.Time.max().values,
+                                   calendar=calendar).year
+        config.set('climatology', 'startYear', str(startYear))
+        config.set('climatology', 'endYear', str(endYear))
+
+        # update the file name in case the start and end years changed
+        outputFileClimo = '{}/mocStreamfunction_years{:04d}-{:04d}.nc'.format(
+                           outputDirectory, startYear, endYear)
+
+        dictClimo['startYearClimo'] = startYear
+        dictClimo['endYearClimo'] = endYear
 
         # Compute annual climatology
         annualClimatology = ds.mean('Time')

--- a/mpas_analysis/ocean/ocean_modelvsobs.py
+++ b/mpas_analysis/ocean/ocean_modelvsobs.py
@@ -222,10 +222,8 @@ def ocn_modelvsobs(config, field):
                                 startDate=startDate,
                                 endDate=endDate)
 
-    startYear = days_to_datetime(ds.Time.min().values, calendar=calendar).year
-    endYear = days_to_datetime(ds.Time.max().values, calendar=calendar).year
-    config.set('climatology', 'startYear', str(startYear))
-    config.set('climatology', 'endYear', str(endYear))
+    changed, startYear, endYear = \
+        climatology.update_start_end_year(ds, config, calendar)
 
     monthlyClimatology = climatology.compute_monthly_climatology(ds, calendar)
 

--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -125,10 +125,8 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
     # Compute climatologies (first motnhly and then seasonally)
     print "  Compute seasonal climatologies..."
 
-    startYear = days_to_datetime(ds.Time.min().values, calendar=calendar).year
-    endYear = days_to_datetime(ds.Time.max().values, calendar=calendar).year
-    config.set('climatology', 'startYear', str(startYear))
-    config.set('climatology', 'endYear', str(endYear))
+    changed, startYear, endYear = \
+        climatology.update_start_end_year(ds, config, calendar)
 
     monthlyClimatology = climatology.compute_monthly_climatology(ds, calendar)
 


### PR DESCRIPTION
Add a function to update the `startYear` and `endYear` config options based on the start and end of a climatology data set.  A warning is issued if the start and end years are different from those requested by the user.

All analysis tasks for computing climatologies now use this function to make sure plot titles and file names use the start and end years of the data set (as opposed to those requested in the config file).  The MOC cache file name now uses the actual start and end years as well.