### PR TITLE
Bug fix: name of mean velocity climatology when analyzing only one year

### DIFF
--- a/mpas_analysis/ocean/meridional_overturning_circulation.py
+++ b/mpas_analysis/ocean/meridional_overturning_circulation.py
@@ -327,9 +327,16 @@ def _compute_moc_climo_postprocess(config, runStreams, variableMap, calendar,
     if not os.path.exists(outputFileClimo):
         print '   Load data...'
 
-        velClimoFile = '{}/meanVelocity_years{:04d}-{:04d}.nc'.format(
-                       outputDirectory, dictClimo['startYearClimo'],
-                       dictClimo['endYearClimo'])
+        startYearClimo = dictClimo['startYearClimo']
+        endYearClimo = dictClimo['endYearClimo']
+        cachePrefix = '{}/meanVelocity'.format(outputDirectory)
+
+        if startYearClimo == endYearClimo:
+            yearString = '{:04d}'.format(startYearClimo)
+            velClimoFile = '{}_year{}.nc'.format(cachePrefix, yearString)
+        else:
+            yearString = '{:04d}-{:04d}'.format(startYearClimo, endYearClimo)
+            velClimoFile = '{}_years{}.nc'.format(cachePrefix, yearString)
 
         annualClimatology = xr.open_dataset(velClimoFile)
 


### PR DESCRIPTION
If the velocity climatology covers only 1 year, the name being loaded was previously not
correct (e.g. `meanVelocity_years0001-0001.nc` instead of `meanVelcoity_year0001.nc`),
leading to an error that the file was not found.