### PR TITLE
Make mpas_analysis an installable package; add a license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,39 @@
+Copyright (c) 2013,  Los Alamos National Security, LLC (LANS) (Ocean: LA-CC-13-047;
+Land Ice: LA-CC-13-117) and the University Corporation for Atmospheric Research (UCAR).
+
+All rights reserved. 
+
+LANS is the operator of the Los Alamos National Laboratory under Contract No.
+DE-AC52-06NA25396 with the U.S. Department of Energy.  UCAR manages the National
+Center for Atmospheric Research under Cooperative Agreement ATM-0753581 with the
+National Science Foundation.  The U.S. Government has rights to use, reproduce,
+and distribute this software.  NO WARRANTY, EXPRESS OR IMPLIED IS OFFERED BY
+LANS, UCAR OR THE GOVERNMENT AND NONE OF THEM ASSUME ANY LIABILITY FOR THE USE
+OF THIS SOFTWARE.  If software is modified to produce derivative works, such
+modified software should be clearly marked, so as not to confuse it with the
+version available from LANS and UCAR.
+
+Additionally, redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1) Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2) Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3) None of the names of LANS, UCAR or the names of its contributors, if any, may
+be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/conda/recipe/build.sh
+++ b/conda/recipe/build.sh
@@ -1,2 +1,9 @@
 #!/usr/bin/sh
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 python setup.py install --single-version-externally-managed --record=record.txt

--- a/conda/recipe/build.sh
+++ b/conda/recipe/build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/sh
+python setup.py install --single-version-externally-managed --record=record.txt

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -1,0 +1,47 @@
+{% set version = "0.7.0" %}
+
+package:
+    name: mpas_analysis
+    version: {{ version }}
+
+source:
+    path: ../..
+
+build:
+    number: 0
+
+test:
+    requires:
+        - pytest
+    imports:
+        - mpas_analysis
+        - pytest
+    commands:
+        - pytest --pyargs mpas_analysis
+
+requirements:
+    build:
+        - python
+        - setuptools
+    run:
+        - python
+        - numpy
+        - scipy
+        - matplotlib
+        - netcdf4
+        - xarray >=0.10.0
+        - dask
+        - bottleneck
+        - basemap
+        - lxml
+        - nco >=4.7.0
+        - pillow
+
+about:
+    home:  http://gitub.com/MPAS-Dev/MPAS-Analysis
+
+extra:
+    recipe-maintainers:
+        - doutriaux1
+        - xylar
+

--- a/configs/anvil/job_script.anvil.bash
+++ b/configs/anvil/job_script.anvil.bash
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 # comment out if using debug queue
 #PBS -q acme

--- a/configs/cori/job_script.cori-haswell.bash
+++ b/configs/cori/job_script.cori-haswell.bash
@@ -1,4 +1,11 @@
 #!/bin/bash -l
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 # comment out if using debug queue
 #SBATCH --partition=regular

--- a/configs/cori/job_script.cori-knl.bash
+++ b/configs/cori/job_script.cori-knl.bash
@@ -1,4 +1,11 @@
 #!/bin/bash -l
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 # comment out if using debug queue
 #SBATCH --partition=regular

--- a/configs/edison/job_script.edison.bash
+++ b/configs/edison/job_script.edison.bash
@@ -1,4 +1,11 @@
 #!/bin/bash -l
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 # comment out if using debug queue
 #SBATCH --partition=regular

--- a/configs/job_script.default.bash
+++ b/configs/job_script.default.bash
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/lanl/job_script.lanl.bash
+++ b/configs/lanl/job_script.lanl.bash
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 # change number of nodes to change the number of parallel tasks
 # (anything between 1 and the total number of tasks to run)

--- a/configs/olcf/job_script.olcf.bash
+++ b/configs/olcf/job_script.olcf.bash
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 # comment out if using debug queue
 #PBS -q batch

--- a/configs/theta/job_script.theta.bash
+++ b/configs/theta/job_script.theta.bash
@@ -1,4 +1,11 @@
 #!/bin/bash
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 #COBALT -t 1:00:00
 #COBALT -n 1
 #COBALT -A OceanClimate

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'MPAS-Analysis'
-copyright = u'2016-2017, Los Alamos National Security, LLC (LANS) (Ocean: ' \
+copyright = u'2016-2018, Los Alamos National Security, LLC (LANS) (Ocean: ' \
             u'LA-CC-13-047; Land Ice: LA-CC-13-117) and the University ' \
             u'Corporation for Atmospheric Research (UCAR)'
 author = u'Xylar Asay-Davis, Milena Veneziani, Phillip Wolfram, ' \

--- a/licenses/A-PRIME_LICENSE.txt
+++ b/licenses/A-PRIME_LICENSE.txt
@@ -1,0 +1,29 @@
+Copyright (c) 2017, UT-BATTELLE, LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+

--- a/licenses/NUMPY_LICENSE.txt
+++ b/licenses/NUMPY_LICENSE.txt
@@ -1,0 +1,30 @@
+Copyright (c) 2005-2017, NumPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+       copyright notice, this list of conditions and the following
+       disclaimer in the documentation and/or other materials provided
+       with the distribution.
+
+    * Neither the name of the NumPy Developers nor the names of any
+       contributors may be used to endorse or promote products derived
+       from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/SEMENOV_LICENSE
+++ b/licenses/SEMENOV_LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2017 by Dmitry Semenov (https://codepen.io/dimsemenov/pen/ZYbPJM)
+
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/XARRAY_LICENSE.txt
+++ b/licenses/XARRAY_LICENSE.txt
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses/_headers/README.md
+++ b/licenses/_headers/README.md
@@ -1,0 +1,91 @@
+# License Header Tools
+
+Before releasing software, it's important to ensure each "code" file has a license header, and that
+header has an appropriate copyright date. Provided here are two main `bash` scripts to assist
+developers in adding and updating the header files.
+
+* `license-prepend-missing.sh` finds "code" files which do not have a license header, and prepends
+  the relevant license header to the file.
+
+  *Warning: Matlab uses the header of the file for its automatic help text. For Matlab files,
+  license files need to be appended to the file, or removed from the distribution entirely (LIVVkit
+  opted for the latter).*
+
+* `license-bump-copyright.sh` will find outdated copyright date statements, and replace them
+  (in place) with a current copyright statement.
+
+## Usage
+
+### `license-prepend-missing.sh`
+
+The `license-prepend-missing.sh` script will prepend a license header from a template to files with
+these extensions:
+
+| Extension | Template file |
+| --------- | ------------- |
+| `.py`     | `header-py`  |
+| `.sh`     | `header-py`  |
+| `.bash`   | `header-py`  |
+| `.html`   | `header-html`|
+| `.css`    | `header-css` |
+| `.js`     | `header-css` |
+| `.ncl`    | `header-ncl` |
+
+*Note: Because comment syntax differs between these file types, files mush have one of the above
+extensions --- extension-less files, and files without the above extensions are ignored.*
+
+This script work by first sourcing `license-setup.sh`, which sets the important search variables:
+
+* `SOURCE_DIR` sets the top level of the source repository, relative to the current working
+  directory. Currently, this is set as `../..` assuming the scripts will be run from this directory
+  (`docs/headers`).
+
+* `CURRENT` is a string that should be unique to the license header (e.g., `Copyright (c)`) and is
+  used to determine if the header is present in a file.
+
+* `ALWAYS_IGNORE` contains a set of regular expressions to match files which should always be
+  ignored by the find command (e.g., `*.git/*`).
+
+* `FILE_IGNORE` contains a set of regular expressions to match the types of files that don't need a
+  license header (e.g., `*.png`, `*.md`).
+
+* `PYTHON_IGNORE` contains a set of regular expressions to match python files which don't need a
+  license header, or are repackaged and licensed separately.
+
+* `CSS_IGNORE` contains a set of regular expressions to match web (CSS, Javascript, HTML) files
+  which don't need a license header, or are repackaged and licensed separately.
+
+The `license-prepend-missing.sh` script then goes through a number of find-and-modify blocks for
+the above extensions, and appends a license header to the files missing a header.
+
+**Before** running the `license-prepend-missing.sh` script, it's important to ensure that the script
+is finding the correct files.
+
+**First**, run the `license-find-missing.sh` script to verify the found files, which will output a list
+of files without a license header.
+
+**Read through this output carefully!**  This find command is generous and not restricted to the
+above extensions. Files found with extensions differing from the list above will either need to be
+added to the appropriate `*_IGNORE` variables in `license-setup.sh`, or added to the appropriate
+find-and-modify block in `license-prepend-missing.sh` (or have a header added to it manually).  *If
+this file type's comment syntax differs from those found in the available templates, a new template
+will need to be created and a new find-and-modify block added to `license-prepend-missing.sh`.*
+
+Once you're confident the `license-find-missing.sh` script is finding all the appropriate files, and
+`license-prepend-missing.sh` has all the required find-and-modify blocks, simply run the
+`liscense-prepend-missing.sh` script. You should now see a license header at the top of all your
+"code" files.
+
+### `license-bump-copyright.sh`
+
+This script also uses the `*_IGNORE` variables from `license-setup.sh`, but instead of using the
+`CURRENT` string to determine if a license header is present, it looks for the `OLD` string, which
+is more restrictive, and replaces it (in place) with the `NEW` string.
+
+For example, `CURRENT` is typically set as `Copyright (c)`, which will match files with any copyright
+statement, while `OLD` may be set as `Copyright (c) 2015, UT` to match files with the 2015
+copyright statement and `NEW` would set to `Copyright (c) 2015,2016, UT` to add 2016 to the
+copyright statement. (`OLD` and `NEW` are found in `license-bump-copyright.sh`.)
+
+*Note: Like `license-find-missing.sh`, this script is not restricted to the above file types that
+`license-prepend-missing.sh` is.*

--- a/licenses/_headers/header-css
+++ b/licenses/_headers/header-css
@@ -1,0 +1,10 @@
+/*
+/ Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+/ and the University Corporation for Atmospheric Research (UCAR).
+/
+/ Unless noted otherwise source code is licensed under the BSD license.
+/ Additional copyright and license information can be found in the LICENSE file
+/ distributed with this code, or at http://mpas-dev.github.com/license.html
+/ */
+
+

--- a/licenses/_headers/header-css-full
+++ b/licenses/_headers/header-css-full
@@ -1,0 +1,43 @@
+/*
+/ Copyright (c) 2017,  Los Alamos National Security, LLC (LANS) (Ocean: LA-CC-13-047;
+/ Land Ice: LA-CC-13-117) and the University Corporation for Atmospheric Research (UCAR).
+/
+/ All rights reserved.
+/
+/ LANS is the operator of the Los Alamos National Laboratory under Contract No.
+/ DE-AC52-06NA25396 with the U.S. Department of Energy.  UCAR manages the National
+/ Center for Atmospheric Research under Cooperative Agreement ATM-0753581 with the
+/ National Science Foundation.  The U.S. Government has rights to use, reproduce,
+/ and distribute this software.  NO WARRANTY, EXPRESS OR IMPLIED IS OFFERED BY
+/ LANS, UCAR OR THE GOVERNMENT AND NONE OF THEM ASSUME ANY LIABILITY FOR THE USE
+/ OF THIS SOFTWARE.  If software is modified to produce derivative works, such
+/ modified software should be clearly marked, so as not to confuse it with the
+/ version available from LANS and UCAR.
+/
+/ Additionally, redistribution and use in source and binary forms, with or without
+/ modification, are permitted provided that the following conditions are met:
+/
+/ 1) Redistributions of source code must retain the above copyright notice, this
+/ list of conditions and the following disclaimer.
+/
+/ 2) Redistributions in binary form must reproduce the above copyright notice,
+/ this list of conditions and the following disclaimer in the documentation and/or
+/ other materials provided with the distribution.
+/
+/ 3) None of the names of LANS, UCAR or the names of its contributors, if any, may
+/ be used to endorse or promote products derived from this software without
+/ specific prior written permission.
+/
+/ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+/ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+/ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+/ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+/ ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+/ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+/ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+/ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+/ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+/ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+/ */
+
+

--- a/licenses/_headers/header-html
+++ b/licenses/_headers/header-html
@@ -1,0 +1,10 @@
+<!--
+  - Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+  - and the University Corporation for Atmospheric Research (UCAR).
+  -
+  - Unless noted otherwise source code is licensed under the BSD license.
+  - Additional copyright and license information can be found in the LICENSE file
+  - distributed with this code, or at http://mpas-dev.github.com/license.html
+  -->
+
+

--- a/licenses/_headers/header-html-full
+++ b/licenses/_headers/header-html-full
@@ -1,0 +1,43 @@
+<!--
+  - Copyright (c) 2017,  Los Alamos National Security, LLC (LANS) (Ocean: LA-CC-13-047;
+  - Land Ice: LA-CC-13-117) and the University Corporation for Atmospheric Research (UCAR).
+  -
+  - All rights reserved.
+  -
+  - LANS is the operator of the Los Alamos National Laboratory under Contract No.
+  - DE-AC52-06NA25396 with the U.S. Department of Energy.  UCAR manages the National
+  - Center for Atmospheric Research under Cooperative Agreement ATM-0753581 with the
+  - National Science Foundation.  The U.S. Government has rights to use, reproduce,
+  - and distribute this software.  NO WARRANTY, EXPRESS OR IMPLIED IS OFFERED BY
+  - LANS, UCAR OR THE GOVERNMENT AND NONE OF THEM ASSUME ANY LIABILITY FOR THE USE
+  - OF THIS SOFTWARE.  If software is modified to produce derivative works, such
+  - modified software should be clearly marked, so as not to confuse it with the
+  - version available from LANS and UCAR.
+  -
+  - Additionally, redistribution and use in source and binary forms, with or without
+  - modification, are permitted provided that the following conditions are met:
+  -
+  - 1) Redistributions of source code must retain the above copyright notice, this
+  - list of conditions and the following disclaimer.
+  -
+  - 2) Redistributions in binary form must reproduce the above copyright notice,
+  - this list of conditions and the following disclaimer in the documentation and/or
+  - other materials provided with the distribution.
+  -
+  - 3) None of the names of LANS, UCAR or the names of its contributors, if any, may
+  - be used to endorse or promote products derived from this software without
+  - specific prior written permission.
+  -
+  - THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  - ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  - WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  - DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+  - ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  - (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  - LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  - ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  - (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  - SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+

--- a/licenses/_headers/header-ncl
+++ b/licenses/_headers/header-ncl
@@ -1,0 +1,7 @@
+; Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+; and the University Corporation for Atmospheric Research (UCAR).
+;
+; Unless noted otherwise source code is licensed under the BSD license.
+; Additional copyright and license information can be found in the LICENSE file
+; distributed with this code, or at http://mpas-dev.github.com/license.html
+;

--- a/licenses/_headers/header-ncl-full
+++ b/licenses/_headers/header-ncl-full
@@ -1,0 +1,39 @@
+; Copyright (c) 2017,  Los Alamos National Security, LLC (LANS) (Ocean: LA-CC-13-047;
+; Land Ice: LA-CC-13-117) and the University Corporation for Atmospheric Research (UCAR).
+;
+; All rights reserved.
+;
+; LANS is the operator of the Los Alamos National Laboratory under Contract No.
+; DE-AC52-06NA25396 with the U.S. Department of Energy.  UCAR manages the National
+; Center for Atmospheric Research under Cooperative Agreement ATM-0753581 with the
+; National Science Foundation.  The U.S. Government has rights to use, reproduce,
+; and distribute this software.  NO WARRANTY, EXPRESS OR IMPLIED IS OFFERED BY
+; LANS, UCAR OR THE GOVERNMENT AND NONE OF THEM ASSUME ANY LIABILITY FOR THE USE
+; OF THIS SOFTWARE.  If software is modified to produce derivative works, such
+; modified software should be clearly marked, so as not to confuse it with the
+; version available from LANS and UCAR.
+;
+; Additionally, redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions are met:
+;
+; 1) Redistributions of source code must retain the above copyright notice, this
+; list of conditions and the following disclaimer.
+;
+; 2) Redistributions in binary form must reproduce the above copyright notice,
+; this list of conditions and the following disclaimer in the documentation and/or
+; other materials provided with the distribution.
+;
+; 3) None of the names of LANS, UCAR or the names of its contributors, if any, may
+; be used to endorse or promote products derived from this software without
+; specific prior written permission.
+;
+; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+; ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+; ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+; (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+; ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/_headers/header-py
+++ b/licenses/_headers/header-py
@@ -1,0 +1,7 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#

--- a/licenses/_headers/header-py-full
+++ b/licenses/_headers/header-py-full
@@ -1,0 +1,39 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS) (Ocean: LA-CC-13-047;
+# Land Ice: LA-CC-13-117) and the University Corporation for Atmospheric Research (UCAR).
+#
+# All rights reserved.
+#
+# LANS is the operator of the Los Alamos National Laboratory under Contract No.
+# DE-AC52-06NA25396 with the U.S. Department of Energy.  UCAR manages the National
+# Center for Atmospheric Research under Cooperative Agreement ATM-0753581 with the
+# National Science Foundation.  The U.S. Government has rights to use, reproduce,
+# and distribute this software.  NO WARRANTY, EXPRESS OR IMPLIED IS OFFERED BY
+# LANS, UCAR OR THE GOVERNMENT AND NONE OF THEM ASSUME ANY LIABILITY FOR THE USE
+# OF THIS SOFTWARE.  If software is modified to produce derivative works, such
+# modified software should be clearly marked, so as not to confuse it with the
+# version available from LANS and UCAR.
+#
+# Additionally, redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1) Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2) Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# 3) None of the names of LANS, UCAR or the names of its contributors, if any, may
+# be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/_headers/license-bump-copyright.sh
+++ b/licenses/_headers/license-bump-copyright.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2017, UT-BATTELLE, LLC
+# All rights reserved.
+#
+# This software is released under the BSD license detailed
+# in the file licenses/A-PRIME_LICENSE
+#
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
+# Get the source dir and ignore variables
+source license-setup.sh
+
+OLD="Copyright (c) 2015,2016, UT"
+NEW="Copyright (c) 2017, UT"
+
+ALWAYS_IGNORE=(-not -path "*.git*" -not -path "*docs/*")
+FILE_IGNORE=(-not -iname "*.md" -not -iname "*.json" -not -iname "*.txt" \
+             -not -iname "*.png" -not -iname "*.jpg" -not -iname "*.svg" )
+
+echo "--------------------------------------------------------------------------------"
+echo "    THESE FILES HAVE AN OUTDATED LICENSE HEADER:"
+echo "--------------------------------------------------------------------------------"
+find $SOURCE_DIR -type f "${ALWAYS_IGNORE[@]}" \
+    "${FILE_IGNORE[@]}" \
+    | xargs grep -l "$OLD" \
+    | sort
+
+find ${SOURCE_DIR}/docs -type f \
+    -not -path "*_build*" \
+    -not -path "*source*" \
+    "${FILE_IGNORE[@]}" \
+    | xargs grep -l "$OLD" \
+    | sort
+
+
+echo "--------------------------------------------------------------------------------"
+echo "    UPDATING THE LICENSE HEADERS:"
+echo "--------------------------------------------------------------------------------"
+find $SOURCE_DIR -type f "${ALWAYS_IGNORE[@]}" \
+    "${FILE_IGNORE[@]}" \
+    | xargs grep -l "$OLD" \
+    | sort \
+    | while read SRC
+do
+    echo "Bumping $SRC"
+    sed -i "s/$OLD/$NEW/g" $SRC
+done
+
+
+find ${SOURCE_DIR}/docs -type f \
+    -not -path "*_build*" \
+    -not -path "*source*" \
+    "${FILE_IGNORE[@]}" \
+    | xargs grep -l "$OLD" \
+    | sort \
+    | while read SRC
+do
+    echo "Bumping $SRC"
+    sed -i "s/$OLD/$NEW/g" $SRC
+done

--- a/licenses/_headers/license-find-missing.sh
+++ b/licenses/_headers/license-find-missing.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2017, UT-BATTELLE, LLC
+# All rights reserved.
+#
+# This software is released under the BSD license detailed
+# in the file licenses/A-PRIME_LICENSE
+#
+# Get the source dir and ignore variables
+source license-setup.sh
+
+echo "--------------------------------------------------------------------------------"
+echo "    THESE FILES ARE MISSING A CURRENT LICENSE HEADER:"
+echo "--------------------------------------------------------------------------------"
+find $SOURCE_DIR -type f "${ALWAYS_IGNORE[@]}" \
+    "${FILE_IGNORE[@]}" \
+    "${PYTHON_IGNORE[@]}" \
+    "${CSS_IGNORE[@]}" \
+    | xargs grep -L "$CURRENT" \
+    | sort
+

--- a/licenses/_headers/license-prepend-missing.sh
+++ b/licenses/_headers/license-prepend-missing.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2017, UT-BATTELLE, LLC
+# All rights reserved.
+#
+# This software is released under the BSD license detailed
+# in the file licenses/A-PRIME_LICENSE
+#
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
+# Get the source dir and ignore variables
+source license-setup.sh
+
+echo "--------------------------------------------------------------------------------"
+echo "    PREPENDING A LICENSE HEADER ONTO THESE FILES:"
+echo "--------------------------------------------------------------------------------"
+find $SOURCE_DIR -type f "${ALWAYS_IGNORE[@]}" \
+    "${FILE_IGNORE[@]}" \
+    "${PYTHON_IGNORE[@]}" \
+    "${CSS_IGNORE[@]}" \
+    | xargs grep -L "$CURRENT" \
+    | sort
+
+echo "--------------------------------------------------------------------------------"
+echo "    BEGIN PREPENDING:"
+echo "--------------------------------------------------------------------------------"
+############################################################
+# Prepend license header to python files without a shebang.
+# Will ignore files with a current license header.
+############################################################
+GET=( -iname "*.py" )
+
+find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
+    | xargs grep -L "#!" \
+    | xargs grep -L "$CURRENT" \
+    | while read SRC
+do
+    BN=`basename ${SRC}`
+    echo HEADING ${SRC}
+    cp header-py /tmp/licHead
+    cat ${SRC} >> /tmp/licHead
+    chmod --reference=${SRC} /tmp/licHead
+    mv /tmp/licHead ${SRC}
+done
+
+#######################################################################
+# Prepend license header to python, bash, and sh files with a shebang.
+# Will ignore files with a current license header.
+#######################################################################
+GET=( -iname "*.py" -or -iname "*.sh" -or -iname "*.bash" -or -iname "*.csh" -or -iname "*.pbs")
+
+find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
+    | xargs grep -l --max-count=1 "#!" \
+    | xargs grep -L "$CURRENT" \
+    | while read SRC
+do
+    BN=`basename ${SRC}`
+    echo HEADING ${SRC}
+    cat ${SRC} | head -1 > /tmp/licHead
+    cat header-py >> /tmp/licHead
+    cat ${SRC} | tail -n +2 >> /tmp/licHead
+    chmod --reference=${SRC} /tmp/licHead
+    mv /tmp/licHead ${SRC}
+done
+
+
+####################################################
+# Prepend license header to html files.
+# Will ignore files with a current license header.
+####################################################
+GET=( -iname "*.html")
+
+find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" \
+    | xargs grep -L "$CURRENT" \
+    | while read SRC
+do
+    BN=`basename ${SRC}`
+    echo HEADING ${SRC}
+    cp header-html /tmp/licHead
+    cat ${SRC} >> /tmp/licHead
+    chmod --reference=${SRC} /tmp/licHead
+    mv /tmp/licHead ${SRC}
+done
+
+####################################################
+# Prepend license header to css and js files.
+# Will ignore files with a current license header.
+####################################################
+GET=( -iname "*.css" -or -iname "*.js" )
+
+find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${CSS_IGNORE[@]}" \
+    | xargs grep -L "$CURRENT" \
+    | while read SRC
+do
+    BN=`basename ${SRC}`
+    echo HEADING ${SRC}
+    cp header-css /tmp/licHead
+    cat ${SRC} >> /tmp/licHead
+    chmod --reference=${SRC} /tmp/licHead
+    mv /tmp/licHead ${SRC}
+done
+
+echo "--------------------------------------------------------------------------------"
+echo "    DONE PREPENDING!"
+echo "--------------------------------------------------------------------------------"
+

--- a/licenses/_headers/license-setup.sh
+++ b/licenses/_headers/license-setup.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2017, UT-BATTELLE, LLC
+# All rights reserved.
+#
+# This software is released under the BSD license detailed
+# in the file licenses/A-PRIME_LICENSE
+#
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+
+SOURCE_DIR="../.."
+
+CURRENT="Copyright (c)"
+
+ALWAYS_IGNORE=(-not -path "*.git*" -not -path "*docs/*" -not -path "build/*" \
+               -not -path "dist/*" -not -path "*.egg-info/*" \
+               -not -path "licenses/*" )
+
+FILE_IGNORE=(-not -iname "*.md" -not -iname "*.json" -not -iname "*.txt" \
+             -not -iname "*.png" -not -iname "*.jpg" -not -iname "*.svg" \
+             -not -iname "config.*" -not -iname "*.nc"\
+             -not -iname "*.pyc" \
+             -not -iname "*.sl" -not -iname "*.ps1" -not -iname "*.yml"    )
+
+PYTHON_IGNORE=(-not -iname "__init__.py")

--- a/mpas_analysis/analysis_task_template.py
+++ b/mpas_analysis/analysis_task_template.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 '''
 This is an example analysis task to be used as a template for new tasks.
 It should be copied into one of the component folders (`ocean`, `sea_ice`,

--- a/mpas_analysis/configuration/mpas_analysis_config_parser.py
+++ b/mpas_analysis/configuration/mpas_analysis_config_parser.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 A configuratin parser class for MPAS analysis.  MpasAnalysisConfigParser adds
 the capabilities to get an option including a default value

--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 

--- a/mpas_analysis/ocean/climatology_map_mld.py
+++ b/mpas_analysis/ocean/climatology_map_mld.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 

--- a/mpas_analysis/ocean/climatology_map_sose.py
+++ b/mpas_analysis/ocean/climatology_map_sose.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 '''
 Analysis tasks for comparing Antarctic climatology maps against observations
 and reanalysis data.

--- a/mpas_analysis/ocean/climatology_map_ssh.py
+++ b/mpas_analysis/ocean/climatology_map_ssh.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 

--- a/mpas_analysis/ocean/climatology_map_sss.py
+++ b/mpas_analysis/ocean/climatology_map_sss.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 

--- a/mpas_analysis/ocean/climatology_map_sst.py
+++ b/mpas_analysis/ocean/climatology_map_sst.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 

--- a/mpas_analysis/ocean/compute_anomaly_subtask.py
+++ b/mpas_analysis/ocean/compute_anomaly_subtask.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/ocean/plot_climatology_map_subtask.py
+++ b/mpas_analysis/ocean/plot_climatology_map_subtask.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 An analysis subtasks for plotting comparison of 2D model fields against
 observations.

--- a/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
+++ b/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \

--- a/mpas_analysis/ocean/plot_hovmoller_subtask.py
+++ b/mpas_analysis/ocean/plot_hovmoller_subtask.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \

--- a/mpas_analysis/ocean/remap_depth_slices_subtask.py
+++ b/mpas_analysis/ocean/remap_depth_slices_subtask.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 

--- a/mpas_analysis/ocean/time_series_ohc_anomaly.py
+++ b/mpas_analysis/ocean/time_series_ohc_anomaly.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \

--- a/mpas_analysis/ocean/time_series_salinity_anomaly.py
+++ b/mpas_analysis/ocean/time_series_salinity_anomaly.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/ocean/time_series_temperature_anomaly.py
+++ b/mpas_analysis/ocean/time_series_temperature_anomaly.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \

--- a/mpas_analysis/ocean/utility.py
+++ b/mpas_analysis/ocean/utility.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 A utility for computing common ocean fields (e.g. zMid) from datasets
 

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/sea_ice/plot_climatology_map_subtask.py
+++ b/mpas_analysis/sea_ice/plot_climatology_map_subtask.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 '''
 Defines the base class for analysis tasks.
 

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Functions for creating climatologies from monthly time series data
 

--- a/mpas_analysis/shared/climatology/comparison_descriptors.py
+++ b/mpas_analysis/shared/climatology/comparison_descriptors.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Functions for creating climatologies from monthly time series data
 

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/shared/climatology/remap_observed_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_observed_climatology_subtask.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 

--- a/mpas_analysis/shared/constants/constants.py
+++ b/mpas_analysis/shared/constants/constants.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Constants that are common to all analysis tasks
 

--- a/mpas_analysis/shared/containers.py
+++ b/mpas_analysis/shared/containers.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
     Module of custom container data types
 

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Utility functions for importing MPAS files into xarray. These functions extend
 the capabilities of mpas_xarray to include mapping variable names from MPAS

--- a/mpas_analysis/shared/grid/grid.py
+++ b/mpas_analysis/shared/grid/grid.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 '''
 Classes for describing meshes and grids , including creating SCRIP files,
 used to create mapping files

--- a/mpas_analysis/shared/html/image_xml.py
+++ b/mpas_analysis/shared/html/image_xml.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/shared/html/templates/component_gallery.html
+++ b/mpas_analysis/shared/html/templates/component_gallery.html
@@ -1,3 +1,13 @@
+<!--
+  - Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+  - and the University Corporation for Atmospheric Research (UCAR).
+  -
+  - Unless noted otherwise source code is licensed under the BSD license.
+  - Additional copyright and license information can be found in the LICENSE file
+  - distributed with this code, or at http://mpas-dev.github.com/license.html
+  -->
+
+
 @galleryTitle
 
     <div class="image-gallery" itemscope itemtype="http://schema.org/ImageGallery">

--- a/mpas_analysis/shared/html/templates/component_group.html
+++ b/mpas_analysis/shared/html/templates/component_group.html
@@ -1,3 +1,13 @@
+<!--
+  - Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+  - and the University Corporation for Atmospheric Research (UCAR).
+  -
+  - Unless noted otherwise source code is licensed under the BSD license.
+  - Additional copyright and license information can be found in the LICENSE file
+  - distributed with this code, or at http://mpas-dev.github.com/license.html
+  -->
+
+
     <div class="gallery-title">
       <h2><a name="@analysisGroupLink"></a>@analysisGroupName</h2>
 @groupSubtitle

--- a/mpas_analysis/shared/html/templates/component_image.html
+++ b/mpas_analysis/shared/html/templates/component_image.html
@@ -1,3 +1,13 @@
+<!--
+  - Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+  - and the University Corporation for Atmospheric Research (UCAR).
+  -
+  - Unless noted otherwise source code is licensed under the BSD license.
+  - Additional copyright and license information can be found in the LICENSE file
+  - distributed with this code, or at http://mpas-dev.github.com/license.html
+  -->
+
+
       <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
         <a href="@imageFileName" itemprop="contentUrl" data-size="@imageSize">
             <img class="@orientation" src="thumbnails/@imageFileName" itemprop="thumbnail" alt="@imageDescription" />

--- a/mpas_analysis/shared/html/templates/component_quicklink.html
+++ b/mpas_analysis/shared/html/templates/component_quicklink.html
@@ -1,3 +1,13 @@
+<!--
+  - Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+  - and the University Corporation for Atmospheric Research (UCAR).
+  -
+  - Unless noted otherwise source code is licensed under the BSD license.
+  - Additional copyright and license information can be found in the LICENSE file
+  - distributed with this code, or at http://mpas-dev.github.com/license.html
+  -->
+
+
     <div class="gallery-link small">
       <a href="#@analysisGroupLink">
         <img class="small" src="thumbnails/fixed_@imageFileName" alt="@analysisGroupName">

--- a/mpas_analysis/shared/html/templates/component_subtitle.html
+++ b/mpas_analysis/shared/html/templates/component_subtitle.html
@@ -1,1 +1,11 @@
+<!--
+  - Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+  - and the University Corporation for Atmospheric Research (UCAR).
+  -
+  - Unless noted otherwise source code is licensed under the BSD license.
+  - Additional copyright and license information can be found in the LICENSE file
+  - distributed with this code, or at http://mpas-dev.github.com/license.html
+  -->
+
+
       <h3>@subtitle</h3>

--- a/mpas_analysis/shared/html/templates/index.js
+++ b/mpas_analysis/shared/html/templates/index.js
@@ -1,3 +1,13 @@
+/*
+/ Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+/ and the University Corporation for Atmospheric Research (UCAR).
+/
+/ Unless noted otherwise source code is licensed under the BSD license.
+/ Additional copyright and license information can be found in the LICENSE file
+/ distributed with this code, or at http://mpas-dev.github.com/license.html
+/ */
+
+
 var initPhotoSwipeFromDOM = function(gallerySelector) {
 
     // parse slide data (url, title, size ...) from DOM elements

--- a/mpas_analysis/shared/html/templates/main_component.html
+++ b/mpas_analysis/shared/html/templates/main_component.html
@@ -1,3 +1,13 @@
+<!--
+  - Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+  - and the University Corporation for Atmospheric Research (UCAR).
+  -
+  - Unless noted otherwise source code is licensed under the BSD license.
+  - Additional copyright and license information can be found in the LICENSE file
+  - distributed with this code, or at http://mpas-dev.github.com/license.html
+  -->
+
+
     <div class="gallery-link component">
       <a target="_blank" href="@componentDir/index.html">
         <img class="component" src="@componentDir/thumbnails/fixed_@firstImage" alt="@componentName Analysis">

--- a/mpas_analysis/shared/html/templates/main_page.html
+++ b/mpas_analysis/shared/html/templates/main_page.html
@@ -1,3 +1,13 @@
+<!--
+  - Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+  - and the University Corporation for Atmospheric Research (UCAR).
+  -
+  - Unless noted otherwise source code is licensed under the BSD license.
+  - Additional copyright and license information can be found in the LICENSE file
+  - distributed with this code, or at http://mpas-dev.github.com/license.html
+  -->
+
+
 <!DOCTYPE html>
 <html >
 <head>

--- a/mpas_analysis/shared/html/templates/style.css
+++ b/mpas_analysis/shared/html/templates/style.css
@@ -1,3 +1,13 @@
+/*
+/ Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+/ and the University Corporation for Atmospheric Research (UCAR).
+/
+/ Unless noted otherwise source code is licensed under the BSD license.
+/ Additional copyright and license information can be found in the LICENSE file
+/ distributed with this code, or at http://mpas-dev.github.com/license.html
+/ */
+
+
 body {
     background:#EEE;
     font-family:"myriad-pro","Myriad Pro","Helvetica Neue",Helvetica,Arial,sans-serif;

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 '''
 Functions for performing interpolation
 

--- a/mpas_analysis/shared/io/mpas_reader.py
+++ b/mpas_analysis/shared/io/mpas_reader.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Utility functions for reading a single MPAS file into xarray and for removing
 all but a given list of variables from a data set.

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Module of classes/routines to manipulate fortran namelist and streams
 files.

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 IO utility functions
 

--- a/mpas_analysis/shared/io/write_netcdf.py
+++ b/mpas_analysis/shared/io/write_netcdf.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Plotting utilities, including routines for plotting:
     * time series (and comparing with reference data sets)

--- a/mpas_analysis/shared/time_series/anomaly.py
+++ b/mpas_analysis/shared/time_series/anomaly.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \

--- a/mpas_analysis/shared/time_series/moving_average.py
+++ b/mpas_analysis/shared/time_series/moving_average.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 # -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Utility functions related to time-series data sets
 

--- a/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
+++ b/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Time keeping utility functions
 

--- a/mpas_analysis/test/test_analysis_task.py
+++ b/mpas_analysis/test/test_analysis_task.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit tests for utility functions in run_mpas_analysis
 

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit test infrastructure for climatologies.
 

--- a/mpas_analysis/test/test_generalized_reader.py
+++ b/mpas_analysis/test/test_generalized_reader.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit test infrastructure for the generalized_reader.
 

--- a/mpas_analysis/test/test_interpolate.py
+++ b/mpas_analysis/test/test_interpolate.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 '''
 Unit test infrastructure for horizontal interpolation.
 

--- a/mpas_analysis/test/test_io_utility.py
+++ b/mpas_analysis/test/test_io_utility.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit test infrastructure, adapted from approach of xarray.
 

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit test infrastructure for MpasClimatologyTask.
 

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit test infrastructure for MpasAnalysisConfigParser
 

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit test infrastructure for mpas_xarray.
 

--- a/mpas_analysis/test/test_namelist_streams_interface.py
+++ b/mpas_analysis/test/test_namelist_streams_interface.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit test infrastructure for namelist and streams readers, adapted from
 approach of xarray.

--- a/mpas_analysis/test/test_open_mpas_dataset.py
+++ b/mpas_analysis/test/test_open_mpas_dataset.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit test infrastructure for the generalized_reader.
 

--- a/mpas_analysis/test/test_remap_obs_clim_subtask.py
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit test infrastructure for MpasClimatologyTask.
 

--- a/mpas_analysis/test/test_remap_obs_clim_subtask/remap_mld_obs.py
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask/remap_mld_obs.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 import numpy
 
 from mpas_analysis.shared.interpolation import Remapper

--- a/mpas_analysis/test/test_timekeeping.py
+++ b/mpas_analysis/test/test_timekeeping.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 """
 Unit test infrastructure for the Date class
 

--- a/preprocess_masks/make_ice_shelf_masks.py
+++ b/preprocess_masks/make_ice_shelf_masks.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 '''
 Make a mask file for a given mesh from ice-shelf geometric features.

--- a/preprocess_observations/mds.py
+++ b/preprocess_observations/mds.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 import sys
 import re
 import glob

--- a/preprocess_observations/remap_SOSE_T_S.py
+++ b/preprocess_observations/remap_SOSE_T_S.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 import numpy
 import xarray
 import matplotlib.pyplot as plt

--- a/preprocess_observations/remap_rignot.py
+++ b/preprocess_observations/remap_rignot.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 import numpy
 import xarray
 import matplotlib.pyplot as plt

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[wheel]
+universal = 1
+
+[tool:pytest]
+python_files=test_*.py

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 from setuptools import setup, find_packages
 import warnings

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+import warnings
+
+isrelease = True
+
+version = '0.7.0'
+
+if not isrelease:
+    import subprocess
+    try:
+        pipe = subprocess.Popen(
+            ["git", "describe", "--always", "--match", "v[0-9]*"],
+            stdout=subprocess.PIPE)
+        (version, stderr) = pipe.communicate()
+    except:
+        warnings.warn("WARNING: Couldn't get git revision, using generic "
+                      "version string")
+
+setup(name='mpas_analysis',
+      version=version,
+      description='Analysis for Model for Prediction Across Scales (MPAS) '
+                  'simulations.',
+      url='https://github.com/MPAS-Dev/MPAS-Analysis',
+      author='MPAS-Analysis Developers',
+      author_email='mpas-developers@googlegroups.com',
+      license='BSD',
+      classifiers=[
+          'Development Status :: 3 - Alpha',
+          'License :: OSI Approved :: BSD License',
+          'Operating System :: OS Independent',
+          'Intended Audience :: Science/Research',
+          'Programming Language :: Python',
+          'Programming Language :: Python :: 2',
+          'Programming Language :: Python :: 2.7',
+          'Topic :: Scientific/Engineering',
+      ],
+      packages=find_packages(),
+      package_data={'mpas_analysis': ['config.default'],
+                    'mpas_analysis.shared.html': ['templates/*'],
+                    'mpas_analysis.test': ['test*/*', 'test*/*/*']},
+      install_requires=['numpy', 'scipy', 'matplotlib', 'netCDF4', 'xarray',
+                        'dask', 'bottleneck', 'basemap', 'lxml', 'nco',
+                        ' pyproj', 'pillow'],
+      scripts=['run_mpas_analysis'])

--- a/utility_scripts/make_mpas_to_lat_lon_mapping.py
+++ b/utility_scripts/make_mpas_to_lat_lon_mapping.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 '''
 Creates a mapping file that can be used with ncremap (NCO) to remap MPAS files


### PR DESCRIPTION
A new script, `setup.py` has been added for installing mpas_analysis as a package.

In order to be able to locate `config.default` after the package has been installed, it was necessary to move this file into `mpas_analysis`.  I have updated the README and `run_analysis.py` accordingly.