### PR TITLE
Fixes MOC for 18to6 on titan

### DIFF
--- a/config.default
+++ b/config.default
@@ -392,7 +392,8 @@ regionMaskFiles = /path/to/MOCregional/mapping/file
 # is handled automatically.  If the MOC calculation encounters memory problems,
 # consider setting maxChunkSize to a number significantly lower than nEdges
 # in your MPAS mesh so that the calculation will be divided into smaller
-# pieces.
+# pieces. 
+# Note, need to use maxChunkSize for the 18to6
 # maxChunkSize = 1000
 
 # Size of latitude bins over which MOC streamfunction is integrated

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -1,0 +1,176 @@
+[runs]
+## options related to the run to be analyzed and reference runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = GMPAS-IAF_oRRS18to6v3
+# referenceRunName is the name of a reference run to compare against (or None
+# to turn off comparison with a reference, e.g. if no reference case is
+# available)
+referenceRunName = None
+# preprocessedReferenceRunName is the name of a reference run that has been
+# preprocessed to compare against (or None to turn off comparison).  Reference
+# runs of this type would have preprocessed results because they were not
+# performed with MPAS components (so they cannot be easily ingested by
+# MPAS-Analysis)
+preprocessedReferenceRunName = None
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /lustre/atlas1/cli115/scratch/vanroek/GMPAS-IAF_oRRS18to6v3/run
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+# NOTE: This directory path must be specific to each test case.
+baseDirectory = /dir/to/analysis/output
+
+# a list of analyses to generate.  Valid names are:
+#   'timeSeriesOHC', 'timeSeriesSST', 'regriddedSST',
+#   'regriddedSSS', 'regriddedMLD', 'streamfunctionMOC',
+#   'indexNino34', 'meridionalHeatTransport',
+#   'timeSeriesSeaIceAreaVol', 'regriddedSeaIceConcThick'
+# the following shortcuts exist:
+#   'all' -- all analyses will be run
+#   'all_timeSeries' -- all time-series analyses will be run
+#   'all_regriddedHorizontal' -- all analyses involving regridded horizontal
+#                                fields will be run
+#   'all_ocean' -- all ocean analyses will be run
+#   'all_seaIce' -- all sea-ice analyses will be run
+#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
+#                             other analyses).
+#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
+#                                            given category of analysis
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    ./run_analysis.py config.analysis --generate \
+#         all,no_ocean,all_timeSeries
+#generate = ['all_regriddedHorizontal', 'streamfunctionMOC']
+generate = ['streamfunctionMOC']
+
+# alternative examples that would perform all analysis except
+#   'timeSeriesOHC'
+#generate = ['timeSeriesSST', 'streamfunctionMOC',
+#            'all_regriddedHorizontal', 'all_seaIce']
+#generate = ['all', 'no_timeSeriesOHC']
+# Each subsequent list entry can be used to alter previous list entries. For
+# example, the following would produce all analyses except regriddedSST,
+# regriddedSSS and regriddedMLD (albeit not in a very intuitive way):
+#generate = ['all', 'no_ocean', 'all_timeSeries']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 11
+# the last year over which to average climatalogies
+endYear = 11
+
+# should remapping be performed with ncremap or with the Remapper class
+# directly in MPAS-Analysis
+useNcremap = True
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+startYear = 11
+endYear = 11
+
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
+[oceanObservations]
+## options related to ocean observations with which the results will be compared
+
+# directory where ocean observations are stored
+baseDirectory = /lustre/atlas/proj-shared/cli115/observations
+sstSubdirectory = SST
+sssSubdirectory = SSS
+mldSubdirectory = MLD
+ninoSubdirectory = Nino
+mhtSubdirectory = MHT
+
+[oceanReference]
+## options related to ocean reference run with which the results will be
+## compared
+
+# directory where ocean reference simulation results are stored
+baseDirectory = /dir/to/ocean/reference
+
+[oceanPreprocessedReference]
+## options related to preprocessed ocean reference run with which the results
+## will be compared (e.g. a POP, CESM or ACME v0 run)
+
+# directory where ocean reference simulation results are stored
+baseDirectory = /dir/to/ocean/reference
+
+[seaIceObservations]
+## options related to sea ice observations with which the results will be
+## compared
+
+# directory where sea ice observations are stored
+baseDirectory = /lustre/atlas/proj-shared/cli115/observations/SeaIce
+areaNH = IceArea_timeseries/iceAreaNH_climo.nc
+areaSH = IceArea_timeseries/iceAreaSH_climo.nc
+volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
+volSH = none
+concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
+
+[seaIceReference]
+## options related to sea ice reference run with which the results will be
+## compared
+
+# directory where sea ice reference simulation results are stored
+baseDirectory = /dir/to/seaice/reference
+
+[seaIcePreprocessedReference]
+## options related to preprocessed sea ice reference run with which the results
+## will be compared (e.g. a CICE, CESM or ACME v0 run)
+
+# directory where ocean reference simulation results are stored
+baseDirectory = /dir/to/seaice/reference
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning
+## circulation (MOC)
+
+# Mask file for post-processing regional MOC computation
+regionMaskFiles = /lustre/atlas1/cli115/proj-shared/mpas_analysis/region_masks/oRRS18to6v3.170111.SingleRegionAtlanticWTransportTransects_masks.nc
+
+# xarray (with dask) divides data sets into "chunks", allowing computations
+# to be made on data that is larger than the available memory.  MPAS-Analysis
+# supports setting a maximum chunk size for data sets generally, and a
+# separate option specific to loading the 3D velocity field in the MOC
+# specifically.  By default, maxChunkSize is left undefined, so that chunking
+# is handled automatically.  If the MOC calculation encounters memory problems,
+# consider setting maxChunkSize to a number significantly lower than nEdges
+# in your MPAS mesh so that the calculation will be divided into smaller
+# pieces.
+maxChunkSize = 500

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -717,25 +717,18 @@ def _compute_masked_mean(ds, maskVaries):  # {{{
 
     if maskVaries:
         dsWeightedSum = (ds * ds.daysInMonth).sum(dim='Time', keep_attrs=True)
-        dsWeightedSum.compute()
 
         weights = ds_to_weights(ds)
-        weights.compute()
 
         weightSum = (weights * ds.daysInMonth).sum(dim='Time')
-        weightSum.compute()
 
         timeMean = dsWeightedSum / weightSum.where(weightSum > 0.)
-        timeMean.compute()
     else:
         days = ds.daysInMonth.sum(dim='Time')
-        days.compute()
 
         dsWeightedSum = (ds * ds.daysInMonth).sum(dim='Time', keep_attrs=True)
-        dsWeightedSum.compute()
 
         timeMean = dsWeightedSum / days.where(days > 0.)
-        timeMean.compute()
 
     return timeMean  # }}}
 


### PR DESCRIPTION
Use of *.compute() was dangerous because it required
xarray / dask to store arrays in memory, which is problematic
for large problem sizes like the 18to6.  For the MOC
calculation for the 18to6, use of `maxChunkSize` is required to
ensure that the large arrays fit into memory for the climatology
calculation.  However, for smaller problem sizes (60to30)
use of `maxChunkSize` will result in a performance penalty relative
to this value being None because computations will be faster if
arrays fit into memory.