### PR TITLE
Improve chunking capability

### DIFF
--- a/config.default
+++ b/config.default
@@ -356,6 +356,17 @@ regionNames = ['Atlantic']
 # Mask file for post-processing regional MOC computation
 regionMaskFiles = /path/to/MOCregional/mapping/file
 
+# xarray (with dask) divides data sets into "chunks", allowing computations
+# to be made on data that is larger than the available memory.  MPAS-Analysis
+# supports setting a maximum chunk size for data sets generally, and a
+# separate option specific to loading the 3D velocity field in the MOC
+# specifically.  By default, maxChunkSize is left undefined, so that chunking
+# is handled automatically.  If the MOC calculation encounters memory problems,
+# consider setting maxChunkSize to a number significantly lower than nEdges
+# in your MPAS mesh so that the calculation will be divided into smaller
+# pieces.
+# maxChunkSize = 1000
+
 # Size of latitude bins over which MOC streamfunction is integrated
 latBinSizeGlobal = 1.
 latBinSizeAtlantic = 0.5

--- a/configs/edison/config.20161006bugfix.alpha8.A_WCYCL1850S.ne30_oEC_ICG.edison
+++ b/configs/edison/config.20161006bugfix.alpha8.A_WCYCL1850S.ne30_oEC_ICG.edison
@@ -131,6 +131,7 @@ polarPlot = False
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning 
 ## circulation (MOC)
+maxChunkSize = 1000
 
 # Mask file for ocean basin regional computation
 regionMaskFiles = /global/project/projectdirs/acme/mapping/grids/EC60to30v1_SingleRegionAtlanticWTransportTransects_masks.nc

--- a/configs/edison/config.20161117.beta0.A_WCYCL1850.ne30_oEC.edison
+++ b/configs/edison/config.20161117.beta0.A_WCYCL1850.ne30_oEC.edison
@@ -132,6 +132,7 @@ polarPlot = False
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning 
 ## circulation (MOC)
+maxChunkSize = 1000
 
 # Mask file for ocean basin regional computation
 regionMaskFiles = /global/project/projectdirs/acme/mapping/grids/EC60to30v1_SingleRegionAtlanticWTransportTransects_masks.nc

--- a/configs/edison/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -132,6 +132,7 @@ polarPlot = False
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning 
 ## circulation (MOC)
+maxChunkSize = 1000
 
 # Mask file for ocean basin regional computation
 regionMaskFiles = /global/project/projectdirs/acme/mapping/grids/EC60to30v3_SingleRegionAtlanticWTransportTransects_masks.nc

--- a/mpas_analysis/ocean/meridional_overturning_circulation.py
+++ b/mpas_analysis/ocean/meridional_overturning_circulation.py
@@ -157,7 +157,8 @@ def moc_streamfunction(config):  # {{{
         # (mocDictClimo, mocDictTseries) = _compute_moc_analysismember(config,
         #     streams, calendar, sectionName, dictClimo, dictTseries)
     else:
-        _cache_velocity_climatologies(config, startDateClimo, endDateClimo,
+        _cache_velocity_climatologies(config, sectionName,
+                                      startDateClimo, endDateClimo,
                                       inputFilesClimo, simulationStartTime,
                                       variableMap, calendar)
 
@@ -244,7 +245,8 @@ def _load_mesh(runStreams):  # {{{
         refTopDepth, refLayerThickness  # }}}
 
 
-def _cache_velocity_climatologies(config, startDateClimo, endDateClimo,
+def _cache_velocity_climatologies(config, sectionName,
+                                  startDateClimo, endDateClimo,
                                   inputFilesClimo, simulationStartTime,
                                   variableMap, calendar):  # {{{
     '''compute yearly velocity climatologies and cache them'''
@@ -257,6 +259,7 @@ def _cache_velocity_climatologies(config, startDateClimo, endDateClimo,
 
     make_directories(outputDirectory)
 
+    chunking = config.getExpression(sectionName, 'maxChunkSize')
     ds = open_multifile_dataset(fileNames=inputFilesClimo,
                                 calendar=calendar,
                                 config=config,
@@ -265,7 +268,8 @@ def _cache_velocity_climatologies(config, startDateClimo, endDateClimo,
                                 variableList=variableList,
                                 variableMap=variableMap,
                                 startDate=startDateClimo,
-                                endDate=endDateClimo)
+                                endDate=endDateClimo,
+                                chunking=chunking)
 
     # update the start and end year in config based on the real extend of ds
     update_start_end_year(ds, config, calendar)
@@ -451,6 +455,7 @@ def _compute_moc_time_series_postprocess(config, runStreams, variableMap,
     dvEdge, areaCell, refBottomDepth, latCell, nVertLevels, \
         refTopDepth, refLayerThickness = _load_mesh(runStreams)
 
+    chunking = config.getExpression(sectionName, 'maxChunkSize')
     ds = open_multifile_dataset(fileNames=dictTseries['inputFilesTseries'],
                                 calendar=calendar,
                                 config=config,
@@ -459,7 +464,8 @@ def _compute_moc_time_series_postprocess(config, runStreams, variableMap,
                                 variableList=variableList,
                                 variableMap=variableMap,
                                 startDate=dictTseries['startDateTseries'],
-                                endDate=dictTseries['endDateTseries'])
+                                endDate=dictTseries['endDateTseries'],
+                                chunking=chunking)
     latAtlantic = mocDictClimo['latAtlantic']['data']
     dLat = latAtlantic - 26.5
     indlat26 = np.where(dLat == np.amin(np.abs(dLat)))

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -804,16 +804,25 @@ def _compute_masked_mean(ds, maskVaries):
 
     if maskVaries:
         dsWeightedSum = (ds * ds.daysInMonth).sum(dim='Time', keep_attrs=True)
+        dsWeightedSum.compute()
 
         weights = ds_to_weights(ds)
+        weights.compute()
 
         weightSum = (weights * ds.daysInMonth).sum(dim='Time')
+        weightSum.compute()
 
         timeMean = dsWeightedSum / weightSum.where(weightSum > 0.)
+        timeMean.compute()
     else:
         days = ds.daysInMonth.sum(dim='Time')
+        days.compute()
+
         dsWeightedSum = (ds * ds.daysInMonth).sum(dim='Time', keep_attrs=True)
+        dsWeightedSum.compute()
+
         timeMean = dsWeightedSum / days.where(days > 0.)
+        timeMean.compute()
 
     return timeMean
 

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -31,8 +31,16 @@ class TestMPASAnalysisConfigParser(TestCase):
         self.assertEqual(colorMapName, 'coolwarm')
 
         self.assertEqual(self.config.getint('Test', 'testInt'), 15)
-        self.assertEqual(self.config.getfloat('Test', 'testFloat'), 18.)
+        self.assertEqual(self.config.getExpression('Test', 'testInt'), 15)
+
+        self.assertEqual(self.config.getfloat('Test', 'testFloat'), 18.0)
+        self.assertEqual(self.config.getExpression('Test', 'testFloat'), 18.0)
+
+        self.assertEqual(self.config.getfloat('Test', 'testFloat2'), 3.)
+        self.assertEqual(self.config.getExpression('Test', 'testFloat2'), 3.)
+
         self.assertEqual(self.config.getboolean('Test', 'testBool'), True)
+        self.assertEqual(self.config.getExpression('Test', 'testBool'), True)
 
         testList = self.config.getExpression('sst_modelvsobs',
                                              'cmapIndicesModelObs')

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -65,6 +65,9 @@ class TestMPASAnalysisConfigParser(TestCase):
                                     'key2': -12,
                                     'key3': False})
 
+        testNone = self.config.getExpression('Test', 'doesntexist')
+        assert testNone is None
+
     @requires_numpy
     def test_read_config_numpy(self):
         self.setup_config()

--- a/mpas_analysis/test/test_mpas_config_parser/config.analysis
+++ b/mpas_analysis/test/test_mpas_config_parser/config.analysis
@@ -21,6 +21,7 @@ comparisonTimes =  ['JFM', 'JAS', 'ANN']
 testInt = 15
 
 testFloat = 18.0
+testFloat2 = 3.
 
 testBool = True
 


### PR DESCRIPTION
Simplifies chunking capability and allows for chunking to explicitly be defined for
`open_multifile_dataset`.  Defaults to not performing chunking unless specified in a 
particular configuration file for the MOC case.  Note, this sets a chunking parameter for all edison runs for the MOC.