### PR TITLE
Cache progress on all analysis tasks

### DIFF
--- a/config.default
+++ b/config.default
@@ -152,6 +152,11 @@ overwriteMpasClimatology = False
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
 mpasInterpolationMethod = bilinear
 
+# the number of years per cached climatology file.  These cached files are
+# aggregated together to create annual climatologies, for example, when
+# computing the MOC.
+yearsPerCacheFile = 1
+
 [timeSeries]
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs

--- a/mpas_analysis/ocean/nino34_index.py
+++ b/mpas_analysis/ocean/nino34_index.py
@@ -7,13 +7,14 @@ Luke Van Roekel, Xylar Asay-Davis
 
 Last Modified
 -------------
-03/29/2017
+04/08/2017
 """
 
 import xarray as xr
 import pandas as pd
 import numpy as np
 from scipy import signal, stats
+import os
 
 from ..shared.climatology import climatology
 from ..shared.constants import constants
@@ -52,7 +53,7 @@ def nino34_index(config, streamMap=None, variableMap=None):  # {{{
 
     Last Modified
     -------------
-    03/29/2017
+    04/08/2017
     """
 
     print '  Load SST data...'
@@ -69,8 +70,10 @@ def nino34_index(config, streamMap=None, variableMap=None):  # {{{
     streamName = historyStreams.find_stream(streamMap['timeSeriesStats'])
     fileNames = historyStreams.readpath(streamName, startDate=startDate,
                                         endDate=endDate,  calendar=calendar)
-    print 'Reading files {} through {}'.format(fileNames[0], fileNames[-1])
-
+    print '\n  Reading files:\n' \
+          '    {} through\n    {}'.format(
+              os.path.basename(fileNames[0]),
+              os.path.basename(fileNames[-1]))
     mainRunName = config.get('runs', 'mainRunName')
 
     # regionIndex should correspond to NINO34 in surface weighted Average AM
@@ -139,17 +142,18 @@ def compute_nino34_index(regionSST, calendar):  # {{{
 
     Last Modified
     -------------
-    03/30/2017
+    04/08/2017
     """
 
     if not isinstance(regionSST, xr.core.dataarray.DataArray):
         raise ValueError('regionSST should be an xarray DataArray')
 
     # add 'month' data array so we can group by month below.
-    regionSST = climatology.add_months_and_days_in_month(regionSST, calendar)
+    regionSST = climatology.add_years_months_days_in_month(regionSST, calendar)
 
     # Compute monthly average and anomaly of climatology of SST
-    monthlyClimatology = climatology.compute_monthly_climatology(regionSST)
+    monthlyClimatology = \
+        climatology.compute_monthly_climatology(regionSST, maskVaries=False)
 
     anomaly = regionSST.groupby('month') - monthlyClimatology
 

--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -1,5 +1,6 @@
 import numpy as np
 import netCDF4
+import os
 
 from ..shared.plot.plotting import timeseries_analysis_plot
 
@@ -28,7 +29,7 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
     to their mpas_analysis counterparts.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 03/23/2017
+    Last Modified: 04/08/2017
     """
 
     # perform common setup for the task
@@ -71,7 +72,10 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
     streamName = historyStreams.find_stream(streamMap['timeSeriesStats'])
     fileNames = historyStreams.readpath(streamName, startDate=startDate,
                                         endDate=endDate, calendar=calendar)
-    print 'Reading files {} through {}'.format(fileNames[0], fileNames[-1])
+    print '\n  Reading files:\n' \
+          '    {} through\n    {}'.format(
+              os.path.basename(fileNames[0]),
+              os.path.basename(fileNames[-1]))
 
     # Define/read in general variables
     print '  Read in depth and compute specific depth indexes...'

--- a/mpas_analysis/ocean/ohc_timeseries.py
+++ b/mpas_analysis/ocean/ohc_timeseries.py
@@ -14,7 +14,7 @@ from ..shared.analysis_task import setup_task
 
 from ..shared.time_series import time_series
 
-from ..shared.io.utility import build_config_full_path
+from ..shared.io.utility import build_config_full_path, make_directories
 
 
 def ohc_timeseries(config, streamMap=None, variableMap=None):
@@ -74,10 +74,7 @@ def ohc_timeseries(config, streamMap=None, variableMap=None):
     outputDirectory = build_config_full_path(config, 'output',
                                              'timeseriesSubdirectory')
 
-    try:
-        os.makedirs(outputDirectory)
-    except OSError:
-        pass
+    make_directories(outputDirectory)
 
     regionNames = config.getExpression('regions', 'regions')
     regionNames = [regionNames[index] for index in regionIndicesToPlot]

--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -1,3 +1,5 @@
+import os
+
 from ..shared.plot.plotting import timeseries_analysis_plot
 
 from ..shared.generalized_reader.generalized_reader \
@@ -24,7 +26,7 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
     to their mpas_analysis counterparts.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 03/23/2017
+    Last Modified: 04/08/2017
     """
 
     print '  Load SST data...'
@@ -42,7 +44,10 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
     streamName = historyStreams.find_stream(streamMap['timeSeriesStats'])
     fileNames = historyStreams.readpath(streamName, startDate=startDate,
                                         endDate=endDate,  calendar=calendar)
-    print 'Reading files {} through {}'.format(fileNames[0], fileNames[-1])
+    print '\n  Reading files:\n' \
+          '    {} through\n    {}'.format(
+              os.path.basename(fileNames[0]),
+              os.path.basename(fileNames[-1]))
 
     mainRunName = config.get('runs', 'mainRunName')
     preprocessedReferenceRunName = config.get('runs',

--- a/mpas_analysis/ocean/sst_timeseries.py
+++ b/mpas_analysis/ocean/sst_timeseries.py
@@ -12,7 +12,7 @@ from ..shared.analysis_task import setup_task
 
 from ..shared.time_series import time_series
 
-from ..shared.io.utility import build_config_full_path
+from ..shared.io.utility import build_config_full_path, make_directories
 
 
 def sst_timeseries(config, streamMap=None, variableMap=None):
@@ -73,10 +73,7 @@ def sst_timeseries(config, streamMap=None, variableMap=None):
     outputDirectory = build_config_full_path(config, 'output',
                                              'timeseriesSubdirectory')
 
-    try:
-        os.makedirs(outputDirectory)
-    except OSError:
-        pass
+    make_directories(outputDirectory)
 
     regionNames = config.getExpression('regions', 'regions')
     regionNames = [regionNames[index] for index in regionIndicesToPlot]

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -1,4 +1,5 @@
 import xarray as xr
+import os
 
 from ..shared.plot.plotting import timeseries_analysis_plot, \
     timeseries_analysis_plot_polar
@@ -31,7 +32,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
     to their mpas_analysis counterparts.
 
     Author: Xylar Asay-Davis, Milena Veneziani
-    Last Modified: 03/23/2017
+    Last Modified: 04/08/2017
     """
 
     # perform common setup for the task
@@ -46,7 +47,10 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
     streamName = historyStreams.find_stream(streamMap['timeSeriesStats'])
     fileNames = historyStreams.readpath(streamName, startDate=startDate,
                                         endDate=endDate,  calendar=calendar)
-    print 'Reading files {} through {}'.format(fileNames[0], fileNames[-1])
+    print '\n  Reading files:\n' \
+          '    {} through\n    {}'.format(
+              os.path.basename(fileNames[0]),
+              os.path.basename(fileNames[-1]))
 
     variableNames = ['iceAreaCell', 'iceVolumeCell']
 

--- a/mpas_analysis/sea_ice/timeseries.py
+++ b/mpas_analysis/sea_ice/timeseries.py
@@ -4,7 +4,7 @@ import os
 from ..shared.plot.plotting import timeseries_analysis_plot, \
     timeseries_analysis_plot_polar
 
-from ..shared.io.utility import build_config_full_path
+from ..shared.io.utility import build_config_full_path, make_directories
 
 from ..shared.timekeeping.utility import date_to_days, days_to_datetime, \
     datetime_to_days
@@ -119,10 +119,7 @@ def seaice_timeseries(config, streamMap=None, variableMap=None):
     outputDirectory = build_config_full_path(config, 'output',
                                              'timeseriesSubdirectory')
 
-    try:
-        os.makedirs(outputDirectory)
-    except OSError:
-        pass
+    make_directories(outputDirectory)
 
     print '  Load sea-ice data...'
     # Load mesh

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -396,7 +396,9 @@ def compute_monthly_climatology(ds, calendar=None, maskVaries=True):
     maskVaries: bool, optional
         If the mask (where variables in ``ds`` are ``NaN``) varies with time.
         If not, the weighted average does not need make extra effort to account
-        for the mask.
+        for the mask.  Most MPAS fields will have masks that don't vary in
+        time, whereas observations may sometimes be present only at some
+        times and not at others, requiring ``maskVaries = True``.
 
     Returns
     -------
@@ -451,7 +453,9 @@ def compute_climatology(ds, monthValues, calendar=None, maskVaries=True):
     maskVaries: bool, optional
         If the mask (where variables in ``ds`` are ``NaN``) varies with time.
         If not, the weighted average does not need make extra effort to account
-        for the mask.
+        for the mask.  Most MPAS fields will have masks that don't vary in
+        time, whereas observations may sometimes be present only at some
+        times and not at others, requiring ``maskVaries = True``.
 
     Returns
     -------

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -7,7 +7,7 @@ Xylar Asay-Davis
 
 Last Modified
 -------------
-03/04/2017
+04/08/2017
 """
 
 import xarray as xr
@@ -241,6 +241,10 @@ def get_mpas_climatology_file_names(config, fieldName, monthNames):
         The absolute path to a file where the climatology should be stored
         before regridding.
 
+    climatologyPrefix : str
+        The prfix including absolute path for climatology cache files before
+        regridding.
+
     regriddedFileName : str
         The absolute path to a file where the climatology should be stored
         after regridding.
@@ -281,15 +285,17 @@ def get_mpas_climatology_file_names(config, fieldName, monthNames):
     except OSError:
         pass
 
-    climatologyFileName = '{}/{}_{}_{}_years{:04d}-{:04d}.nc'.format(
-        climatologyDirectory, fieldName, meshName, monthNames, startYear,
-        endYear)
+    climatologyPrefix = '{}/{}_{}_{}'.format(climatologyDirectory, fieldName,
+                                             meshName, monthNames)
+    climatologyFileName = '{}_years{:04d}-{:04d}.nc'.format(climatologyPrefix,
+                                                            startYear,
+                                                            endYear)
     regriddedFileName = \
         '{}/{}_{}_to_{}x{}degree_{}_years{:04d}-{:04d}.nc'.format(
             regriddedDirectory, fieldName, meshName, comparisonLatRes,
             comparisonLonRes, monthNames, startYear, endYear)
 
-    return (climatologyFileName, regriddedFileName)
+    return (climatologyFileName, climatologyPrefix, regriddedFileName)
 
 
 def get_observation_climatology_file_names(config, fieldName, monthNames,
@@ -398,63 +404,7 @@ def compute_monthly_climatology(ds, calendar=None, maskVaries=True):
         A data set with a ``Time`` coordinate expressed as days since
         0001-01-01 or ``month`` coordinate
 
-    calendar: ``{'gregorian', 'gregorian_noleap'}``, optional
-        The name of one of the calendars supported by MPAS cores, used to
-        determine ``month`` from ``Time`` coordinate, so must be supplied if
-        ``ds`` does not already have a ``month`` coordinate or data array
-
-    maskVaries: bool, optional
-        If the mask (where variables in ``ds`` are ``NaN``) varies with time.
-        If not, the weighted average does not need make extra effort to account
-        for the mask.
-
-    Returns
-    -------
-    climatology : object of same type as ``ds``
-        A data set without the ``'Time'`` coordinate containing the mean
-        of ds over all months in monthValues, weighted by the number of days
-        in each month.
-
-    Authors
-    -------
-    Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    03/30/2017
-    """
-
-    def compute_one_month_climatology(ds):
-        monthValues = list(ds.month.values)
-        return compute_climatology(ds, monthValues, calendar, maskVaries)
-
-    if 'month' not in ds.coords or 'daysInMonth' not in ds.coords:
-        ds = add_months_and_days_in_month(ds, calendar)
-
-    monthlyClimatology = \
-        ds.groupby('month').apply(compute_one_month_climatology)
-
-    return monthlyClimatology
-
-
-def compute_climatology(ds, monthValues, calendar=None, maskVaries=True):
-    """
-    Compute a monthly, seasonal or annual climatology data set from a data
-    set.  The mean is weighted but the number of days in each month of
-    the data set, ignoring values masked out with NaNs.  If the month
-    coordinate is not present, a data array ``month`` will be added based
-    on ``Time`` and the provided calendar.
-
-    Parameters
-    ----------
-    ds : ``xarray.Dataset`` or ``xarray.DataArray`` object
-        A data set with a ``Time`` coordinate expressed as days since
-        0001-01-01 or ``month`` coordinate
-
-    monthValues : int or array-like of ints
-        A single month or an array of months to be averaged together
-
-    calendar: ``{'gregorian', 'gregorian_noleap'}``, optional
+    calendar : ``{'gregorian', 'gregorian_noleap'}``, optional
         The name of one of the calendars supported by MPAS cores, used to
         determine ``month`` from ``Time`` coordinate, so must be supplied if
         ``ds`` does not already have a ``month`` coordinate or data array
@@ -480,8 +430,62 @@ def compute_climatology(ds, monthValues, calendar=None, maskVaries=True):
     04/08/2017
     """
 
-    if ('month' not in ds.coords or 'daysInMonth' not in ds.coords):
-        ds = add_months_and_days_in_month(ds, calendar)
+    def compute_one_month_climatology(ds):
+        monthValues = list(ds.month.values)
+        return compute_climatology(ds, monthValues, calendar, maskVaries)
+
+    ds = add_years_months_days_in_month(ds, calendar)
+
+    monthlyClimatology = \
+        ds.groupby('month').apply(compute_one_month_climatology)
+
+    return monthlyClimatology
+
+
+def compute_climatology(ds, monthValues, calendar=None, maskVaries=True):
+    """
+    Compute a monthly, seasonal or annual climatology data set from a data
+    set.  The mean is weighted but the number of days in each month of
+    the data set, ignoring values masked out with NaNs.  If the month
+    coordinate is not present, a data array ``month`` will be added based
+    on ``Time`` and the provided calendar.
+
+    Parameters
+    ----------
+    ds : ``xarray.Dataset`` or ``xarray.DataArray`` object
+        A data set with a ``Time`` coordinate expressed as days since
+        0001-01-01 or ``month`` coordinate
+
+    monthValues : int or array-like of ints
+        A single month or an array of months to be averaged together
+
+    calendar : ``{'gregorian', 'gregorian_noleap'}``, optional
+        The name of one of the calendars supported by MPAS cores, used to
+        determine ``month`` from ``Time`` coordinate, so must be supplied if
+        ``ds`` does not already have a ``month`` coordinate or data array
+
+    maskVaries: bool, optional
+        If the mask (where variables in ``ds`` are ``NaN``) varies with time.
+        If not, the weighted average does not need make extra effort to account
+        for the mask.
+
+    Returns
+    -------
+    climatology : object of same type as ``ds``
+        A data set without the ``'Time'`` coordinate containing the mean
+        of ds over all months in monthValues, weighted by the number of days
+        in each month.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    04/08/2017
+    """
+
+    ds = add_years_months_days_in_month(ds, calendar)
 
     mask = xr.zeros_like(ds.month, bool)
 
@@ -493,6 +497,173 @@ def compute_climatology(ds, monthValues, calendar=None, maskVaries=True):
     climatology = _compute_masked_mean(climatologyMonths, maskVaries)
 
     return climatology
+
+
+def cache_climatologies(ds, monthValues, config, cachePrefix, calendar,
+                        printProgress=False):  # {{{
+    '''
+    Cache NetCDF files for each year of an annual climatology, and then use
+    the cached files to compute a climatology for the full range of years.
+    The start and end years of the climatology are taken from ``config``, and
+    are updated in ``config`` if the data set ``ds`` doesn't contain this
+    full range.
+
+    Note: only works with climatologies where the mask (locations of ``NaN``
+    values) doesn't vary with time.
+
+    Parameters
+    ----------
+    ds : ``xarray.Dataset`` or ``xarray.DataArray`` object
+        A data set with a ``Time`` coordinate expressed as days since
+        0001-01-01
+
+    monthValues : int or array-like of ints
+        A single month or an array of months to be averaged together
+
+    config :  instance of MpasAnalysisConfigParser
+        Contains configuration options
+
+    cachePrefix :  str
+        The file prefix (including path) to which the year (or years) will be
+        appended as cache files are stored
+
+    calendar : ``{'gregorian', 'gregorian_noleap'}``
+        The name of one of the calendars supported by MPAS cores, used to
+        determine ``year`` and ``month`` from ``Time`` coordinate
+
+    printProgress: bool, optional
+        Whether progress messages should be printed as the climatology is
+        computed
+
+    Returns
+    -------
+    climatology : object of same type as ``ds``
+        A data set without the ``'Time'`` coordinate containing the mean
+        of ds over all months in monthValues, weighted by the number of days
+        in each month.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    04/08/2017
+    '''
+    startYearClimo = config.getint('climatology', 'startYear')
+    endYearClimo = config.getint('climatology', 'endYear')
+    yearsPerCacheFile = config.getint('climatology', 'yearsPerCacheFile')
+
+    cacheInfo = []
+
+    ds = add_years_months_days_in_month(ds, calendar)
+
+    if printProgress:
+        print '   Computing and caching climatologies covering {}-year ' \
+              'spans...'.format(yearsPerCacheFile)
+
+    cacheIndices = numpy.zeros(ds.dims['Time'], int)
+    yearsInDs = ds.year.values
+
+    # figure out which files to load and which years go in each file
+    for firstYear in range(startYearClimo, endYearClimo+1, yearsPerCacheFile):
+        years = range(firstYear, numpy.minimum(endYearClimo+1,
+                                               firstYear+yearsPerCacheFile))
+        if len(years) == 0:
+            continue
+
+        if yearsPerCacheFile == 1:
+            yearString = '{:04d}'.format(years[0])
+            outputFileClimo = '{}_year{}.nc'.format(cachePrefix, yearString)
+        else:
+            yearString = '{:04d}-{:04d}'.format(years[0], years[-1])
+            outputFileClimo = '{}_years{}.nc'.format(cachePrefix, yearString)
+
+        done = False
+        if os.path.exists(outputFileClimo):
+            # already cached
+            dsCached = xr.open_dataset(outputFileClimo)
+            if dsCached.attrs['totalMonths'] == 12*len(years):
+                # also complete, so we can move on
+                done = True
+
+        cacheIndex = len(cacheInfo)
+        for year in years:
+            cacheIndices[yearsInDs == year] = cacheIndex
+
+        if numpy.count_nonzero(cacheIndices == cacheIndex) == 0:
+            continue
+
+        cacheInfo.append((outputFileClimo, done, years))
+
+    ds = ds.copy()
+    ds.coords['cacheIndices'] = ('Time', cacheIndices)
+
+    # compute and store each cache file
+    for cacheIndex, info in enumerate(cacheInfo):
+        outputFileClimo, done, years = info
+        if done:
+            continue
+        dsYear = ds.where(ds.cacheIndices == cacheIndex, drop=True)
+
+        if printProgress:
+            if yearsPerCacheFile == 1:
+                yearString = '{:04d}'.format(years[0])
+            else:
+                yearString = '{:04d}-{:04d}'.format(years[0], years[-1])
+            print '     {}'.format(yearString)
+
+        totalDays = dsYear.daysInMonth.sum(dim='Time').values
+
+        monthCount = dsYear.dims['Time']
+
+        climatology = compute_climatology(dsYear,  monthValues, calendar,
+                                          maskVaries=False)
+
+        climatology.attrs['totalDays'] = totalDays
+        climatology.attrs['totalMonths'] = monthCount
+
+        climatology.to_netcdf(outputFileClimo)
+
+    # compute the aggregate climatology
+    yearString = '{:04d}-{:04d}'.format(startYearClimo, endYearClimo)
+    outputFileClimo = '{}_years{}.nc'.format(cachePrefix, yearString)
+
+    done = False
+    if os.path.exists(outputFileClimo):
+        climatology = xr.open_dataset(outputFileClimo)
+        if climatology.attrs['totalMonths'] == (endYearClimo-startYearClimo+1)*12:
+            # also complete, so we can move on
+            done = True
+
+    if not done:
+        if printProgress:
+            print '   Computing aggregated climatology {}...'.format(yearString)
+
+        first = True
+        for cacheIndex, info in enumerate(cacheInfo):
+            inFileClimo = info[0]
+            ds = xr.open_dataset(inFileClimo)
+            days = ds.attrs['totalDays']
+            months = ds.attrs['totalMonths']
+            if first:
+                totalDays = days
+                totalMonths = months
+                climatology = ds * days
+                first = False
+            else:
+                totalDays += days
+                totalMonths += months
+                climatology = climatology + ds * days
+
+        climatology = climatology / totalDays
+
+        climatology.attrs['totalDays'] = totalDays
+        climatology.attrs['totalMonths'] = totalMonths
+
+        climatology.to_netcdf(outputFileClimo)
+
+    return climatology  # }}}
 
 
 def update_start_end_year(ds, config, calendar):
@@ -508,7 +679,7 @@ def update_start_end_year(ds, config, calendar):
     config :  instance of MpasAnalysisConfigParser
         Contains configuration options
 
-    calendar: {'gregorian', 'gregorian_noleap'}
+    calendar : {'gregorian', 'gregorian_noleap'}
         The name of one of the calendars supported by MPAS cores
 
     Returns
@@ -549,12 +720,13 @@ def update_start_end_year(ds, config, calendar):
     return changed, startYear, endYear
 
 
-def add_months_and_days_in_month(ds, calendar):
+def add_years_months_days_in_month(ds, calendar=None):  # {{{
     '''
-    Add ``months`` and ``daysInMonth`` as data arrays in ``ds``.  The number
-    of days in each month of ``ds`` is computed either using the ``startTime``
-    and ``endTime`` if available or assuming ``gregorian_noleap`` calendar and
-    ignoring leap years.
+    Add ``year``, ``month`` and ``daysInMonth`` as data arrays in ``ds``.
+    The number of days in each month of ``ds`` is computed either using the
+    ``startTime`` and ``endTime`` if available or assuming ``gregorian_noleap``
+    calendar and ignoring leap years.  ``year`` and ``month`` are computed
+    accounting correctly for the the calendar.
 
     Parameters
     ----------
@@ -562,15 +734,15 @@ def add_months_and_days_in_month(ds, calendar):
         A data set with a ``Time`` coordinate expressed as days since
         0001-01-01
 
-    calendar: ``{'gregorian', 'gregorian_noleap'}``
+    calendar : ``{'gregorian', 'gregorian_noleap'}``, optional
         The name of one of the calendars supported by MPAS cores, used to
-        determine ``month`` from ``Time`` coordinate
+        determine ``year`` and ``month`` from ``Time`` coordinate
 
     Returns
     -------
     ds : object of same type as ``ds``
-        The data set with ``month`` and ``daysInMonth`` data arrays added (if
-        not already present)
+        The data set with ``year``, ``month`` and ``daysInMonth`` data arrays
+        added (if not already present)
 
     Authors
     -------
@@ -578,33 +750,44 @@ def add_months_and_days_in_month(ds, calendar):
 
     Last Modified
     -------------
-    03/29/2017
-    """    '''
+    04/08/2017
+    '''
+
+    if ('year' in ds.coords and 'month' in ds.coords and
+            'daysInMonth' in ds.coords):
+        return ds
 
     ds = ds.copy()
 
-    if 'month' not in ds.coords:
+    if 'year' not in ds.coords or 'month' not in ds.coords:
         if calendar is None:
-            raise ValueError('calendar must be provided if month coordinate is not in ds')
-        months = [date.month for date in days_to_datetime(ds.Time,
-                                                          calendar=calendar)]
+            raise ValueError('calendar must be provided if month and year '
+                             'coordinate is not in ds.')
+        datetimes = days_to_datetime(ds.Time, calendar=calendar)
 
-        ds.coords['month'] = ('Time', months)
+    if 'year' not in ds.coords:
+        ds.coords['year'] = ('Time', [date.year for date in datetimes])
+
+    if 'month' not in ds.coords:
+        ds.coords['month'] = ('Time', [date.month for date in datetimes])
 
     if 'daysInMonth' not in ds.coords:
         if 'startTime' in ds.coords and 'endTime' in ds.coords:
             ds.coords['daysInMonth'] = ds.endTime - ds.startTime
         else:
             if calendar == 'gregorian':
-                warnings.warn('The MPAS run used the Gregorian calendar but does not appear to have\n'
-                              'supplied start and end times.  Climatologies will be computed with\n'
-                              'month durations ignoring leap years.')
-            # TODO: support leap years if calendar is 'gregorian'
+                message = 'The MPAS run used the Gregorian calendar but ' \
+                          'does not appear to have\n' \
+                          'supplied start and end times.  Climatologies ' \
+                          'will be computed with\n' \
+                          'month durations ignoring leap years.'
+                warnings.warn(message)
+
             daysInMonth = numpy.array([constants.daysInMonth[month-1] for
                                        month in ds.month.values], float)
             ds.coords['daysInMonth'] = ('Time', daysInMonth)
 
-    return ds
+    return ds  # }}}
 
 
 def _compute_masked_mean(ds, maskVaries):
@@ -623,7 +806,8 @@ def _compute_masked_mean(ds, maskVaries):
             for var in ds.data_vars:
                 weights[var] = ds[var].notnull()
         else:
-            raise TypeError('ds must be an instance of either xarray.Dataset or xarray.DataArray.')
+            raise TypeError('ds must be an instance of either xarray.Dataset '
+                            'or xarray.DataArray.')
 
         return weights
 

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -20,7 +20,7 @@ from ..constants import constants
 
 from ..timekeeping.utility import days_to_datetime
 
-from ..io.utility import build_config_full_path
+from ..io.utility import build_config_full_path, make_directories
 
 from ..interpolation import interpolate
 
@@ -82,10 +82,8 @@ def write_mpas_mapping_file(config, meshFileName):
         # file name
         mappingSubdirectory = build_config_full_path(config, 'output',
                                                      'mappingSubdirectory')
-        try:
-            os.makedirs(mappingSubdirectory)
-        except OSError:
-            pass
+
+        make_directories(mappingSubdirectory)
 
         meshName = config.get('input', 'mpasMeshName')
 
@@ -189,10 +187,7 @@ def write_observations_mapping_file(config, componentName, fieldName,
             mappingSubdirectory = build_config_full_path(config, 'output',
                                                          'mappingSubdirectory')
 
-            try:
-                os.makedirs(mappingSubdirectory)
-            except OSError:
-                pass
+            make_directories(mappingSubdirectory)
 
             obsMappingFileName = \
                 '{}/map_obs_{}_{}_to_{}x{}degree_{}.nc'.format(
@@ -276,14 +271,9 @@ def get_mpas_climatology_file_names(config, fieldName, monthNames):
 
     regriddedDirectory = build_config_full_path(
         config, 'output', 'mpasRegriddedClimSubdirectory')
-    try:
-        os.makedirs(regriddedDirectory)
-    except OSError:
-        pass
-    try:
-        os.makedirs(climatologyDirectory)
-    except OSError:
-        pass
+
+    make_directories(regriddedDirectory)
+    make_directories(climatologyDirectory)
 
     climatologyPrefix = '{}/{}_{}_{}'.format(climatologyDirectory, fieldName,
                                              meshName, monthNames)
@@ -377,16 +367,10 @@ def get_observation_climatology_file_names(config, fieldName, monthNames,
         regriddedDirectory, fieldName, gridName, comparisonLatRes,
         comparisonLonRes, monthNames)
 
-    try:
-        os.makedirs(climatologyDirectory)
-    except OSError:
-        pass
+    make_directories(climatologyDirectory)
 
     if not matchesComparison:
-        try:
-            os.makedirs(regriddedDirectory)
-        except OSError:
-            pass
+        make_directories(regriddedDirectory)
 
     return (climatologyFileName, regriddedFileName)
 
@@ -583,7 +567,8 @@ def cache_climatologies(ds, monthValues, config, cachePrefix, calendar,
         if os.path.exists(outputFileClimo):
             # already cached
             dsCached = xr.open_dataset(outputFileClimo)
-            if dsCached.attrs['totalMonths'] == 12*len(years):
+            if (dsCached.attrs['totalMonths'] ==
+                    constants.monthsInYear*len(years)):
                 # also complete, so we can move on
                 done = True
 
@@ -632,13 +617,15 @@ def cache_climatologies(ds, monthValues, config, cachePrefix, calendar,
     done = False
     if os.path.exists(outputFileClimo):
         climatology = xr.open_dataset(outputFileClimo)
-        if climatology.attrs['totalMonths'] == (endYearClimo-startYearClimo+1)*12:
+        if (climatology.attrs['totalMonths'] ==
+                (endYearClimo-startYearClimo+1)*constants.monthsInYear):
             # also complete, so we can move on
             done = True
 
     if not done:
         if printProgress:
-            print '   Computing aggregated climatology {}...'.format(yearString)
+            print '   Computing aggregated climatology ' \
+                  '{}...'.format(yearString)
 
         first = True
         for cacheIndex, info in enumerate(cacheInfo):

--- a/mpas_analysis/shared/constants/constants.py
+++ b/mpas_analysis/shared/constants/constants.py
@@ -20,6 +20,8 @@ lonmax = 180.
 latmin = -90.
 latmax = 90.
 
+monthsInYear = 12
+
 monthDictionary = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
                    'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11,
                    'Dec': 12, 'JFM': np.array([1, 2, 3]),
@@ -30,7 +32,8 @@ monthDictionary = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
 
 daysInMonth = np.array([31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31])
 
-abrevMonthNames = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]
+abrevMonthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug",
+                   "Sep", "Oct", "Nov", "Dec"]
 
 # conversion factor from m^3/s to Sverdrups
 m3ps_to_Sv = 1e-6

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -177,7 +177,7 @@ def open_multifile_dataset(fileNames, calendar, config,
     ds = ds.sel(Time=slice(startDate, endDate))
 
     # private record of autoclose use
-    ds.attrs['_autoclose'] = autoclose
+    ds.attrs['_autoclose'] = int(autoclose)
 
     return ds  # }}}
 

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -1,0 +1,138 @@
+"""
+Utility functions related to time-series data sets
+
+Authors
+-------
+Xylar Asay-Davis
+
+Last Modified
+-------------
+04/08/2017
+"""
+
+import xarray as xr
+import numpy
+import os
+
+from ..timekeeping.utility import days_to_datetime
+
+
+def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
+                      calendar, yearsPerCacheUpdate=1,
+                      printProgress=False):  # {{{
+    '''
+    Create or update a NetCDF file ``cacheFileName`` containing the given time
+    series, calculated with ``timeSeriesCalcFunction`` over the given times,
+    start and end year, and time frequency with which results are cached.
+
+    Note: only works with climatologies where the mask (locations of ``NaN``
+    values) doesn't vary with time.
+
+    Parameters
+    ----------
+    timesInDataSet : array-like
+        Times at which the time series is to be calculated, typically taken
+        from ``ds.Times.values`` for a data set from which the time series
+        will be extracted or computed.
+
+    timeSeriesCalcFunction : function
+        A function with arguments ``timeIndices``, indicating the entries in
+        ``timesInDataSet`` to be computed, and ``firstCall``, indicating
+        whether this is the first call to the funciton (useful for printing
+        progress information).
+
+    cacheFileName :  str
+        The absolute path to the cache file where the times series will be
+        stored
+
+    calendar : ``{'gregorian', 'gregorian_noleap'}``
+        The name of one of the calendars supported by MPAS cores, used to
+        determine ``year`` and ``month`` from ``Time`` coordinate
+
+    yearsPerCacheUpdate : int, optional
+        The frequency with which the cache file is updated as the computation
+        progresses.  If the computation is expensive, it may be useful to
+        output the file frequently.  If not, there will be needless overhead
+        in caching the file too frequently.
+
+    printProgress: bool, optional
+        Whether progress messages should be printed as the climatology is
+        computed
+
+    Returns
+    -------
+    climatology : object of same type as ``ds``
+        A data set without the ``'Time'`` coordinate containing the mean
+        of ds over all months in monthValues, weighted by the number of days
+        in each month.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    04/08/2017
+
+    '''
+
+    timesProcessed = numpy.zeros(len(timesInDataSet), bool)
+    # figure out which files to load and which years go in each file
+    continueOutput = os.path.exists(cacheFileName)
+    cacheDataSetExists = False
+    if continueOutput:
+        if printProgress:
+            print '   Read in previously computed time series'
+        # read in what we have so far
+        dsCache = xr.open_dataset(cacheFileName, decode_times=False)
+        # force loading and then close so we can overwrite the file later
+        dsCache.load()
+        dsCache.close()
+        for time in dsCache.Time.values:
+            timesProcessed[timesInDataSet == time] = True
+        cacheDataSetExists = True
+
+    datetimes = days_to_datetime(timesInDataSet, calendar=calendar)
+    yearsInDataSet = numpy.array([date.year for date in datetimes])
+
+    startYear = yearsInDataSet[0]
+    endYear = yearsInDataSet[-1]
+
+    firstProcessed = True
+    for firstYear in range(startYear, endYear+1, yearsPerCacheUpdate):
+        years = range(firstYear, numpy.minimum(endYear+1,
+                                               firstYear+yearsPerCacheUpdate))
+
+        mask = numpy.zeros(len(yearsInDataSet), bool)
+        for year in years:
+            mask = numpy.logical_or(mask, yearsInDataSet == year)
+        mask = numpy.logical_and(mask, numpy.logical_not(timesProcessed))
+
+        timeIndices = numpy.nonzero(mask)[0]
+
+        if len(timeIndices) == 0:
+            # no unprocessed time entries in this data range
+            continue
+
+        if printProgress:
+            if firstProcessed:
+                print '   Process and save time series'
+            if yearsPerCacheUpdate == 1:
+                print '     {:04d}'.format(years[0])
+            else:
+                print '     {:04d}-{:04d}'.format(years[0], years[-1])
+
+        ds = timeSeriesCalcFunction(timeIndices, firstProcessed)
+        firstProcessed = False
+
+        if cacheDataSetExists:
+            dsCache = xr.concat([dsCache, ds], dim='Time')
+        else:
+            dsCache = ds
+            cacheDataSetExists = True
+
+        dsCache.to_netcdf(cacheFileName)
+
+    return dsCache.sel(Time=slice(timesInDataSet[0],timesInDataSet[-1]))  # }}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -110,12 +110,16 @@ class TestClimatology(TestCase):
         config = self.setup_config()
         fieldName = 'sst'
         monthNames = 'JFM'
-        (climatologyFileName, regriddedFileName) = \
+        (climatologyFileName, climatologyPrefix, regriddedFileName) = \
             climatology.get_mpas_climatology_file_names(config, fieldName,
                                                         monthNames)
         expectedClimatologyFileName = '{}/clim/mpas/sst_QU240_JFM_' \
                                       'years0002-0002.nc'.format(self.test_dir)
         self.assertEqual(climatologyFileName, expectedClimatologyFileName)
+
+        expectedClimatologyPrefix = '{}/clim/mpas/sst_QU240_' \
+                                    'JFM'.format(self.test_dir)
+        self.assertEqual(climatologyPrefix, expectedClimatologyPrefix)
 
         expectedRegriddedFileName = '{}/clim/mpas/regrid/sst_QU240_to_' \
                                     '0.5x0.5degree_JFM_' \
@@ -170,7 +174,7 @@ class TestClimatology(TestCase):
         assert('daysInMonth' not in ds.coords.keys())
 
         # test add_months_and_days_in_month
-        ds = climatology.add_months_and_days_in_month(ds, calendar)
+        ds = climatology.add_years_months_days_in_month(ds, calendar)
 
         self.assertArrayEqual(ds.month.values, [1, 2, 3])
         self.assertArrayEqual(numpy.round(ds.daysInMonth.values), [31, 28, 31])

--- a/mpas_analysis/test/test_generalized_reader.py
+++ b/mpas_analysis/test/test_generalized_reader.py
@@ -144,7 +144,7 @@ class TestGeneralizedReader(TestCase):
             assert hasattr(ds, '_autoclose'), \
                 '`autoclose` not defined for dataset'
             if hasattr(ds, '_autoclose'):
-                assert ds._autoclose == autoclose, \
+                assert ds._autoclose == int(autoclose), \
                         ('`autoclose` used for dataset is inconsistent '
                          'with expected test value.')
 

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -28,23 +28,6 @@ def checkPathExists(path):  # {{{
 # }}}
 
 
-def makeDirectories(path):  # {{{
-    """
-    Make the given path if it does not already exist.
-
-    Returns the path unchanged.
-
-    Author: Xylar Asay-Davis
-    Last Modified: 02/02/2017
-    """
-
-    try:
-        os.makedirs(path)
-    except OSError:
-        pass
-    return path  # }}}
-
-
 def checkGenerate(config, analysisName, mpasCore, analysisCategory=None):
     # {{{
     """


### PR DESCRIPTION
This merge performs caching of all time series and climatology calculations.

The climatology caching can be performed at a frequency set by the config option `yearsPerCacheFile`, which defaults to 1 (meaning results are cached every year).  Once these climatology results are cached, they are aggregated together to compute the full climatology.  The aggregation process is much faster than the original caching, meaning subsequent climatology calculations will be substantially faster even if the start and/or end years of the climatology calculation change.

The time series caching is performed in a single file, which is updated periodically (yearly for MOC; every 10 years for other, faster time-series analysis tasks).  As with the climatology caching, time-series caching is smart enough to pick up where it left off if the start and/or end years of the time series change (e.g. because the simulation has made more progress).

The weighted averages used to compute climatologies now have a flag, `maskVaries` to control whether the mask is considered in the denominator of the weighted average.  If the mask doesn't vary with time (as is typical in MPAS components), considerable time can be saved by setting `maskVaries=False`.  This is now used for all MPAS climatology calculations.  For climatologies of certain observational data sets (notably MLD), it is important to have `maskVaries=True` because the mask does, in fact, vary substantially from month to month.

A small bug has been fixed in `generalized_reader` where an attribute of type `bool` (`_autoclose`) was being stored, but NetCDF does not support `bool`.  This meant that data sets opened with the generalized reader could not be written to NetCDF.

To support time-series caching, some clean up and reorganization was required, particularly in OHC and sea-ice time series.