### PR TITLE
Add namelist maps

### DIFF
--- a/mpas_analysis/ocean/nino34_index.py
+++ b/mpas_analysis/ocean/nino34_index.py
@@ -61,7 +61,7 @@ def nino34_index(config, streamMap=None, variableMap=None):  # {{{
     field = 'nino'
 
     # perform common setup for the task
-    namelist, runStreams, historyStreams, calendar, streamMap, \
+    namelist, runStreams, historyStreams, calendar, namelistMap, streamMap, \
         variableMap, plotsDirectory = setup_task(config, componentName='ocean')
 
     simulationStartTime = get_simulation_start_time(runStreams)

--- a/mpas_analysis/ocean/ocean_modelvsobs.py
+++ b/mpas_analysis/ocean/ocean_modelvsobs.py
@@ -61,7 +61,7 @@ def ocn_modelvsobs(config, field):
     """
 
     # perform common setup for the task
-    namelist, runStreams, historyStreams, calendar, streamMap, \
+    namelist, runStreams, historyStreams, calendar, namelistMap, streamMap, \
         variableMap, plotsDirectory = setup_task(config, componentName='ocean')
 
     simulationStartTime = get_simulation_start_time(runStreams)

--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -49,7 +49,7 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
         return dsLocal
 
     # perform common setup for the task
-    namelist, runStreams, historyStreams, calendar, streamMap, \
+    namelist, runStreams, historyStreams, calendar, namelistMap, streamMap, \
         variableMap, plotsDirectory = setup_task(config, componentName='ocean')
 
     simulationStartTime = get_simulation_start_time(runStreams)

--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -40,7 +40,7 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
     print '  Load SST data...'
 
     # perform common setup for the task
-    namelist, runStreams, historyStreams, calendar, streamMap, \
+    namelist, runStreams, historyStreams, calendar, namelistMap, streamMap, \
         variableMap, plotsDirectory = setup_task(config, componentName='ocean')
 
     simulationStartTime = get_simulation_start_time(runStreams)

--- a/mpas_analysis/ocean/variable_stream_map.py
+++ b/mpas_analysis/ocean/variable_stream_map.py
@@ -1,5 +1,23 @@
-# mappings of stream names from various MPAS-O versions to those in
-# mpas_analysis
+'''
+Mappings of namelist options, stream names and variable names from various
+MPAS-O versions to those used by mpas_analysis
+
+Authors
+-------
+Xylar Asay-Davis
+
+Last Modified
+-------------
+03/29/2017
+'''
+
+oceanNamelistMap = {
+    'config_am_timeseriesstatsmonthly_enable':
+        ['config_am_timeseriesstatsmonthly_enable',
+         'config_am_timeseriesstats_enable'],
+    'config_am_mocstreamfunction_enable':
+        ['config_am_mocstreamfunction_enable']}
+
 oceanStreamMap = {'timeSeriesStats': ['timeSeriesStatsOutput',
                                       'timeSeriesStatsMonthly',
                                       'timeSeriesStatsMonthlyOutput']}

--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -65,9 +65,9 @@ def seaice_modelvsobs(config, streamMap=None, variableMap=None):
     """
 
     # perform common setup for the task
-    namelist, runStreams, historyStreams, calendar, streamMap, variableMap, \
-        plotsDirectory, simulationStartTime, restartFileName = \
-        setup_sea_ice_task(config)
+    namelist, runStreams, historyStreams, calendar, namelistMap, \
+        streamMap, variableMap, plotsDirectory, simulationStartTime, \
+        restartFileName = setup_sea_ice_task(config)
 
     # get a list of timeSeriesStatsMonthly output files from the streams file,
     # reading only those that are between the start and end dates

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -63,9 +63,9 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
         return dsAreaSum
 
     # perform common setup for the task
-    namelist, runStreams, historyStreams, calendar, streamMap, variableMap, \
-        plotsDirectory, simulationStartTime, restartFileName = \
-        setup_sea_ice_task(config)
+    namelist, runStreams, historyStreams, calendar, namelistMap, \
+        streamMap, variableMap, plotsDirectory, simulationStartTime, \
+        restartFileName = setup_sea_ice_task(config)
 
     # get a list of timeSeriesStatsMonthly output files from the streams file,
     # reading only those that are between the start and end dates

--- a/mpas_analysis/sea_ice/utility.py
+++ b/mpas_analysis/sea_ice/utility.py
@@ -66,7 +66,7 @@ def setup_sea_ice_task(config):  # {{{
     04/03/2017
     '''
     # perform common setup for the task
-    namelist, runStreams, historyStreams, calendar, streamMap, \
+    namelist, runStreams, historyStreams, calendar, namelistMap, streamMap, \
         variableMap, plotsDirectory = setup_task(config,
                                                  componentName='seaIce')
 
@@ -99,8 +99,9 @@ def setup_sea_ice_task(config):  # {{{
                           'at least one restart file for seaice_timeseries '
                           'calculation')
 
-    return namelist, runStreams, historyStreams, calendar, streamMap, \
-        variableMap, plotsDirectory, simulationStartTime, restartFileName
+    return namelist, runStreams, historyStreams, calendar, namelistMap, \
+        streamMap, variableMap, plotsDirectory, simulationStartTime, \
+        restartFileName
     # }}}
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/sea_ice/variable_stream_map.py
+++ b/mpas_analysis/sea_ice/variable_stream_map.py
@@ -1,5 +1,18 @@
-# mappings of stream names from various MPAS-SI versions to those in
-# mpas_analysis
+'''
+Mappings of namelist options, stream names and variable names from various
+MPAS-SeaIce versions to those used by mpas_analysis
+
+Authors
+-------
+Xylar Asay-Davis
+
+Last Modified
+-------------
+03/29/2017
+'''
+
+seaIceNamelistMap = {}
+
 seaIceStreamMap = {'timeSeriesStats': ['timeSeriesStatsMonthlyOutput']}
 
 

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -6,13 +6,15 @@ Xylar Asay-Davis
 Last Modified: 03/23/2017
 '''
 
+import warnings
+
 from .io import NameList, StreamsFile
 from .io.utility import build_config_full_path, make_directories
 
-from ..ocean.variable_stream_map import oceanStreamMap, \
+from ..ocean.variable_stream_map import oceanNamelistMap, oceanStreamMap, \
     oceanVariableMap
 
-from ..sea_ice.variable_stream_map import seaIceStreamMap, \
+from ..sea_ice.variable_stream_map import seaIceNamelistMap, seaIceStreamMap, \
     seaIceVariableMap
 
 
@@ -43,6 +45,10 @@ def setup_task(config, componentName):  # {{{
 
     calendar: {'gregorian', 'gregorian_noleap'}
         The name of the calendars used in the MPAS run
+
+    namelistMap : dict
+        A dictionary of MPAS namelist options that map to their mpas_analysis
+        counterparts.
 
     streamMap : dict
         A dictionary of MPAS stream names that map to their mpas_analysis
@@ -89,16 +95,90 @@ def setup_task(config, componentName):  # {{{
     make_directories(plotsDirectory)
 
     if componentName == 'ocean':
+        namelistMap = oceanNamelistMap
         streamMap = oceanStreamMap
         variableMap = oceanVariableMap
     elif componentName == 'seaIce':
+        namelistMap = seaIceNamelistMap
         streamMap = seaIceStreamMap
         variableMap = seaIceVariableMap
     else:
+        namelistMap = None
         streamMap = None
         variableMap = None
 
-    return namelist, runStreams, historyStreams, calendar, streamMap, \
-        variableMap, plotsDirectory  # }}}
+    return namelist, runStreams, historyStreams, calendar, namelistMap, \
+        streamMap, variableMap, plotsDirectory  # }}}
+
+
+def check_analysis_enabled(namelist, analysisOptionName, namelistMap=None,
+                           default=False, raiseException=True):
+    '''
+    Check to make sure a given analysis is turned on, issuing a warning or
+    raising an exception if not.
+
+    Parameters
+    ----------
+    namelist : NameList object
+        for parsing namelist options
+
+    analysisOptionName : str
+        The name of a boolean namelist option indicating whether the given
+        analysis member is enabled
+
+    namelistMap : dict, optional
+        A dictionary of MPAS namelist options that map to their mpas_analysis
+        counterparts.
+
+    default : bool, optional
+        If no analysis option with the given name can be found, indicates
+        whether the given analysis is assumed to be enabled by default.
+
+    raiseException : bool, optional
+        Whether
+
+    Returns
+    -------
+    enabled : bool
+        Whether the given analysis is enabled
+
+    Raises
+    ------
+    RuntimeError
+        If the given analysis option is not found and ``default`` is not
+        ``True`` or if the analysis option is found and is ``False``.  The
+        exception is only raised if ``raiseException = True``.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    04/01/2017
+    '''
+
+    try:
+        if namelistMap is None:
+            optionName = analysisOptionName
+        else:
+            optionName = namelist.find_option(namelistMap[analysisOptionName])
+        enabled = namelist.getbool(optionName)
+    except ValueError:
+        enabled = default
+        if default:
+            message = 'WARNING: namelist option {} not found.\n' \
+                      'This likely indicates that the simulation you are ' \
+                      'analyzing was run with an\n' \
+                      'older version of MPAS-O that did not support this ' \
+                      'flag.  Assuming enabled.'.format(analysisOptionName)
+            warnings.warn(message)
+
+    if not enabled and raiseException:
+        raise RuntimeError('*** MPAS-Analysis relies on {} = .true.\n'
+                           '*** Make sure to enable this analysis '
+                           'member.'.format(analysisOptionName))
+
+    return enabled
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -9,7 +9,7 @@ Phillip Wolfram, Xylar Asay-Davis
 
 Last modified
 -------------
-02/06/2017
+04/01/2017
 """
 
 from lxml import etree
@@ -103,6 +103,44 @@ class NameList:
             return True
         else:
             return False
+
+    def find_option(self, possibleOptions):
+        """
+        If one (or more) of the names in ``possibleOptions`` is an option in
+        this namelist file, returns the first match.
+
+        Parameters
+        ----------
+        possibleOptions: list of str
+            A list of options to search for
+
+        Returns
+        -------
+        optionName : str
+            The name of an option from possibleOptions occurring in the
+            namelist file
+
+        Raises
+        ------
+        ValueError
+            If no match is found.
+
+        Authors
+        -------
+        Xylar Asay-Davis
+
+        Last modified
+        -------------
+        04/01/2017
+        """
+
+        for optionName in possibleOptions:
+            if optionName in self.nml.keys():
+                return optionName
+
+        raise ValueError('None of the possible options {} found in namelist file {}.'.format(
+            possibleOptions, self.fname))
+
     # }}}
 
 
@@ -295,18 +333,38 @@ class StreamsFile:
 
     def find_stream(self, possibleStreams):
         """
-        If one (or more) of the names in possibleStreams is a stream in this
-        streams file, returns the first match.  If no match is found, raises
-        a ValueError.
+        If one (or more) of the names in ``possibleStreams`` is an stream in
+        this streams file, returns the first match.
 
+        Parameters
+        ----------
+        possibleStreams: list of str
+            A list of streams to search for
+
+        Returns
+        -------
+        streamName : str
+            The name of an stream from possibleOptions occurring in the
+            streams file
+
+        Raises
+        ------
+        ValueError
+            If no match is found.
+
+        Authors
+        -------
         Xylar Asay-Davis
-        Last modified: 12/07/2016
+
+        Last modified
+        -------------
+        04/01/2017
         """
         for streamName in possibleStreams:
             if self.has_stream(streamName):
                 return streamName
 
-        raise ValueError('Stream {} not found in streams file {}.'.format(
-            streamName, self.fname))
+        raise ValueError('None of the possible streams {} found in streams file {}.'.format(
+            possibleStreams, self.fname))
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -200,6 +200,10 @@ if __name__ == "__main__":
                         type=str, nargs='+', help='config file')
     args = parser.parse_args()
 
+    for configFile in args.configFiles:
+        if not os.path.exists(configFile):
+            raise OSError('Config file {} not found.'.format(configFile))
+
     # add config.default to cover default not included in the config files
     # provided on the command line
     defaultConfig = '{}/config.default'.format(


### PR DESCRIPTION
These dictionaries are used to map namelist options between different MPAS versions, analogous to `variableMaps` for variable names and `streamsMaps` for stream names.

Adds a function `check_analysis_enabled` to `analysis_task` that can be used to check if an analysis member is enabled and optionally raise an exception if it is not.