### PR TITLE
Add unit test for cache_climatologies

### DIFF
--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -699,6 +699,14 @@ def _compute_masked_mean(ds, maskVaries):
     Compute the time average of data set, masked out where the variables in ds
     are NaN and, if ``maskVaries == True``, weighting by the number of days
     used to compute each monthly mean time in ds.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    04/08/2017
     '''
     def ds_to_weights(ds):
         # make an identical data set to ds but replacing all data arrays with
@@ -744,6 +752,14 @@ def _get_comparison_lat_lon(comparisonLatRes, comparisonLonRes):
     '''
     Returns the lat and lon arrays defining the corners of the comparison
     grid.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    04/08/2017
     '''
     nLat = int((constants.latmax-constants.latmin)/comparisonLatRes)+1
     nLon = int((constants.lonmax-constants.lonmin)/comparisonLonRes)+1
@@ -759,6 +775,14 @@ def _get_grid_name(gridFileName, latVarName, lonVarName, comparisonLatRes,
     Given a grid file with given lat and lon variable names, finds the
     resolution of the grid and generates a grid name.  Given comparison
     lat and lon resolution, determines if the grid matches the comparison grid.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    04/08/2017
     '''
     inFile = netCDF4.Dataset(gridFileName, 'r')
 
@@ -789,6 +813,14 @@ def _setup_climatology_caching(ds, startYearClimo, endYearClimo,
     '''
     Determine which cache files already exist, which are incomplete and which
     years are present in each cache file (whether existing or to be created).
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    04/08/2017
     '''
 
     cacheInfo = []
@@ -848,6 +880,14 @@ def _cache_individual_climatologies(ds, cacheInfo, printProgress,
                                     calendar):  # {{{
     '''
     Cache individual climatologies for later aggregation.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    04/08/2017
     '''
 
     for cacheIndex, info in enumerate(cacheInfo):
@@ -879,6 +919,14 @@ def _cache_aggregated_climatology(startYearClimo, endYearClimo, cachePrefix,
                                   cacheInfo):  # {{{
     '''
     Cache aggregated climatology from individual climatologies.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+
+    Last Modified
+    -------------
+    04/08/2017
     '''
 
     if startYearClimo == endYearClimo:


### PR DESCRIPTION
This merge adds a unit test for the `cache_climatologies` function.  The unit test computes and caches a climatology computed on 3 months of data.  The climatology is computed both with caching every 1 year and every 2 years.  The resulting climatology is verified against a reference solution in each case.  Checks are made to ensure that the file(s) produced have the expected names and that they are either modified or left unmodified by a second call to `cache_climatologies`, depending on whether each cache file is considered to be "complete".

The `cache_climatologies` function has been broken into 3 non-public helper functions.

A few small bugs related to the names of cache files have been fixed.  Previously, the final "individual" cache file was being named after the actual range of years, not the expected range.   For example, suppose a simulation has run for 42 years and cache files are stored every 5 years.  The last file had the suffix `years0041-0042`, whereas it now has `years0041-0045` even though it is incomplete.  The next time the analysis runs, an attempt will be made to recompute only this final 5-year climatology because it is incomplete and the simulation may have progressed.