### PR TITLE
Removed preprocessedReferenceRunName from timeseries figure names

### DIFF
--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -214,12 +214,11 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
         xLabel = 'Time [years]'
         yLabel = '[x$10^{22}$ J]'
 
+        figureName = '{}/ohc_{}_{}.png'.format(plotsDirectory,
+                                               regions[regionIndex],
+                                               mainRunName)
+
         if preprocessedReferenceRunName != 'None':
-            figureName = '{}/ohc_{}_{}_{}.png'.format(
-                    plotsDirectory,
-                    regions[regionIndex],
-                    mainRunName,
-                    preprocessedReferenceRunName)
             ohcPreprocessedTotal = dsPreprocessedTimeSlice.ohc_tot
             ohcPreprocessed700m = dsPreprocessedTimeSlice.ohc_700m
             ohcPreprocessed2000m = dsPreprocessedTimeSlice.ohc_2000m
@@ -241,9 +240,6 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
 
         if (not compareWithObservations and
                 preprocessedReferenceRunName == 'None'):
-            figureName = '{}/ohc_{}_{}.png'.format(plotsDirectory,
-                                                   regions[regionIndex],
-                                                   mainRunName)
             timeseries_analysis_plot(config, [ohcTotal, ohc700m, ohc2000m,
                                               ohcBottom],
                                      movingAveragePoints, title,

--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -109,10 +109,11 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
 
         SST = SSTregions[:, regionIndex]
 
+        figureName = '{}/sst_{}_{}.png'.format(plotsDirectory,
+                                               regions[regionIndex],
+                                               mainRunName)
+
         if preprocessedReferenceRunName != 'None':
-            figureName = '{}/sst_{}_{}_{}.png'.format(
-                plotsDirectory, regions[regionIndex], mainRunName,
-                preprocessedReferenceRunName)
             SST_v0 = dsPreprocessedTimeSlice.SST
 
             title = '{}\n {} (b-)'.format(title, preprocessedReferenceRunName)
@@ -123,9 +124,6 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
                                      lineWidths=[1.2, 1.2],
                                      calendar=calendar)
         else:
-            figureName = '{}/sst_{}_{}.png'.format(plotsDirectory,
-                                                   regions[regionIndex],
-                                                   mainRunName)
             timeseries_analysis_plot(config, [SST], movingAveragePoints, title,
                                      xLabel, yLabel, figureName,
                                      lineStyles=['r-'], lineWidths=[1.2],

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -178,32 +178,18 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
 
         xLabel = 'Time [years]'
 
-        if preprocessedReferenceRunName != 'None':
-            figureNameStdNH = '{}/{}NH_{}_{}.png'.format(
-                plotsDirectory, variableName, mainRunName,
-                preprocessedReferenceRunName)
-            figureNameStdSH = '{}/{}SH_{}_{}.png'.format(
-                plotsDirectory, variableName, mainRunName,
-                preprocessedReferenceRunName)
-            figureNamePolarNH = '{}/{}NH_{}_{}_polar.png'.format(
-                plotsDirectory, variableName, mainRunName,
-                preprocessedReferenceRunName)
-            figureNamePolarSH = '{}/{}SH_{}_{}_polar.png'.format(
-                plotsDirectory, variableName, mainRunName,
-                preprocessedReferenceRunName)
-        else:
-            figureNameStdNH = '{}/{}NH_{}.png'.format(plotsDirectory,
-                                                      variableName,
-                                                      mainRunName)
-            figureNameStdSH = '{}/{}SH_{}.png'.format(plotsDirectory,
-                                                      variableName,
-                                                      mainRunName)
-            figureNamePolarNH = '{}/{}NH_{}_polar.png'.format(plotsDirectory,
-                                                              variableName,
-                                                              mainRunName)
-            figureNamePolarSH = '{}/{}SH_{}_polar.png'.format(plotsDirectory,
-                                                              variableName,
-                                                              mainRunName)
+        figureNameStdNH = '{}/{}NH_{}.png'.format(plotsDirectory,
+                                                  variableName,
+                                                  mainRunName)
+        figureNameStdSH = '{}/{}SH_{}.png'.format(plotsDirectory,
+                                                  variableName,
+                                                  mainRunName)
+        figureNamePolarNH = '{}/{}NH_{}_polar.png'.format(plotsDirectory,
+                                                          variableName,
+                                                          mainRunName)
+        figureNamePolarSH = '{}/{}SH_{}_polar.png'.format(plotsDirectory,
+                                                          variableName,
+                                                          mainRunName)
 
         titleNH = '{} (NH), {} (r)'.format(plotTitle, mainRunName)
         titleSH = '{} (SH), {} (r)'.format(plotTitle, mainRunName)


### PR DESCRIPTION
Since data from the preprocessedReferenceRun is not always plotted (depending on whether its temporal range overlaps with that of the mainRun), it is easier to remove the `preprocessedReferenceRun` string from the timeseries file names.
This was the cleanest way to address a problem in ACME PreAndPostProcessing, when the html index file is generated: since the `generate_html` script is independent from the python scripts, it always looks for a certain figure name, no matter what MPAS-Analysis generates. Removing the option of having preprocessedReferenceRun in the filename makes things consistent.