### PR TITLE
Fix errors with caching climatologies

### DIFF
--- a/mpas_analysis/ocean/ocean_modelvsobs.py
+++ b/mpas_analysis/ocean/ocean_modelvsobs.py
@@ -17,6 +17,7 @@ import datetime
 import numpy as np
 import netCDF4
 import os
+import warnings
 
 from ..shared.interpolation import interpolate
 
@@ -255,9 +256,16 @@ def ocn_modelvsobs(config, field):
                                                         monthNames=months)
 
         if overwriteMpasClimatology or not os.path.exists(climatologyFileName):
-            climatology.cache_climatologies(ds, monthValues, config,
-                                            climatologyPrefix, calendar,
-                                            printProgress=True)
+            seasonalClimatology = climatology.cache_climatologies(
+                ds, monthValues, config, climatologyPrefix, calendar,
+                printProgress=True)
+
+            if seasonalClimatology is None:
+                # apparently, there was no data available to create the
+                # climatology
+                warnings.warn('no data to create {} climatology for {}'.format(
+                    field, months))
+                continue
 
         interpolate.remap(inFileName=climatologyFileName,
                           outFileName=regriddedFileName,

--- a/mpas_analysis/ocean/ocean_modelvsobs.py
+++ b/mpas_analysis/ocean/ocean_modelvsobs.py
@@ -255,12 +255,9 @@ def ocn_modelvsobs(config, field):
                                                         monthNames=months)
 
         if overwriteMpasClimatology or not os.path.exists(climatologyFileName):
-            seasonalClimatology = climatology.cache_climatologies(
-                ds, monthValues, config, climatologyPrefix, calendar,
-                printProgress=True)
-            # write out the climatology so we can interpolate it with
-            # interpolate.remap
-            seasonalClimatology.to_netcdf(climatologyFileName)
+            climatology.cache_climatologies(ds, monthValues, config,
+                                            climatologyPrefix, calendar,
+                                            printProgress=True)
 
         interpolate.remap(inFileName=climatologyFileName,
                           outFileName=regriddedFileName,

--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -18,6 +18,7 @@ import numpy.ma as ma
 import numpy as np
 
 import netCDF4
+import warnings
 
 from ..shared.constants import constants
 
@@ -200,9 +201,15 @@ def _compute_and_plot_concentration(config, ds, mpasMappingFileName, calendar):
                     monthNames=months)
 
         if overwriteMpasClimatology or not os.path.exists(climatologyFileName):
-            climatology.cache_climatologies(ds, monthValues, config,
-                                            climatologyPrefix, calendar,
-                                            printProgress=True)
+            seasonalClimatology = climatology.cache_climatologies(
+                ds, monthValues, config, climatologyPrefix, calendar,
+                printProgress=True)
+            if seasonalClimatology is None:
+                # apparently, there was no data available to create the
+                # climatology
+                warnings.warn('no data to create sea ice concentration '
+                              'climatology for {}'.format(months))
+                continue
 
         interpolate.remap(inFileName=climatologyFileName,
                           outFileName=regriddedFileName,
@@ -382,9 +389,15 @@ def _compute_and_plot_thickness(config, ds,  mpasMappingFileName, calendar):
                     monthNames=months)
 
         if overwriteMpasClimatology or not os.path.exists(climatologyFileName):
-            climatology.cache_climatologies(ds, monthValues, config,
-                                            climatologyPrefix, calendar,
-                                            printProgress=True)
+            seasonalClimatology = climatology.cache_climatologies(
+                ds, monthValues, config, climatologyPrefix, calendar,
+                printProgress=True)
+            if seasonalClimatology is None:
+                # apparently, there was no data available to create the
+                # climatology
+                warnings.warn('no data to create sea ice thickness '
+                              'climatology for {}'.format(months))
+                continue
 
         interpolate.remap(inFileName=climatologyFileName,
                           outFileName=regriddedFileName,

--- a/mpas_analysis/sea_ice/modelvsobs.py
+++ b/mpas_analysis/sea_ice/modelvsobs.py
@@ -200,12 +200,9 @@ def _compute_and_plot_concentration(config, ds, mpasMappingFileName, calendar):
                     monthNames=months)
 
         if overwriteMpasClimatology or not os.path.exists(climatologyFileName):
-            seasonalClimatology = climatology.cache_climatologies(
-                ds, monthValues, config, climatologyPrefix, calendar,
-                printProgress=True)
-            # write out the climatology so we can interpolate it with
-            # interpolate.remap
-            seasonalClimatology.to_netcdf(climatologyFileName)
+            climatology.cache_climatologies(ds, monthValues, config,
+                                            climatologyPrefix, calendar,
+                                            printProgress=True)
 
         interpolate.remap(inFileName=climatologyFileName,
                           outFileName=regriddedFileName,
@@ -385,13 +382,9 @@ def _compute_and_plot_thickness(config, ds,  mpasMappingFileName, calendar):
                     monthNames=months)
 
         if overwriteMpasClimatology or not os.path.exists(climatologyFileName):
-            seasonalClimatology = climatology.cache_climatologies(
-                ds, monthValues, config, climatologyPrefix, calendar,
-                printProgress=True)
-            # write out the climatology so we can interpolate it with
-            # interpolate.remap.  Set _FillValue so ncremap doesn't produce
-            # an error
-            seasonalClimatology.to_netcdf(climatologyFileName)
+            climatology.cache_climatologies(ds, monthValues, config,
+                                            climatologyPrefix, calendar,
+                                            printProgress=True)
 
         interpolate.remap(inFileName=climatologyFileName,
                           outFileName=regriddedFileName,

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -934,6 +934,10 @@ def _cache_aggregated_climatology(startYearClimo, endYearClimo, cachePrefix,
     outputFileClimo = '{}_{}.nc'.format(cachePrefix, fileSuffix)
 
     done = False
+    if len(cacheInfo) == 0:
+        climatology = None
+        done = True
+
     if os.path.exists(outputFileClimo):
         # already cached
         climatology = None
@@ -965,6 +969,7 @@ def _cache_aggregated_climatology(startYearClimo, endYearClimo, cachePrefix,
             print '   Computing aggregated climatology ' \
                   '{}...'.format(yearString)
 
+
         first = True
         for cacheIndex, info in enumerate(cacheInfo):
             inFileClimo = info[0]
@@ -981,7 +986,7 @@ def _cache_aggregated_climatology(startYearClimo, endYearClimo, cachePrefix,
                 totalMonths += months
                 climatology = climatology + ds * days
 
-        ds.close()
+            ds.close()
         climatology = climatology / totalDays
 
         climatology.attrs['totalDays'] = totalDays

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -115,7 +115,7 @@ class TestClimatology(TestCase):
             climatology.get_mpas_climatology_file_names(config, fieldName,
                                                         monthNames)
         expectedClimatologyFileName = '{}/clim/mpas/sst_QU240_JFM_' \
-                                      'years0002-0002.nc'.format(self.test_dir)
+                                      'year0002.nc'.format(self.test_dir)
         self.assertEqual(climatologyFileName, expectedClimatologyFileName)
 
         expectedClimatologyPrefix = '{}/clim/mpas/sst_QU240_' \
@@ -124,7 +124,7 @@ class TestClimatology(TestCase):
 
         expectedRegriddedFileName = '{}/clim/mpas/regrid/sst_QU240_to_' \
                                     '0.5x0.5degree_JFM_' \
-                                    'years0002-0002.nc'.format(self.test_dir)
+                                    'year0002.nc'.format(self.test_dir)
         self.assertEqual(regriddedFileName, expectedRegriddedFileName)
 
     def test_get_observation_climatology_file_names(self):


### PR DESCRIPTION
In cases where the single cached climatology file has the same name as the aggregate climatology file, we don't need to aggregate. We also want to make sure to close open data sets to prevent conflicts when writing to files of the same name (though this situation hopefully is avoided in any case).

Previously, files containing a single year of climatology data were being given a suffix like `years0001-0001`.  This has now been fixed for greater consistency, to prevent redundant copies of the same data set from being written, and to prevent occasional "permission denied" errors when trying to write the same file.

Unnecessary save operations after file caching in the `modelvsobs` tasks have been removed to save time and prevent "permission denied" errors.

A helper function `_get_year_string` has been added to `climatology` to determine if a sequence of years covers a single year or multiple years and to return an appropriate file suffix.