### PR TITLE
Update LANL configs, add new config for ACME B case with land-ice cavities

### DIFF
--- a/configs/lanl/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
+++ b/configs/lanl/config.20161117.beta0.A_WCYCL1850S.ne30_oEC_ICG.edison
@@ -66,6 +66,13 @@ startYear = 2
 # the last year over which to average climatalogies
 endYear = 3
 
+# The names of the mapping file used for interpolation.  If a mapping file has
+# already been generated, supplying the absolute path can save the time of
+# generating a new one.  If nothing is supplied, the file name is automatically
+# generated based on the MPAS mesh name, the comparison grid resolution, and
+# the interpolation method
+mpasMappingFile = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/mapping/map_oEC60to30_TO_0.5x0.5degree_blin.160412.nc
+
 [timeSeries]
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
@@ -124,4 +131,4 @@ polarPlot = False
 ## circulation (MOC)
 
 # Mask file for ocean basin regional computation
-regionMaskFiles = /usr/projects/climate/mpeterse/analysis_input_files/EC60to30v1/EC60to30v1_SingleRegionAtlanticWTransportTransects_masks.nc
+regionMaskFiles = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/region_masks/EC60to30v1_SingleRegionAtlantic_new_transect_masks.nc

--- a/configs/lanl/config.20170106.B-EC60to30wLI_with_double_count.wolf
+++ b/configs/lanl/config.20170106.B-EC60to30wLI_with_double_count.wolf
@@ -1,0 +1,128 @@
+[runs]
+## options related to the run to be analyzed and reference runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = 20170106.B-EC60to30wLI_with_double_count
+# preprocessedReferenceRunName is the name of a reference run that has been
+# preprocessed to compare against (or None to turn off comparison).  Reference
+# runs of this type would have preprocessed results because they were not
+# performed with MPAS components (so they cannot be easily ingested by
+# MPAS-Analysis)
+preprocessedReferenceRunName = B1850C5_ne30_v0.4
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /lustre/scratch2/turquoise/jer/ACME/cases/B_build_double_counting/run
+
+# names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
+mpasMeshName = EC60to30wLI
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+baseDirectory = /dir/to/analysis/output
+
+# a list of analyses to generate.  Valid names are:
+#   'timeSeriesOHC', 'timeSeriesSST', 'regriddedSST',
+#   'regriddedSSS', 'regriddedMLD', 'timeSeriesSeaIceAreaVol',
+#   'regriddedSeaIceConcThick'
+# the following shortcuts exist:
+#   'all' -- all analyses will be run
+#   'all_timeSeries' -- all time-series analyses will be run
+#   'all_regriddedHorizontal' -- all analyses involving regridded horizontal
+#                                fields will be run
+#   'all_ocean' -- all ocean analyses will be run
+#   'all_seaIce' -- all sea-ice analyses will be run
+#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
+#                             other analyses).
+#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
+#                                            given category of analysis
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    ./run_analysis.py config.analysis --generate \
+#         all,no_ocean,all_timeSeries
+generate = ['all']
+
+# alternative examples that would perform all analysis except
+#   'timeSeriesOHC'
+#generate = ['timeSeriesSST', 'all_regriddedHorizontal', 'all_seaIce']
+#generate = ['all', 'no_timeSeriesOHC']
+# Each subsequent list entry can be used to alter previous list entries. For
+# example, the following would produce all analyses except regriddedSST,
+# regriddedSSS and regriddedMLD (albeit not in a very intuitive way):
+#generate = ['all', 'no_ocean', 'all_timeSeries']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 5
+# the last year over which to average climatalogies
+endYear = 10
+
+# The names of the mapping file used for interpolation.  If a mapping file has
+# already been generated, supplying the absolute path can save the time of
+# generating a new one.  If nothing is supplied, the file name is automatically
+# generated based on the MPAS mesh name, the comparison grid resolution, and
+# the interpolation method
+mpasMappingFile = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/mapping/map_oEC60to30wLI_to_0.5x0.5degree_blin.170328.nc
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+startYear = 1
+endYear = 9999
+
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
+[oceanObservations]
+## options related to ocean observations with which the results will be compared
+
+# directory where ocean observations are stored
+baseDirectory = /usr/projects/climate/SHARED_CLIMATE/observations
+
+[oceanPreprocessedReference]
+## options related to preprocessed ocean reference run with which the results
+## will be compared (e.g. a POP, CESM or ACME v0 run)
+
+# directory where ocean reference simulation results are stored
+baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+
+[seaIceObservations]
+## options related to sea ice observations with which the results will be
+## compared
+
+# directory where sea ice observations are stored
+baseDirectory = /usr/projects/climate/SHARED_CLIMATE/observations/SeaIce
+
+[seaIcePreprocessedReference]
+## options related to preprocessed sea ice reference run with which the results
+## will be compared (e.g. a CICE, CESM or ACME v0 run)
+
+# directory where ocean reference simulation results are stored
+baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning 
+## circulation (MOC)
+
+# Mask file for ocean basin regional computation
+regionMaskFiles = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/region_masks/EC60to30wLIv1_SingleRegionAtlantic_new_transect_masks.nc

--- a/configs/lanl/config.20170120.beta0.GMPAS-QU240.wolf
+++ b/configs/lanl/config.20170120.beta0.GMPAS-QU240.wolf
@@ -66,6 +66,13 @@ startYear = 1
 # the last year over which to average climatalogies
 endYear = 3
 
+# The names of the mapping file used for interpolation.  If a mapping file has
+# already been generated, supplying the absolute path can save the time of
+# generating a new one.  If nothing is supplied, the file name is automatically
+# generated based on the MPAS mesh name, the comparison grid resolution, and
+# the interpolation method
+mpasMappingFile = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/mapping/map_QU240_to_0.5x0.5degree_blin.170309.nc
+
 [timeSeries]
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
@@ -118,3 +125,10 @@ baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_
 
 # plot on polar plot
 polarPlot = False
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning 
+## circulation (MOC)
+
+# Mask file for ocean basin regional computation
+regionMaskFiles = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/region_masks/QU240v1_SingleRegionAtlanticWTransportTransects_masks.nc

--- a/mpas_analysis/ocean/meridional_overturning_circulation.py
+++ b/mpas_analysis/ocean/meridional_overturning_circulation.py
@@ -19,6 +19,7 @@ import xarray as xr
 import numpy as np
 import netCDF4
 import os
+import warnings
 
 from ..shared.constants.constants import m3ps_to_Sv, rad_to_deg
 from ..shared.plot.plotting import plot_vertical_section,\
@@ -71,8 +72,15 @@ def moc_streamfunction(config):  # {{{
     namelist, runStreams, historyStreams, calendar, streamMap, \
         variableMap, plotsDirectory = setup_task(config, componentName='ocean')
 
-    timeSeriesStatsMonthlyAnalysisMemberFlag = namelist.get(
-        'config_am_timeseriesstatsmonthly_enable')
+    try:
+        timeSeriesStatsMonthlyAnalysisMemberFlag = namelist.get(
+            'config_am_timeseriesstatsmonthly_enable')
+    except KeyError:
+        warnings.warn('WARNING: namelist option config_am_timeseriesstatsmonthly_enable not found.\n'
+                      'This likely indicates that the simulation you are analyzing was run with an\n'
+                      'older version of MPAS-O that did not support this flag.  Assuming .true.')
+        timeSeriesStatsMonthlyAnalysisMemberFlag = '.true.'
+
     if timeSeriesStatsMonthlyAnalysisMemberFlag == '.false.':
         raise RuntimeError('*** MPAS-Analysis relies on the existence of monthly\n'
                            '*** averaged files: make sure to enable the\n'
@@ -121,7 +129,14 @@ def moc_streamfunction(config):  # {{{
     regionNames = config.getExpression(sectionName, 'regionNames')
 
     # **** Compute MOC ****
-    mocAnalysisMemberFlag = namelist.get('config_am_mocstreamfunction_enable')
+    try:
+        mocAnalysisMemberFlag = namelist.get('config_am_mocstreamfunction_enable')
+    except KeyError:
+        warnings.warn('WARNING: namelist option config_am_mocstreamfunction_enable not found.\n'
+                      'This likely indicates that the simulation you are analyzing was run with an\n'
+                      'older version of MPAS-O that did not support this flag.  Assuming .false.')
+        mocAnalysisMemberFlag = '.false.'
+
     # Check whether MOC Analysis Member is enabled
     if mocAnalysisMemberFlag == '.true.':
         # Add a moc_analisysMember_processing


### PR DESCRIPTION
Add a new config file for the `B-EC60to30wLI_with_double_count` run that @JeremyFyke has been running.

Update the locations of mapping files and Atlantic MOC mask files for 2 other LANL configurations.

Update MOC computations to have a try/except around namelist option checks (which were crashing for older ACME versions such as used in `B-EC60to30wLI_with_double_count`).