### PR TITLE
Climatology caching skip opening ds

### DIFF
--- a/config.default
+++ b/config.default
@@ -41,7 +41,7 @@ parallelTaskCount = 1
 
 # Prefix on the commnd line before a parallel task (e.g. 'srun -n 1 python')
 # Default is no prefix (run_analysis.py is executed directly)
-commandPrefix = 
+commandPrefix =
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -99,9 +99,10 @@ scratchSubdirectory = scratch
 plotsSubdirectory = plots
 logsSubdirectory = logs
 mpasClimatologySubdirectory = clim/mpas
-mpasRegriddedClimSubdirectory = clim/mpas/regridded
+mpasRemappedClimSubdirectory = clim/mpas/remapped
 mappingSubdirectory = mapping
 timeSeriesSubdirectory = timeseries
+timeCacheSubdirectory = timecache
 
 # a list of analyses to generate.  Valid names are:
 #   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
@@ -152,9 +153,6 @@ comparisonLonResolution = 0.5
 # generated based on the MPAS mesh name, the comparison grid resolution, and
 # the interpolation method
 # mpasMappingFile = /path/to/mapping/file
-
-# overwrite files when building climatologies?
-overwriteMpasClimatology = False
 
 # interpolation order for model and observation results. Likely values are
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
@@ -230,14 +228,11 @@ interpolationMethod = bilinear
 # The directories where observation climatologies will be stored if they need
 # to be computed.  If a relative path is supplied, it is relative to the output
 # base directory.  If an absolute path is supplied, this should point to
-# cached climatology files on the desired comparison grid, in which case
-# overwriteObsClimatology should be False.  If cached regridded files are
-# supplied, there is no need to provide cached files before regridding.
+# cached climatology files on the desired comparison grid.  If cached remapped
+# files are supplied, there is no need to provide cached files before
+# remapping.
 climatologySubdirectory = clim/obs
-regriddedClimSubdirectory = clim/obs/regridded
-
-# overwrite files when building climatologies?
-overwriteObsClimatology = False
+remappedClimSubdirectory = clim/obs/remapped
 
 [oceanReference]
 ## options related to ocean reference run with which the results will be
@@ -252,11 +247,11 @@ baseDirectory = /dir/to/ocean/reference
 
 # directory where ocean reference simulation results are stored
 baseDirectory = /dir/to/ocean/reference
- 
+
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
- 
+
 # directory where sea ice observations are stored
 baseDirectory = /dir/to/seaice/observations
 areaNH = IceArea_timeseries/iceAreaNH_climo.nc
@@ -290,14 +285,11 @@ interpolationMethod = bilinear
 # The directories where observation climatologies will be stored if they need
 # to be computed.  If a relative path is supplied, it is relative to the output
 # base directory.  If an absolute path is supplied, this should point to
-# cached climatology files on the desired comparison grid, in which case
-# overwriteObsClimatology should be False.  If cached regridded files are
-# supplied, there is no need to provide cached files before regridding.
+# cached climatology files on the desired comparison grid.  If cached remapped
+# files are supplied, there is no need to provide cached files before
+# remapping.
 climatologySubdirectory = clim/obs
-regriddedClimSubdirectory = clim/obs/regridded
-
-# overwrite files when building climatologies?
-overwriteObsClimatology = False
+remappedClimSubdirectory = clim/obs/remapped
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be
@@ -399,7 +391,7 @@ regionMaskFiles = /path/to/MOCregional/mapping/file
 # is handled automatically.  If the MOC calculation encounters memory problems,
 # consider setting maxChunkSize to a number significantly lower than nEdges
 # in your MPAS mesh so that the calculation will be divided into smaller
-# pieces. 
+# pieces.
 # Note, need to use maxChunkSize for the 18to6
 # maxChunkSize = 1000
 
@@ -450,7 +442,7 @@ titleFontSize = 18
 polarPlot = False
 
 [climatologyMapSST]
-## options related to plotting horizontally regridded climatologies of
+## options related to plotting horizontally remapped climatologies of
 ## sea surface temperature (SST) against reference model results and
 ## observations
 
@@ -473,7 +465,7 @@ colorbarLevelsDifference = [-5, -3, -2, -1, 0, 1, 2, 3, 5]
 comparisonTimes =  ['JFM', 'JAS', 'ANN']
 
 [climatologyMapSSS]
-## options related to plotting horizontally regridded climatologies of
+## options related to plotting horizontally remapped climatologies of
 ## sea surface salinity (SSS) against reference model results and observations
 
 # colormap for model/observations
@@ -495,7 +487,7 @@ colorbarLevelsDifference = [-3, -2, -1, -0.5, 0, 0.5, 1, 2, 3]
 comparisonTimes =  ['JFM', 'JAS', 'ANN']
 
 [climatologyMapMLD]
-## options related to plotting horizontally regridded climatologies of
+## options related to plotting horizontally remapped climatologies of
 ## mixed layer depth (MLD) against reference model results and observations
 
 # colormap for model/observations
@@ -517,7 +509,7 @@ colorbarLevelsDifference = [-150, -80, -30, -10, 0, 10, 30, 80, 150]
 comparisonTimes =  ['JFM', 'JAS', 'ANN']
 
 [climatologyMapSeaIceConcThick]
-## options related to plotting horizontally regridded climatologies of
+## options related to plotting horizontally remapped climatologies of
 ## sea ice concentration and thickness against reference model results and
 ## observations
 

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -9,7 +9,7 @@ from ..shared.constants.constants import m3ps_to_Sv, \
 from ..shared.plot.plotting import plot_vertical_section,\
     timeseries_analysis_plot, setup_colormap
 
-from ..shared.io.utility import build_config_full_path, make_directories
+from ..shared.io import build_config_full_path, make_directories
 
 from ..shared.generalized_reader.generalized_reader \
     import open_multifile_dataset
@@ -17,8 +17,7 @@ from ..shared.generalized_reader.generalized_reader \
 from ..shared.timekeeping.utility import get_simulation_start_time, \
     days_to_datetime
 
-from ..shared.climatology.climatology import update_start_end_year, \
-    cache_climatologies
+from ..shared.climatology import MpasClimatology
 
 from ..shared.analysis_task import AnalysisTask
 
@@ -55,10 +54,11 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
         '''
         # first, call the constructor from the base class (AnalysisTask)
         super(StreamfunctionMOC, self).__init__(
-            config=config,
-            taskName='streamfunctionMOC',
-            componentName='ocean',
-            tags=['streamfunction', 'moc', 'climatology', 'timeSeries'])
+                config=config,
+                taskName='streamfunctionMOC',
+                componentName='ocean',
+                tags=['streamfunction', 'moc', 'climatology', 'timeSeries'],
+                prerequisiteTasks=['cacheOceanTimeSeriesStatsTimes'])
 
         # }}}
 
@@ -98,17 +98,7 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
         #   First a list necessary for the streamfunctionMOC climatology
         streamName = self.historyStreams.find_stream(
             self.streamMap['timeSeriesStats'])
-        self.startDateClimo = config.get('climatology', 'startDate')
-        self.endDateClimo = config.get('climatology', 'endDate')
-        self.inputFilesClimo = \
-            self.historyStreams.readpath(streamName,
-                                         startDate=self.startDateClimo,
-                                         endDate=self.endDateClimo,
-                                         calendar=self.calendar)
         self.simulationStartTime = get_simulation_start_time(self.runStreams)
-
-        self.startYearClimo = config.getint('climatology', 'startYear')
-        self.endYearClimo = config.getint('climatology', 'endYear')
 
         #   Then a list necessary for the streamfunctionMOC Atlantic timeseries
         self.startDateTseries = config.get('timeSeries', 'startDate')
@@ -141,11 +131,6 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
         print "\n Plotting streamfunction of Meridional Overturning " \
               "Circulation (MOC)..."
 
-        print '\n  List of files for climatologies:\n' \
-              '    {} through\n    {}'.format(
-                  os.path.basename(self.inputFilesClimo[0]),
-                  os.path.basename(self.inputFilesClimo[-1]))
-
         print '\n  List of files for time series:\n' \
               '    {} through\n    {}'.format(
                   os.path.basename(self.inputFilesTseries[0]),
@@ -163,8 +148,10 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
             #                                      sectionName, dictClimo,
             #                                      dictTseries)
         else:
-            self._cache_velocity_climatologies()
-            self._compute_moc_climo_postprocess()
+            velocityClimatology = self._cache_velocity_climatologies()
+            self.startYearClimo = velocityClimatology.startYear
+            self.endYearClimo = velocityClimatology.endYear
+            self._compute_moc_climo_postprocess(velocityClimatology)
             dsMOCTimeSeries = self._compute_moc_time_series_postprocess()
 
         # **** Plot MOC ****
@@ -244,42 +231,56 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
     def _cache_velocity_climatologies(self):  # {{{
         '''compute yearly velocity climatologies and cache them'''
 
+        velocityClimatology = MpasClimatology(
+            task=self,
+            fieldName='meanVelocity',
+            monthNames='ANN',
+            streamName='timeSeriesStats')
+
+        # compute and cache the velocity climatology
+        velocityClimatology.cache(openDataSetFunc=self._open_velcoity_part,
+                                  printProgress=True)
+
+        return velocityClimatology  # }}}
+
+    def _open_velcoity_part(self, inputFileNames, startDate, endDate):  # {{{
+        """
+        Open part of the monthly mean velocity data set between the given
+        start and end date, used to cache a climatology of the data set.
+
+        Parameters
+        ----------
+        inputFileNames : list of str
+            File names in the multifile data set to open
+
+        startDate, endDate : float
+            start and end date to which to crop the Time dimension (given in
+            days since 0001-01-01)
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        """
+
         variableList = ['avgNormalVelocity',
                         'avgVertVelocityTop']
 
-        config = self.config
-
-        outputDirectory = build_config_full_path(config, 'output',
-                                                 'mpasClimatologySubdirectory')
-
-        make_directories(outputDirectory)
-
-        chunking = config.getExpression(self.sectionName, 'maxChunkSize')
+        chunking = self.config.getExpression(self.sectionName, 'maxChunkSize')
         ds = open_multifile_dataset(
-            fileNames=self.inputFilesClimo,
+            fileNames=inputFileNames,
             calendar=self.calendar,
-            config=config,
+            config=self.config,
             simulationStartTime=self.simulationStartTime,
             timeVariableName='Time',
             variableList=variableList,
             variableMap=self.variableMap,
-            startDate=self.startDateClimo,
-            endDate=self.endDateClimo,
+            startDate=startDate,
+            endDate=endDate,
             chunking=chunking)
 
-        # update the start and end year in config based on the real extend of
-        # ds
-        update_start_end_year(ds, config, self.calendar)
+        return ds  # }}}
 
-        cachePrefix = '{}/meanVelocity'.format(outputDirectory)
-
-        # compute and cache the velocity climatology
-        cache_climatologies(ds, monthDictionary['ANN'],
-                            config, cachePrefix, self.calendar,
-                            printProgress=True)
-        # }}}
-
-    def _compute_moc_climo_postprocess(self):  # {{{
+    def _compute_moc_climo_postprocess(self, velocityClimatology):  # {{{
 
         '''compute mean MOC streamfunction as a post-process'''
 
@@ -340,19 +341,7 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
                            outputDirectory, self.startYearClimo,
                            self.endYearClimo)
         if not os.path.exists(outputFileClimo):
-            print '   Load data...'
-
-            cachePrefix = '{}/meanVelocity'.format(outputDirectory)
-
-            if self.startYearClimo == self.endYearClimo:
-                yearString = '{:04d}'.format(self.startYearClimo)
-                velClimoFile = '{}_year{}.nc'.format(cachePrefix, yearString)
-            else:
-                yearString = '{:04d}-{:04d}'.format(self.startYearClimo,
-                                                    self.endYearClimo)
-                velClimoFile = '{}_years{}.nc'.format(cachePrefix, yearString)
-
-            annualClimatology = xr.open_dataset(velClimoFile)
+            annualClimatology = velocityClimatology.dataSet
 
             # Convert to numpy arrays
             # (can result in a memory error for large array size)

--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -14,7 +14,7 @@ from ..shared.timekeeping.utility import get_simulation_start_time, \
 
 from ..shared.time_series import time_series
 
-from ..shared.io.utility import build_config_full_path, make_directories, \
+from ..shared.io import build_config_full_path, make_directories, \
     check_path_exists
 
 

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -12,7 +12,7 @@ from ..shared.timekeeping.utility import get_simulation_start_time, \
 
 from ..shared.time_series import time_series
 
-from ..shared.io.utility import build_config_full_path, make_directories, \
+from ..shared.io import build_config_full_path, make_directories, \
     check_path_exists
 
 

--- a/mpas_analysis/sea_ice/sea_ice_analysis_task.py
+++ b/mpas_analysis/sea_ice/sea_ice_analysis_task.py
@@ -1,7 +1,6 @@
 from ..shared.analysis_task import AnalysisTask
 
-from ..shared.io import StreamsFile
-from ..shared.io.utility import build_config_full_path
+from ..shared.io import StreamsFile, build_config_full_path
 
 from ..shared.timekeeping.utility import get_simulation_start_time
 

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -6,7 +6,7 @@ from .sea_ice_analysis_task import SeaIceAnalysisTask
 from ..shared.plot.plotting import timeseries_analysis_plot, \
     timeseries_analysis_plot_polar
 
-from ..shared.io.utility import build_config_full_path, check_path_exists, \
+from ..shared.io import build_config_full_path, check_path_exists, \
     make_directories
 
 from ..shared.timekeeping.utility import date_to_days, days_to_datetime, \

--- a/mpas_analysis/shared/cache_dataset_times_task.py
+++ b/mpas_analysis/shared/cache_dataset_times_task.py
@@ -1,0 +1,153 @@
+from .analysis_task import AnalysisTask
+
+from ..shared.io import StreamsFile, build_config_full_path
+from ..shared.timekeeping.utility import get_simulation_start_time
+
+
+class CacheDatasetTimesTask(AnalysisTask):  # {{{
+    '''
+    A task for caching the times in a multifile data sets of an MPAS analysis
+    member for later use.  Since analysis member may be used by multiple tasks
+    (indeed the ``timeSeriesStats`` is currently used by *all* tasks), it is
+    important that this time information gets processed once before all other
+    tasks get run in parallel.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+    '''
+
+    def __init__(self, config, componentName, streamName,
+                 startAndEndDateSections, namelistOption=None):  # {{{
+        '''
+        Construct an analysis task for caching the times in the multifile
+        data set in the given component and stream.  The name of the task
+        includes the component and stream name.  For example, if
+        ``component='ocean'`` and ``streamName='timeSeriesStats``, then the
+        task name is ``cacheOceanTimeSeriesStatsTimes``.
+
+        Parameters
+        ----------
+        config :  instance of MpasAnalysisConfigParser
+            Contains configuration options
+
+        componentName :  {'ocean', 'seaIce'}
+            The name of the component (same as the folder where the task
+            resides)
+
+        streamName : str
+            The name of the stream from which the climatology data set will
+            be read, used to cache times and update their bounds in the
+            configuration parser.
+
+        startAndEndDateSections : list, {'climatology', 'timeSeries', 'index'}
+            The name of sections in the config file containing ``startDate``
+            and ``endDate`` options as a list.
+
+        namelistOption : str, optional
+            The name of a namelist option (e.g.
+            ``config_am_timeseriesstatsmonthly_enable``) that should be set to
+            true of the required analysis member has been enabled.  If this
+            option is ``None`` (the default), no check is performed
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        '''
+
+        upperComponent = componentName[0].upper() + componentName[1:]
+        upperStream = streamName[0].upper() + streamName[1:]
+
+        taskName = 'cache{}{}Times'.format(
+                upperComponent, upperStream)
+
+        # first, call the constructor from the base class (AnalysisTask).
+        super(CacheDatasetTimesTask, self).__init__(
+                config=config,
+                taskName=taskName,
+                componentName=componentName,
+                tags=startAndEndDateSections)
+
+        self.streamName = streamName
+        self.namelistOption = namelistOption
+        self.startAndEndDateSections = startAndEndDateSections
+
+        # }}}
+
+    def setup_and_check(self):  # {{{
+        '''
+        Perform steps to set up the analysis and check for errors in the setup.
+
+        Raises
+        ------
+        ValueError: if startAndEndDateSections is not a list containing
+            {'climatology', 'timeSeries', 'index'}
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        '''
+
+        # first, call setup_and_check from the base class (AnalysisTask),
+        # which will perform some common setup, including storing:
+        #     self.runDirectory , self.historyDirectory, self.plotsDirectory,
+        #     self.namelist, self.runStreams, self.historyStreams,
+        #     self.calendar, self.namelistMap, self.streamMap, self.variableMap
+        super(CacheDatasetTimesTask, self).setup_and_check()
+
+        if self.namelistOption is not None:
+            self.check_analysis_enabled(
+                analysisOptionName=self.namelistOption,
+                raiseException=True)
+
+        for section in self.startAndEndDateSections:
+            if not self.config.has_section(section):
+                raise ValueError('Config file does not have a section '
+                                 '{}.'.format(section))
+            for option in ['startDate', 'endDate']:
+                if not self.config.has_option(section, option):
+                    raise ValueError('Config section {} does not have '
+                                     'expected option {}.'.format(section,
+                                                                  option))
+
+        # }}}
+
+    def run(self):  # {{{
+        '''
+        The main method of the task that performs the analysis task.
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        '''
+        print ""
+        print "Caching times from the {} component for the {} stream " \
+              "...".format(self.componentName, self.streamName)
+
+        try:
+            self.simulationStartTime = get_simulation_start_time(
+                self.runStreams)
+        except IOError as e:
+            if self.componentName == 'ocean':
+                raise e
+            else:
+                # try the ocean stream instead
+                runDirectory = build_config_full_path(self.config, 'input',
+                                                      'runSubdirectory')
+                oceanStreamsFileName = build_config_full_path(
+                    self.config, 'input', 'oceanStreamsFileName')
+                oceanStreams = StreamsFile(oceanStreamsFileName,
+                                           streamsdir=runDirectory)
+                self.simulationStartTime = \
+                    get_simulation_start_time(oceanStreams)
+
+        for sectionName in self.startAndEndDateSections:
+            # internally, this will also cache the times for the data set
+            self.update_start_end_date(section=sectionName,
+                                       streamName=self.streamName)
+
+        # }}}
+
+# }}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/climatology/__init__.py
+++ b/mpas_analysis/shared/climatology/__init__.py
@@ -1,5 +1,2 @@
-from .climatology import get_lat_lon_comparison_descriptor, get_remapper, \
-    get_mpas_climatology_file_names, get_observation_climatology_file_names, \
-    compute_monthly_climatology, compute_climatology, cache_climatologies, \
-    update_start_end_year, add_years_months_days_in_month, \
-    remap_and_write_climatology
+from .climatology import Climatology, \
+    MpasClimatology, ObservationClimatology

--- a/mpas_analysis/shared/generalized_reader/__init__.py
+++ b/mpas_analysis/shared/generalized_reader/__init__.py
@@ -1,0 +1,1 @@
+from generalized_reader import open_multifile_dataset

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -39,7 +39,7 @@ def open_multifile_dataset(fileNames, calendar, config,
     Parameters
     ----------
     fileNames : list of strings
-        A lsit of file paths to read
+        A list of file paths to read
 
     calendar : {'gregorian', 'gregorian_noleap'}, optional
         The name of one of the calendars supported by MPAS cores

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -11,10 +11,6 @@ remap - perform horizontal interpolation on a data sets, given a mapping file
 Author
 ------
 Xylar Asay-Davis
-
-Last Modified
--------------
-04/13/2017
 '''
 
 import subprocess
@@ -29,7 +25,6 @@ import sys
 from ..grid import MpasMeshDescriptor, LatLonGridDescriptor, \
     ProjectionGridDescriptor
 
-
 class Remapper(object):
     '''
     A class for remapping fields using a given mapping file.  The weights and
@@ -38,10 +33,6 @@ class Remapper(object):
     Author
     ------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/13/2017
     '''
 
     def __init__(self, sourceDescriptor, destinationDescriptor,
@@ -75,10 +66,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/13/2017
         '''
 
         if not isinstance(sourceDescriptor,
@@ -128,10 +115,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/13/2017
         '''
 
         if self.mappingFileName is None or \
@@ -221,10 +204,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/13/2017
         '''
 
         if self.mappingFileName is None:
@@ -315,10 +294,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/13/2017
         '''
 
         if self.mappingFileName is None:
@@ -368,10 +343,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/06/2017
         '''
 
         if self.mappingLoaded:
@@ -443,10 +414,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/05/2017
         '''
 
         sourceDims = self.sourceDescriptor.dims
@@ -518,10 +485,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/05/2017
         '''
 
         # permute the dimensions of inField so the axes to remap are first,
@@ -579,16 +542,6 @@ class Remapper(object):
         outField = numpy.transpose(outField, axes=unpermuteAxes)
 
         return outField  # }}}
-
-
-def _get_lock_path(fileName):  # {{{
-    '''Returns the name of a temporary lock file unique to a given file name'''
-    directory = '{}/.locks/'.format(os.path.dirname(fileName))
-    try:
-        os.makedirs(directory)
-    except OSError:
-        pass
-    return '{}/{}.lock'.format(directory, os.path.basename(fileName))  # }}}
 
 
 def _get_temp_path():  # {{{

--- a/mpas_analysis/shared/io/__init__.py
+++ b/mpas_analysis/shared/io/__init__.py
@@ -1,2 +1,3 @@
 from .namelist_streams_interface import NameList, StreamsFile
-from .utility import paths
+from .utility import paths, make_directories, build_config_full_path,\
+    check_path_exists

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -12,7 +12,7 @@ import random
 import string
 
 
-def paths(*args): # {{{
+def paths(*args):  # {{{
     """
     Returns glob'd paths in list for arbitrary number of function arguments.
     Note, each expanded set of paths is sorted.
@@ -23,21 +23,21 @@ def paths(*args): # {{{
     paths = []
     for aargs in args:
         paths += sorted(glob.glob(aargs))
-    return paths # }}}
+    return paths  # }}}
 
 
 def fingerprint_generator(size=12,
-                          chars=string.ascii_uppercase + string.digits): # {{{
+                          chars=string.ascii_uppercase + string.digits):  # {{{
     """
-    Returns a random string that can be used as a unique fingerprint 
+    Returns a random string that can be used as a unique fingerprint
 
     Reference:
     http://stackoverflow.com/questions/2257441/random-string-generation-with-upper-case-letters-and-digits-in-python
-    
+
     Phillip J. Wolfram
     04/27/2017
     """
-    return ''.join(random.choice(chars) for _ in range(size)) # }}}
+    return ''.join(random.choice(chars) for _ in range(size))  # }}}
 
 
 def make_directories(path):  # {{{
@@ -59,7 +59,7 @@ def make_directories(path):  # {{{
 
 def build_config_full_path(config, section, relativePathOption,
                            relativePathSection=None,
-                           defaultPath=None): # {{{
+                           defaultPath=None):  # {{{
     """
     Returns a full path from a base directory and a relative path
 
@@ -102,7 +102,7 @@ def build_config_full_path(config, section, relativePathOption,
 
     if defaultPath is not None and not os.path.exists(fullPath):
         fullPath = defaultPath
-    return fullPath # }}}
+    return fullPath  # }}}
 
 
 def check_path_exists(path):  # {{{

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -19,7 +19,7 @@ Phillip J. Wolfram, Xylar Asay-Davis
 
 Last modified
 -------------
-02/22/2017
+05/08/2017
 """
 
 
@@ -119,11 +119,11 @@ def open_multifile_dataset(fileNames, calendar,
 def subset_variables(ds, variableList):  # {{{
     """
     Given a data set and a list of variable names, returns a new data set that
-    contains only variables with those names.
+    contains only variables or coords with those names.
 
     Parameters
     ----------
-    ds : xarray.DataSet object
+    ds : ``xarray.DataSet`` object
         The data set from which a subset of variables is to be extracted.
 
     variableList : string or list of strings
@@ -131,9 +131,9 @@ def subset_variables(ds, variableList):  # {{{
 
     Returns
     -------
-    ds : xarray.DataSet object
-        A copy of the original data set with only the variables in
-        variableList.
+    ds : ``xarray.DataSet`` object
+        A copy of the original data set with only the variables and/or coords
+        in ``variableList``.
 
     Raises
     ------
@@ -146,10 +146,11 @@ def subset_variables(ds, variableList):  # {{{
 
     Last modified
     -------------
-    02/16/2017
+    05/08/2017
     """
 
     allvars = ds.data_vars.keys()
+    allcoords = ds.coords.keys()
 
     # get set of variables to drop (all ds variables not in vlist)
     dropvars = set(allvars) - set(variableList)
@@ -161,17 +162,19 @@ def subset_variables(ds, variableList):  # {{{
     coords = set()
     for avar in ds.data_vars.keys():
         coords |= set(ds[avar].coords.keys())
+    coords |= set(variableList)
     dropcoords = set(ds.coords.keys()) - coords
 
     # drop spurious coordinates
     ds = ds.drop(dropcoords)
 
-    if len(ds.data_vars.keys()) == 0:
+    if len(ds.data_vars.keys()) == 0 and len(ds.coords.keys()) == 0:
         raise ValueError(
                 'Empty dataset is returned.\n'
                 'Variables {}\n'
                 'are not found within the dataset '
-                'variables: {}.'.format(variableList, allvars))
+                'variables: {}\n'
+                'or coords: {}.'.format(variableList, allvars, allcoords))
 
     return ds  # }}}
 

--- a/mpas_analysis/shared/variable_namelist_stream_maps/ocean_maps.py
+++ b/mpas_analysis/shared/variable_namelist_stream_maps/ocean_maps.py
@@ -80,12 +80,12 @@ oceanVariableMap['mld'] = \
      'time_avg_dThreshMLD_1',
      'timeMonthly_avg_dThreshMLD']
 
-oceanVariableMap['sst'] = \
+oceanVariableMap['temperature'] = \
     ['time_avg_activeTracers_temperature',
      'time_avg_activeTracers_temperature_1',
      'timeMonthly_avg_activeTracers_temperature']
 
-oceanVariableMap['sss'] = \
+oceanVariableMap['salinity'] = \
     ['time_avg_activeTracers_salinity',
      'time_avg_activeTracers_salinity_1',
      'timeMonthly_avg_activeTracers_salinity']

--- a/mpas_analysis/test/test_analysis_task
+++ b/mpas_analysis/test/test_analysis_task
@@ -1,0 +1,1 @@
+test_climatology

--- a/mpas_analysis/test/test_analysis_task.py
+++ b/mpas_analysis/test/test_analysis_task.py
@@ -5,15 +5,64 @@ Xylar Asay-Davis
 """
 
 import pytest
-from mpas_analysis.test import TestCase
+import shutil
+import tempfile
+import os
+
+from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.analysis_task import AnalysisTask
 from mpas_analysis.configuration.MpasAnalysisConfigParser \
     import MpasAnalysisConfigParser
 
 
+@pytest.mark.usefixtures("loaddatadir")
 class TestAnalysisTask(TestCase):
+    def setUp(self):
+        # Create a temporary directory
+        self.test_dir = tempfile.mkdtemp()
 
-    def test_checkGenerate(self):
+    def tearDown(self):
+        # Remove the directory after the test
+        shutil.rmtree(self.test_dir)
+
+    def setup_config(self):
+        config = MpasAnalysisConfigParser()
+        config.read('config.default')
+        config.set('input', 'baseDirectory', str(self.datadir))
+        config.set('input', 'mpasMeshName', 'QU240')
+
+        config.set('output', 'baseDirectory', self.test_dir)
+        config.set('output', 'mappingSubdirectory', '.')
+
+        config.set('climatology', 'startYear', '2')
+        config.set('climatology', 'endYear', '2')
+
+        return config
+
+    def setup_task(self, config):
+        task = AnalysisTask(config=config,
+                            taskName='genericClimatology',
+                            componentName='ocean',
+                            tags=['climatology', 'horizontalMap'])
+        task.setup_and_check()
+        return task
+
+    def test_setup_and_check(self):
+        config = self.setup_config()
+        task = self.setup_task(config)
+        # make sure everything was set up as expected
+        self.assertEqual(task.calendar, 'gregorian_noleap')
+        self.assertEqual(task.runDirectory, '{}/.'.format(self.datadir))
+        self.assertEqual(task.historyDirectory, '{}/.'.format(self.datadir))
+        self.assertEqual(task.plotsDirectory, '{}/plots'.format(self.test_dir))
+        assert(os.path.exists(task.plotsDirectory))
+        assert(task.namelistMap is not None)
+        assert(task.streamMap is not None)
+        assert(task.variableMap is not None)
+        assert(config.has_option('climatology', 'startDate'))
+        assert(config.has_option('climatology', 'endDate'))
+
+    def test_check_generate(self):
 
         def doTest(generate, expectedResults):
             config = MpasAnalysisConfigParser()
@@ -145,5 +194,73 @@ class TestAnalysisTask(TestCase):
         expectedResults['timeSeriesOHC'] = False
         doTest("['all', 'no_timeSeriesOHC']", expectedResults)
 
+    def test_update_start_end_date(self):
+        config = self.setup_config()
+        task = self.setup_task(config)
+
+        inputFileNames = \
+            task.get_input_file_names(streamName='timeSeriesStats',
+                                      startAndEndDateSection='climatology')
+
+        timeCache = task.cache_multifile_dataset_times(
+            inputFileNames, streamName='timeSeriesStats',
+            timeVariableName='Time')
+
+        # make sure the times have been cached
+        assert(os.path.exists(
+            '{}/timecache/ocean_timeSeriesStats_times.pickle'.format(
+                self.test_dir)))
+
+        for index, fileName in enumerate(timeCache.keys()):
+            assert(fileName == os.path.abspath(inputFileNames[index]))
+            assert(timeCache[fileName]['years'][0] == 2)
+            assert(timeCache[fileName]['months'][0] == index+1)
+
+        changed = task.update_start_end_date(section='climatology',
+                                             streamName='timeSeriesStats')
+
+        assert(not changed)
+        assert(config.getint('climatology', 'startYear') == 2)
+        assert(config.getint('climatology', 'endYear') == 2)
+        assert(config.get('climatology', 'startDate') == '0002-01-01_00:00:00')
+        assert(config.get('climatology', 'endDate') == '0002-12-31_23:59:59')
+
+        config.set('climatology', 'endYear', '50')
+
+        with self.assertWarns('climatology start and/or end year different '
+                              'from requested'):
+            changed = task.update_start_end_date(section='climatology',
+                                                 streamName='timeSeriesStats')
+
+        assert(changed)
+        assert(config.getint('climatology', 'startYear') == 2)
+        assert(config.getint('climatology', 'endYear') == 2)
+        assert(config.get('climatology', 'startDate') == '0002-01-01_00:00:00')
+        assert(config.get('climatology', 'endDate') == '0002-12-31_23:59:59')
+
+    def test_get_input_file_names(self):
+        config = self.setup_config()
+        task = self.setup_task(config)
+
+        inputFileNames = \
+            task.get_input_file_names(streamName='timeSeriesStats',
+                                      startDate='0002-01-01_00:00:00',
+                                      endDate='0002-03-01_00:00:00')
+
+        for index, month in enumerate([1, 2]):
+            expectedFileName = \
+                '{}/./timeSeries.0002-{:02d}-01.nc'.format(str(self.datadir),
+                                                           month)
+            assert(inputFileNames[index] == expectedFileName)
+
+        inputFileNames = \
+            task.get_input_file_names(streamName='timeSeriesStats',
+                                      startAndEndDateSection='climatology')
+
+        for index, month in enumerate([1, 2, 3]):
+            expectedFileName = \
+                '{}/./timeSeries.0002-{:02d}-01.nc'.format(str(self.datadir),
+                                                           month)
+            assert(inputFileNames[index] == expectedFileName)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_climatology/mpas-o_in
+++ b/mpas_analysis/test/test_climatology/mpas-o_in
@@ -1,0 +1,1083 @@
+&run_modes
+ config_ocean_run_mode = 'forward'
+/
+&time_management
+ config_calendar_type = 'gregorian_noleap'
+ config_do_restart = .true.
+ config_restart_timestamp_name = 'rpointer.ocn'
+ config_start_time = 'file'
+/
+&io
+ config_pio_num_iotasks = 0
+ config_pio_stride = 1
+ config_write_output_on_startup = .true.
+/
+&decomposition
+ config_block_decomp_file_prefix = '/lustre/scratch3/turquoise/jonbob/ACME/input_data/ocn/mpas-o/oQU240/mpas-o.graph.info.151209.part.'
+ config_explicit_proc_decomp = .false.
+ config_num_halos = 3
+ config_number_of_blocks = 0
+ config_proc_decomp_file_prefix = 'graph.info.part.'
+/
+&init_setup
+ config_expand_sphere = .false.
+ config_init_configuration = 'none'
+ config_realistic_coriolis_parameter = .false.
+ config_vert_levels = -1
+ config_vertical_grid = 'uniform'
+ config_write_cull_cell_mask = .true.
+/
+&cvtgenerator
+ config_1dcvtgenerator_dzseed = 1.2
+ config_1dcvtgenerator_stretch1 = 1.0770
+ config_1dcvtgenerator_stretch2 = 1.0275
+/
+&init_ssh_and_landicepressure
+ config_iterative_init_variable = 'landIcePressure'
+/
+&time_integration
+ config_dt = '01:00:00'
+ config_time_integrator = 'split_explicit'
+/
+&ale_vertical_grid
+ config_dzdk_positive = .false.
+ config_max_thickness_factor = 6.0
+ config_min_thickness = 1.0
+ config_use_min_max_thickness = .false.
+ config_vert_coord_movement = 'uniform_stretching'
+/
+&ale_frequency_filtered_thickness
+ config_highfreqthick_del2 = 100.0
+ config_highfreqthick_restore_time = 30.0
+ config_thickness_filter_timescale = 5.0
+ config_use_freq_filtered_thickness = .false.
+ config_use_highfreqthick_del2 = .false.
+ config_use_highfreqthick_restore = .false.
+/
+&partial_bottom_cells
+ config_alter_ics_for_pbcs = .false.
+ config_min_pbc_fraction = 0.10
+ config_pbc_alteration_type = 'full_cell'
+/
+&hmix
+ config_apvm_scale_factor = 0.0
+ config_hmix_scalewithmesh = .false.
+ config_maxmeshdensity = -1.0
+/
+&hmix_del2
+ config_mom_del2 = 10.0
+ config_tracer_del2 = 10.0
+ config_use_mom_del2 = .false.
+ config_use_tracer_del2 = .false.
+/
+&hmix_del4
+ config_mom_del4 = 2.0e14
+ config_mom_del4_div_factor = 1.0
+ config_tracer_del4 = 0.0
+ config_use_mom_del4 = .true.
+ config_use_tracer_del4 = .false.
+/
+&hmix_leith
+ config_leith_dx = 15000.0
+ config_leith_parameter = 1.0
+ config_leith_visc2_max = 2.5e3
+ config_use_leith_del2 = .false.
+/
+&mesoscale_eddy_parameterization
+ config_gravwavespeed_trunc = 0.3
+ config_max_relative_slope = 0.01
+ config_redi_bottom_layer_tapering_depth = 0.0
+ config_redi_kappa = 0.0
+ config_redi_surface_layer_tapering_extent = 0.0
+ config_standardgm_tracer_kappa = 600.0
+ config_use_redi_bottom_layer_tapering = .false.
+ config_use_redi_surface_layer_tapering = .false.
+ config_use_standardgm = .true.
+/
+&hmix_del2_tensor
+ config_mom_del2_tensor = 10.0
+ config_use_mom_del2_tensor = .false.
+/
+&hmix_del4_tensor
+ config_mom_del4_tensor = 5.0e13
+ config_use_mom_del4_tensor = .false.
+/
+&rayleigh_damping
+ config_rayleigh_damping_coeff = 0.0
+ config_rayleigh_friction = .false.
+/
+&vmix
+ config_convective_diff = 1.0
+ config_convective_visc = 1.0
+/
+&vmix_const
+ config_use_const_diff = .false.
+ config_use_const_visc = .false.
+ config_vert_diff = 1.0e-5
+ config_vert_visc = 1.0e-4
+/
+&vmix_rich
+ config_bkrd_vert_diff = 1.0e-5
+ config_bkrd_vert_visc = 1.0e-4
+ config_rich_mix = 0.005
+ config_use_rich_diff = .false.
+ config_use_rich_visc = .false.
+/
+&vmix_tanh
+ config_max_diff_tanh = 2.5e-2
+ config_max_visc_tanh = 2.5e-1
+ config_min_diff_tanh = 1.0e-5
+ config_min_visc_tanh = 1.0e-4
+ config_use_tanh_diff = .false.
+ config_use_tanh_visc = .false.
+ config_zmid_tanh = -100
+ config_zwidth_tanh = 100
+/
+&cvmix
+ config_cvmix_background_diffusion = 1.0e-5
+ config_cvmix_background_viscosity = 1.0e-4
+ config_cvmix_convective_basedonbvf = .true.
+ config_cvmix_convective_diffusion = 1.0
+ config_cvmix_convective_triggerbvf = 0.0
+ config_cvmix_convective_viscosity = 1.0
+ config_cvmix_kpp_boundary_layer_depth = 30.0
+ config_cvmix_kpp_criticalbulkrichardsonnumber = 0.25
+ config_cvmix_kpp_ekmanobl = .false.
+ config_cvmix_kpp_interpolationomltype = 'quadratic'
+ config_cvmix_kpp_matching = 'SimpleShapes'
+ config_cvmix_kpp_monobobl = .false.
+ config_cvmix_kpp_stop_obl_search = 100.0
+ config_cvmix_kpp_surface_layer_averaging = 5.0
+ config_cvmix_kpp_surface_layer_extent = 0.1
+ config_cvmix_kpp_use_enhanced_diff = .true.
+ config_cvmix_prandtl_number = 1.0
+ config_cvmix_shear_kpp_exp = 3
+ config_cvmix_shear_kpp_nu_zero = 0.005
+ config_cvmix_shear_kpp_ri_zero = 0.7
+ config_cvmix_shear_mixing_scheme = 'KPP'
+ config_cvmix_shear_pp_alpha = 5.0
+ config_cvmix_shear_pp_exp = 2.0
+ config_cvmix_shear_pp_nu_zero = 0.005
+ config_use_cvmix = .true.
+ config_use_cvmix_background = .true.
+ config_use_cvmix_convection = .true.
+ config_use_cvmix_double_diffusion = .false.
+ config_use_cvmix_fixed_boundary_layer = .false.
+ config_use_cvmix_kpp = .true.
+ config_use_cvmix_shear = .true.
+ config_use_cvmix_tidal_mixing = .false.
+ configure_cvmix_kpp_minimum_obl_under_sea_ice = 10.0
+/
+&forcing
+ config_flux_attenuation_coefficient = 0.001
+ config_flux_attenuation_coefficient_runoff = 10.0
+ config_use_bulk_thickness_flux = .true.
+ config_use_bulk_wind_stress = .true.
+/
+&shortwaveradiation
+ config_forcing_restart_file = 'Restart_forcing_time_stamp'
+ config_jerlov_water_type = 3
+ config_surface_buoyancy_depth = 1
+ config_sw_absorption_type = 'jerlov'
+/
+&frazil_ice
+ config_frazil_fractional_thickness_limit = 0.1
+ config_frazil_heat_of_fusion = 3.337e5
+ config_frazil_ice_density = 1000.0
+ config_frazil_in_open_ocean = .true.
+ config_frazil_land_ice_reference_salinity = 0.0
+ config_frazil_maximum_depth = 100.0
+ config_frazil_maximum_freezing_temperature = 0.0
+ config_frazil_sea_ice_reference_salinity = 4.0
+ config_frazil_under_land_ice = .true.
+ config_frazil_use_surface_pressure = .false.
+ config_specific_heat_sea_water = 3.996e3
+ config_use_frazil_ice_formation = .true.
+/
+&land_ice_fluxes
+ config_land_ice_flux_attenuation_coefficient = 10.0
+ config_land_ice_flux_boundarylayerneighborweight = 0.0
+ config_land_ice_flux_boundarylayerthickness = 10.0
+ config_land_ice_flux_cp_ice = 2.009e3
+ config_land_ice_flux_formulation = 'Jenkins'
+ config_land_ice_flux_isomip_gammat = 1e-4
+ config_land_ice_flux_jenkins_heat_transfer_coefficient = 0.011
+ config_land_ice_flux_jenkins_salt_transfer_coefficient = 3.1e-4
+ config_land_ice_flux_mode = 'off'
+ config_land_ice_flux_rho_ice = 918
+ config_land_ice_flux_rms_tidal_velocity = 5e-2
+ config_land_ice_flux_topdragcoeff = 2.5e-3
+ config_land_ice_flux_usehollandjenkinsadvdiff = .false.
+/
+&advection
+ config_coef_3rd_order = 0.25
+ config_horiz_tracer_adv_order = 3
+ config_monotonic = .true.
+ config_vert_tracer_adv = 'stencil'
+ config_vert_tracer_adv_order = 3
+/
+&bottom_drag
+ config_bottom_drag_coeff = 1.0e-3
+/
+&ocean_constants
+ config_density0 = 1026.0
+/
+&pressure_gradient
+ config_common_level_weight = 0.5
+ config_pressure_gradient_type = 'Jacobian_from_TS'
+/
+&eos
+ config_eos_type = 'jm'
+ config_land_ice_cavity_freezing_temperature_coeff_0 = 6.22e-2
+ config_land_ice_cavity_freezing_temperature_coeff_p = -7.43e-8
+ config_land_ice_cavity_freezing_temperature_coeff_ps = -1.74e-10
+ config_land_ice_cavity_freezing_temperature_coeff_s = -5.63e-2
+ config_land_ice_cavity_freezing_temperature_reference_pressure = 0.0
+ config_open_ocean_freezing_temperature_coeff_0 = -1.8
+ config_open_ocean_freezing_temperature_coeff_p = 0.0
+ config_open_ocean_freezing_temperature_coeff_ps = 0.0
+ config_open_ocean_freezing_temperature_coeff_s = 0.0
+ config_open_ocean_freezing_temperature_reference_pressure = 0.0
+/
+&eos_linear
+ config_eos_linear_alpha = 0.2
+ config_eos_linear_beta = 0.8
+ config_eos_linear_densityref = 1000.0
+ config_eos_linear_sref = 35.0
+ config_eos_linear_tref = 5.0
+/
+&split_explicit_ts
+ config_btr_dt = '0000_00:03:00'
+ config_btr_gam1_velwt1 = 0.5
+ config_btr_gam2_sshwt1 = 1.0
+ config_btr_gam3_velwt2 = 1.0
+ config_btr_solve_ssh2 = .false.
+ config_btr_subcycle_loop_factor = 2
+ config_n_bcl_iter_beg = 1
+ config_n_bcl_iter_end = 2
+ config_n_bcl_iter_mid = 2
+ config_n_btr_cor_iter = 2
+ config_n_ts_iter = 2
+ config_vel_correction = .true.
+/
+&testing
+ config_conduct_tests = .false.
+ config_tensor_test_function = 'sph_uCosCos'
+ config_test_tensors = .false.
+/
+&debug
+ config_check_ssh_consistency = .true.
+ config_check_tracer_monotonicity = .false.
+ config_check_zlevel_consistency = .false.
+ config_disable_redi_horizontal_term1 = .false.
+ config_disable_redi_horizontal_term2 = .false.
+ config_disable_redi_horizontal_term3 = .false.
+ config_disable_redi_k33 = .false.
+ config_disable_thick_all_tend = .false.
+ config_disable_thick_hadv = .false.
+ config_disable_thick_sflux = .false.
+ config_disable_thick_vadv = .false.
+ config_disable_tr_adv = .false.
+ config_disable_tr_all_tend = .false.
+ config_disable_tr_hmix = .false.
+ config_disable_tr_nonlocalflux = .false.
+ config_disable_tr_sflux = .false.
+ config_disable_tr_vmix = .false.
+ config_disable_vel_all_tend = .false.
+ config_disable_vel_coriolis = .false.
+ config_disable_vel_hmix = .false.
+ config_disable_vel_pgrad = .false.
+ config_disable_vel_surface_stress = .false.
+ config_disable_vel_vadv = .false.
+ config_disable_vel_vmix = .false.
+ config_filter_btr_mode = .false.
+ config_include_ke_vertex = .false.
+ config_prescribe_thickness = .false.
+ config_prescribe_velocity = .false.
+ config_read_nearest_restart = .false.
+/
+&constrain_haney_number
+ config_rx1_horiz_smooth_open_ocean_cells = 20
+ config_rx1_horiz_smooth_weight = 1.0
+ config_rx1_init_inner_weight = 0.1
+ config_rx1_inner_iter_count = 10
+ config_rx1_max = 5.0
+ config_rx1_min_layer_thickness = 1.0
+ config_rx1_min_levels = 3
+ config_rx1_outer_iter_count = 20
+ config_rx1_slope_weight = 1e-1
+ config_rx1_vert_smooth_weight = 1.0
+ config_rx1_zstar_weight = 1.0
+ config_use_rx1_constraint = .false.
+/
+&baroclinic_channel
+ config_baroclinic_channel_bottom_depth = 1000.0
+ config_baroclinic_channel_bottom_temperature = 10.1
+ config_baroclinic_channel_coriolis_parameter = -1.2e-4
+ config_baroclinic_channel_gradient_width_dist = 40e3
+ config_baroclinic_channel_gradient_width_frac = 0.08
+ config_baroclinic_channel_salinity = 35.0
+ config_baroclinic_channel_surface_temperature = 13.1
+ config_baroclinic_channel_temperature_difference = 1.2
+ config_baroclinic_channel_use_distances = .false.
+ config_baroclinic_channel_vert_levels = 20
+/
+&lock_exchange
+ config_lock_exchange_bottom_depth = 20.0
+ config_lock_exchange_cold_temperature = 5.0
+ config_lock_exchange_direction = 'y'
+ config_lock_exchange_isopycnal_min_thickness = 0.01
+ config_lock_exchange_layer_type = 'z-level'
+ config_lock_exchange_salinity = 35.0
+ config_lock_exchange_vert_levels = 20
+ config_lock_exchange_warm_temperature = 30.0
+/
+&internal_waves
+ config_internal_waves_amplitude_width_dist = 50e3
+ config_internal_waves_amplitude_width_frac = 0.33
+ config_internal_waves_bottom_depth = 500.0
+ config_internal_waves_bottom_temperature = 10.1
+ config_internal_waves_isopycnal_displacement = 125.0
+ config_internal_waves_layer_type = 'z-level'
+ config_internal_waves_salinity = 35.0
+ config_internal_waves_surface_temperature = 20.1
+ config_internal_waves_temperature_difference = 2.0
+ config_internal_waves_use_distances = false
+ config_internal_waves_vert_levels = 20
+/
+&overflow
+ config_overflow_bottom_depth = 2000.0
+ config_overflow_domain_temperature = 20.0
+ config_overflow_isopycnal_min_thickness = 0.01
+ config_overflow_layer_type = 'z-level'
+ config_overflow_plug_temperature = 10.0
+ config_overflow_plug_width_dist = 20e3
+ config_overflow_plug_width_frac = 0.10
+ config_overflow_ridge_depth = 500.0
+ config_overflow_salinity = 35.0
+ config_overflow_slope_center_dist = 40e3
+ config_overflow_slope_center_frac = 0.20
+ config_overflow_slope_width_dist = 7e3
+ config_overflow_slope_width_frac = 0.05
+ config_overflow_use_distances = false
+ config_overflow_vert_levels = 100
+/
+&global_ocean
+ config_global_ocean_chlorophyll_varname = 'none'
+ config_global_ocean_clearsky_varname = 'none'
+ config_global_ocean_cull_inland_seas = .true.
+ config_global_ocean_deepen_critical_passages = .true.
+ config_global_ocean_depress_by_land_ice = .false.
+ config_global_ocean_depth_conversion_factor = 1.0
+ config_global_ocean_depth_dimname = 'none'
+ config_global_ocean_depth_file = 'none'
+ config_global_ocean_depth_varname = 'none'
+ config_global_ocean_ecosys_depth_conversion_factor = 1.0
+ config_global_ocean_ecosys_depth_varname = 'none'
+ config_global_ocean_ecosys_file = 'unknown'
+ config_global_ocean_ecosys_forcing_file = 'unknown'
+ config_global_ocean_ecosys_forcing_time_dimname = 'none'
+ config_global_ocean_ecosys_lat_varname = 'none'
+ config_global_ocean_ecosys_latlon_degrees = .true.
+ config_global_ocean_ecosys_lon_varname = 'none'
+ config_global_ocean_ecosys_method = 'bilinear_interpolation'
+ config_global_ocean_ecosys_ndepth_dimname = 'none'
+ config_global_ocean_ecosys_nlat_dimname = 'none'
+ config_global_ocean_ecosys_nlon_dimname = 'none'
+ config_global_ocean_ecosys_vert_levels = -1
+ config_global_ocean_interior_restore_rate = 1.0e-7
+ config_global_ocean_land_ice_topo_draft_varname = 'none'
+ config_global_ocean_land_ice_topo_file = 'none'
+ config_global_ocean_land_ice_topo_grounded_frac_varname = 'none'
+ config_global_ocean_land_ice_topo_ice_frac_varname = 'none'
+ config_global_ocean_land_ice_topo_lat_varname = 'none'
+ config_global_ocean_land_ice_topo_latlon_degrees = .true.
+ config_global_ocean_land_ice_topo_lon_varname = 'none'
+ config_global_ocean_land_ice_topo_nlat_dimname = 'none'
+ config_global_ocean_land_ice_topo_nlon_dimname = 'none'
+ config_global_ocean_land_ice_topo_thickness_varname = 'none'
+ config_global_ocean_minimum_depth = 15
+ config_global_ocean_piston_velocity = 5.0e-5
+ config_global_ocean_salinity_file = 'none'
+ config_global_ocean_salinity_varname = 'none'
+ config_global_ocean_smooth_ecosys_iterations = 0
+ config_global_ocean_smooth_topography = .true.
+ config_global_ocean_smooth_ts_iterations = 0
+ config_global_ocean_swdata_file = 'none'
+ config_global_ocean_swdata_lat_varname = 'none'
+ config_global_ocean_swdata_latlon_degrees = .true.
+ config_global_ocean_swdata_lon_varname = 'none'
+ config_global_ocean_swdata_method = 'bilinear_interpolation'
+ config_global_ocean_swdata_nlat_dimname = 'none'
+ config_global_ocean_swdata_nlon_dimname = 'none'
+ config_global_ocean_temperature_file = 'none'
+ config_global_ocean_temperature_varname = 'none'
+ config_global_ocean_topography_file = 'none'
+ config_global_ocean_topography_has_ocean_frac = .false.
+ config_global_ocean_topography_lat_varname = 'none'
+ config_global_ocean_topography_latlon_degrees = .true.
+ config_global_ocean_topography_lon_varname = 'none'
+ config_global_ocean_topography_method = 'bilinear_interpolation'
+ config_global_ocean_topography_nlat_dimname = 'none'
+ config_global_ocean_topography_nlon_dimname = 'none'
+ config_global_ocean_topography_ocean_frac_varname = 'none'
+ config_global_ocean_topography_varname = 'none'
+ config_global_ocean_tracer_depth_conversion_factor = 1.0
+ config_global_ocean_tracer_depth_varname = 'none'
+ config_global_ocean_tracer_lat_varname = 'none'
+ config_global_ocean_tracer_latlon_degrees = .true.
+ config_global_ocean_tracer_lon_varname = 'none'
+ config_global_ocean_tracer_method = 'bilinear_interpolation'
+ config_global_ocean_tracer_ndepth_dimname = 'none'
+ config_global_ocean_tracer_nlat_dimname = 'none'
+ config_global_ocean_tracer_nlon_dimname = 'none'
+ config_global_ocean_tracer_vert_levels = -1
+ config_global_ocean_windstress_conversion_factor = 1
+ config_global_ocean_windstress_file = 'none'
+ config_global_ocean_windstress_lat_varname = 'none'
+ config_global_ocean_windstress_latlon_degrees = .true.
+ config_global_ocean_windstress_lon_varname = 'none'
+ config_global_ocean_windstress_meridional_varname = 'none'
+ config_global_ocean_windstress_method = 'bilinear_interpolation'
+ config_global_ocean_windstress_nlat_dimname = 'none'
+ config_global_ocean_windstress_nlon_dimname = 'none'
+ config_global_ocean_windstress_zonal_varname = 'none'
+ config_global_ocean_zenithangle_varname = 'none'
+/
+&cvmix_wswsbf
+ config_cvmix_wswsbf_bottom_depth = 400.0
+ config_cvmix_wswsbf_coriolis_parameter = 1.0e-4
+ config_cvmix_wswsbf_evaporation_flux = 0.0
+ config_cvmix_wswsbf_interior_salinity_restoring_rate = 1.0e-6
+ config_cvmix_wswsbf_interior_temperature_restoring_rate = 1.0e-6
+ config_cvmix_wswsbf_latent_heat_flux = 0.0
+ config_cvmix_wswsbf_max_windstress = 0.10
+ config_cvmix_wswsbf_mixed_layer_depth_salinity = 0.0
+ config_cvmix_wswsbf_mixed_layer_depth_temperature = 0.0
+ config_cvmix_wswsbf_mixed_layer_salinity_change = 0.0
+ config_cvmix_wswsbf_mixed_layer_temperature_change = 0.0
+ config_cvmix_wswsbf_rain_flux = 0.0
+ config_cvmix_wswsbf_salinity_gradient = 0.0
+ config_cvmix_wswsbf_salinity_gradient_mixed_layer = 0.0
+ config_cvmix_wswsbf_salinity_piston_velocity = 4.0e-6
+ config_cvmix_wswsbf_sensible_heat_flux = 0.0
+ config_cvmix_wswsbf_shortwave_heat_flux = 0.0
+ config_cvmix_wswsbf_surface_restoring_salinity = 35.0
+ config_cvmix_wswsbf_surface_restoring_temperature = 15.0
+ config_cvmix_wswsbf_surface_salinity = 35.0
+ config_cvmix_wswsbf_surface_temperature = 15.0
+ config_cvmix_wswsbf_temperature_gradient = 0.01
+ config_cvmix_wswsbf_temperature_gradient_mixed_layer = 0.0
+ config_cvmix_wswsbf_temperature_piston_velocity = 4.0e-6
+ config_cvmix_wswsbf_vert_levels = 100
+ config_cvmix_wswsbf_vertical_grid = 'uniform'
+/
+&iso
+ config_iso_acc_wind = 0.2
+ config_iso_asf_wind = -0.05
+ config_iso_cont_slope_flag = .true.
+ config_iso_depression_center_lon = 60
+ config_iso_depression_depth = 800
+ config_iso_depression_flag = .true.
+ config_iso_depression_north_lat = -65
+ config_iso_depression_south_lat = -72
+ config_iso_depression_width = 480000
+ config_iso_embayment_center_lat = -71
+ config_iso_embayment_center_lon = 60
+ config_iso_embayment_depth = 2000
+ config_iso_embayment_flag = .true.
+ config_iso_embayment_radius = 500000
+ config_iso_heat_flux_lat_mn = -53
+ config_iso_heat_flux_lat_sm = -65
+ config_iso_heat_flux_lat_ss = -70
+ config_iso_heat_flux_middle = 10
+ config_iso_heat_flux_north = -5
+ config_iso_heat_flux_region1 = -5
+ config_iso_heat_flux_region1_flag = false
+ config_iso_heat_flux_region1_radius = 300000
+ config_iso_heat_flux_region2 = -5
+ config_iso_heat_flux_region2_flag = false
+ config_iso_heat_flux_region2_radius = 240000
+ config_iso_heat_flux_south = -5
+ config_iso_initial_temp_h0 = 1200
+ config_iso_initial_temp_h1 = 500
+ config_iso_initial_temp_latn = -50
+ config_iso_initial_temp_lats = -75
+ config_iso_initial_temp_mt = 0.000075
+ config_iso_initial_temp_t1 = 3.5
+ config_iso_initial_temp_t2 = 4.0
+ config_iso_main_channel_depth = 4000.0
+ config_iso_max_cont_slope = 0.01
+ config_iso_north_wall_lat = -50
+ config_iso_plateau_center_lat = -58
+ config_iso_plateau_center_lon = 300
+ config_iso_plateau_flag = .true.
+ config_iso_plateau_height = 2000
+ config_iso_plateau_radius = 200000
+ config_iso_plateau_slope_width = 1000000
+ config_iso_region1_center_lat = -75
+ config_iso_region1_center_lon = 60
+ config_iso_region2_center_lat = -71
+ config_iso_region2_center_lon = 150
+ config_iso_region3_center_lat = -71
+ config_iso_region3_center_lon = 240
+ config_iso_region4_center_lat = -71
+ config_iso_region4_center_lon = 330
+ config_iso_ridge_center_lon = 180
+ config_iso_ridge_flag = .true.
+ config_iso_ridge_height = 2000.0
+ config_iso_ridge_width = 2000000
+ config_iso_salinity = 35.0
+ config_iso_shelf_depth = 500
+ config_iso_shelf_flag = .true.
+ config_iso_shelf_width = 120000
+ config_iso_south_wall_lat = -70
+ config_iso_surface_temperature_piston_velocity = 5.787e-5
+ config_iso_temperature_restore_lcx1 = 600000
+ config_iso_temperature_restore_lcx2 = 600000
+ config_iso_temperature_restore_lcx3 = 600000
+ config_iso_temperature_restore_lcx4 = 600000
+ config_iso_temperature_restore_lcy1 = 600000
+ config_iso_temperature_restore_lcy2 = 250000
+ config_iso_temperature_restore_lcy3 = 250000
+ config_iso_temperature_restore_lcy4 = 250000
+ config_iso_temperature_restore_region1_flag = .true.
+ config_iso_temperature_restore_region2_flag = .true.
+ config_iso_temperature_restore_region3_flag = .true.
+ config_iso_temperature_restore_region4_flag = .true.
+ config_iso_temperature_restore_t1 = -1
+ config_iso_temperature_restore_t2 = -1
+ config_iso_temperature_restore_t3 = -1
+ config_iso_temperature_restore_t4 = -1
+ config_iso_temperature_sponge_h1 = 1000
+ config_iso_temperature_sponge_l1 = 120000
+ config_iso_temperature_sponge_t1 = 10
+ config_iso_temperature_sponge_tau1 = 10.0
+ config_iso_vert_levels = 100
+ config_iso_wind_stress_max = 0.01
+ config_iso_wind_trans = -65
+/
+&soma
+ config_soma_bottom_depth = 2500.0
+ config_soma_center_latitude = 35.0
+ config_soma_center_longitude = 0.0
+ config_soma_density_difference = 4.0
+ config_soma_density_difference_linear = 0.05
+ config_soma_domain_width = 1.25e6
+ config_soma_phi = 0.1
+ config_soma_ref_density = 1000.0
+ config_soma_shelf_depth = 100.0
+ config_soma_shelf_width = -0.4
+ config_soma_surface_salinity = 33.0
+ config_soma_surface_temperature = 20.0
+ config_soma_thermocline_depth = 300.0
+ config_soma_vert_levels = 100
+/
+&ziso
+ config_ziso_add_easterly_wind_stress_asf = false
+ config_ziso_antarctic_shelf_front_width = 600000
+ config_ziso_bottom_depth = 2500.0
+ config_ziso_coriolis_gradient = 1e-11
+ config_ziso_frazil_enable = false
+ config_ziso_frazil_temperature_anomaly = -3.0
+ config_ziso_initial_temp_h1 = 300.0
+ config_ziso_initial_temp_mt = 7.5e-5
+ config_ziso_initial_temp_t1 = 6.0
+ config_ziso_initial_temp_t2 = 3.6
+ config_ziso_mean_restoring_temp = 3.0
+ config_ziso_meridional_extent = 2.0e6
+ config_ziso_reference_coriolis = -1e-4
+ config_ziso_restoring_sponge_l = 8.0e4
+ config_ziso_restoring_temp_dev_ta = 2.0
+ config_ziso_restoring_temp_dev_tb = 2.0
+ config_ziso_restoring_temp_piston_vel = 1.93e-5
+ config_ziso_restoring_temp_tau = 30.0
+ config_ziso_restoring_temp_ze = 1250.0
+ config_ziso_shelf_depth = 500.0
+ config_ziso_slope_center_position = 5.0e5
+ config_ziso_slope_half_width = 1.0e5
+ config_ziso_use_slopping_bathymetry = false
+ config_ziso_vert_levels = 100
+ config_ziso_wind_stress_max = 0.2
+ config_ziso_wind_stress_shelf_front_max = -0.05
+ config_ziso_wind_transition_position = 800000.0
+ config_ziso_zonal_extent = 1.0e6
+/
+&sub_ice_shelf_2d
+ config_sub_ice_shelf_2d_bottom_depth = 2000.0
+ config_sub_ice_shelf_2d_bottom_salinity = 34.7
+ config_sub_ice_shelf_2d_cavity_thickness = 25.0
+ config_sub_ice_shelf_2d_edge_width = 15.0e3
+ config_sub_ice_shelf_2d_slope_height = 500.0
+ config_sub_ice_shelf_2d_surface_salinity = 34.5
+ config_sub_ice_shelf_2d_temperature = 1.0
+ config_sub_ice_shelf_2d_vert_levels = 20
+ config_sub_ice_shelf_2d_y1 = 30.0e3
+ config_sub_ice_shelf_2d_y2 = 60.0e3
+/
+&periodic_planar
+ config_periodic_planar_bottom_depth = 2500.0
+ config_periodic_planar_velocity_strength = 1.0
+ config_periodic_planar_vert_levels = 100
+/
+&ecosys_column
+ config_ecosys_column_bottom_depth = 6000.0
+ config_ecosys_column_ecosys_filename = 'unknown'
+ config_ecosys_column_ts_filename = 'unknown'
+ config_ecosys_column_vert_levels = 100
+ config_ecosys_column_vertical_grid = '100layerACMEv1'
+/
+&sea_mount
+ config_sea_mount_bottom_depth = 5000.0
+ config_sea_mount_coriolis_parameter = -1.0e-4
+ config_sea_mount_density_alpha = 0.2
+ config_sea_mount_density_coef_exp = 1028
+ config_sea_mount_density_coef_linear = 1024
+ config_sea_mount_density_depth_exp = 500
+ config_sea_mount_density_depth_linear = 4500
+ config_sea_mount_density_gradient_exp = 3.0
+ config_sea_mount_density_gradient_linear = 0.1
+ config_sea_mount_density_ref = 1028
+ config_sea_mount_density_tref = 5.0
+ config_sea_mount_height = 4500.0
+ config_sea_mount_layer_type = 'sigma'
+ config_sea_mount_radius = 10.0e3
+ config_sea_mount_salinity = 35.0
+ config_sea_mount_stratification_type = 'exponential'
+ config_sea_mount_vert_levels = 10
+ config_sea_mount_width = 40.0e3
+/
+&isomip
+ config_isomip_bottom_depth = -900.0
+ config_isomip_coriolis_parameter = -1.4e-4
+ config_isomip_eastern_boundary = 500e3
+ config_isomip_ice_fraction1 = 1.0
+ config_isomip_ice_fraction2 = 1.0
+ config_isomip_ice_fraction3 = 1.0
+ config_isomip_northern_boundary = 1000e3
+ config_isomip_restoring_salinity = 34.4
+ config_isomip_restoring_temperature = -1.9
+ config_isomip_salinity = 34.4
+ config_isomip_salinity_piston_velocity = 1.157e-5
+ config_isomip_southern_boundary = 0.0
+ config_isomip_temperature = -1.9
+ config_isomip_temperature_piston_velocity = 1.157e-5
+ config_isomip_vert_levels = 30
+ config_isomip_vertical_level_distribution = 'constant'
+ config_isomip_western_boundary = 0.0
+ config_isomip_y1 = 0.0
+ config_isomip_y2 = 400e3
+ config_isomip_y3 = 1000e3
+ config_isomip_z1 = -700.0
+ config_isomip_z2 = -200.0
+ config_isomip_z3 = -200.0
+/
+&isomip_plus
+ config_isomip_plus_coriolis_parameter = -1.409e-4
+ config_isomip_plus_effective_density = 1026.
+ config_isomip_plus_init_bot_sal = 34.5
+ config_isomip_plus_init_bot_temp = -1.9
+ config_isomip_plus_init_top_sal = 33.8
+ config_isomip_plus_init_top_temp = -1.9
+ config_isomip_plus_max_bottom_depth = -720.0
+ config_isomip_plus_min_column_thickness = 10.0
+ config_isomip_plus_min_ocean_fraction = 0.5
+ config_isomip_plus_minimum_levels = 3
+ config_isomip_plus_restore_bot_sal = 34.7
+ config_isomip_plus_restore_bot_temp = 1.0
+ config_isomip_plus_restore_evap_rate = 200
+ config_isomip_plus_restore_rate = 10.0
+ config_isomip_plus_restore_top_sal = 33.8
+ config_isomip_plus_restore_top_temp = -1.9
+ config_isomip_plus_restore_xmax = 800.0e3
+ config_isomip_plus_restore_xmin = 790.0e3
+ config_isomip_plus_topography_file = 'input_geometry_processed.nc'
+ config_isomip_plus_vert_levels = 36
+ config_isomip_plus_vertical_level_distribution = 'constant'
+/
+&tracer_forcing_activetracers
+ config_salinity_restoring_constant_piston_velocity = 0.0
+ config_salinity_restoring_max_difference = 0.5
+ config_use_activetracers = .true.
+ config_use_activetracers_exponential_decay = .false.
+ config_use_activetracers_idealage_forcing = .false.
+ config_use_activetracers_interior_restoring = .false.
+ config_use_activetracers_surface_bulk_forcing = .true.
+ config_use_activetracers_surface_restoring = .false.
+ config_use_activetracers_ttd_forcing = .false.
+ config_use_surface_salinity_monthly_restoring = .false.
+/
+&tracer_forcing_debugtracers
+ config_use_debugtracers = .false.
+ config_use_debugtracers_exponential_decay = .false.
+ config_use_debugtracers_idealage_forcing = .false.
+ config_use_debugtracers_interior_restoring = .false.
+ config_use_debugtracers_surface_bulk_forcing = .false.
+ config_use_debugtracers_surface_restoring = .false.
+ config_use_debugtracers_ttd_forcing = .false.
+/
+&tracer_forcing_ecosystracers
+ config_use_ecosystracers = .false.
+ config_use_ecosystracers_exponential_decay = .false.
+ config_use_ecosystracers_idealage_forcing = .false.
+ config_use_ecosystracers_interior_restoring = .false.
+ config_use_ecosystracers_sea_ice_coupling = .false.
+ config_use_ecosystracers_surface_bulk_forcing = .false.
+ config_use_ecosystracers_surface_restoring = .false.
+ config_use_ecosystracers_surface_value = .false.
+ config_use_ecosystracers_ttd_forcing = .false.
+/
+&tracer_forcing_dmstracers
+ config_use_dmstracers = .false.
+ config_use_dmstracers_exponential_decay = .false.
+ config_use_dmstracers_idealage_forcing = .false.
+ config_use_dmstracers_interior_restoring = .false.
+ config_use_dmstracers_sea_ice_coupling = .false.
+ config_use_dmstracers_surface_bulk_forcing = .false.
+ config_use_dmstracers_surface_restoring = .false.
+ config_use_dmstracers_surface_value = .false.
+ config_use_dmstracers_ttd_forcing = .false.
+/
+&tracer_forcing_macromoleculestracers
+ config_use_macromoleculestracers = .false.
+ config_use_macromoleculestracers_exponential_decay = .false.
+ config_use_macromoleculestracers_idealage_forcing = .false.
+ config_use_macromoleculestracers_interior_restoring = .false.
+ config_use_macromoleculestracers_sea_ice_coupling = .false.
+ config_use_macromoleculestracers_surface_bulk_forcing = .false.
+ config_use_macromoleculestracers_surface_restoring = .false.
+ config_use_macromoleculestracers_surface_value = .false.
+ config_use_macromoleculestracers_ttd_forcing = .false.
+/
+&am_globalstats
+ config_am_globalstats_compute_interval = 'output_interval'
+ config_am_globalstats_compute_on_startup = .true.
+ config_am_globalstats_directory = 'analysis_members'
+ config_am_globalstats_enable = .true.
+ config_am_globalstats_output_stream = 'globalStatsOutput'
+ config_am_globalstats_text_file = .false.
+ config_am_globalstats_write_on_startup = .true.
+/
+&am_surfaceareaweightedaverages
+ config_am_surfaceareaweightedaverages_compute_interval = '0000-00-00_01:00:00'
+ config_am_surfaceareaweightedaverages_compute_on_startup = .true.
+ config_am_surfaceareaweightedaverages_enable = .true.
+ config_am_surfaceareaweightedaverages_output_stream = 'surfaceAreaWeightedAveragesOutput'
+ config_am_surfaceareaweightedaverages_write_on_startup = .true.
+/
+&am_watermasscensus
+ config_am_watermasscensus_compute_interval = '0000-00-00_01:00:00'
+ config_am_watermasscensus_compute_on_startup = .true.
+ config_am_watermasscensus_enable = .false.
+ config_am_watermasscensus_maxsalinity = 37.0
+ config_am_watermasscensus_maxtemperature = 30.0
+ config_am_watermasscensus_minsalinity = 32.0
+ config_am_watermasscensus_mintemperature = -2.0
+ config_am_watermasscensus_output_stream = 'waterMassCensusOutput'
+ config_am_watermasscensus_write_on_startup = .true.
+/
+&am_layervolumeweightedaverage
+ config_am_layervolumeweightedaverage_compute_interval = '0000-00-00_01:00:00'
+ config_am_layervolumeweightedaverage_compute_on_startup = .true.
+ config_am_layervolumeweightedaverage_enable = .true.
+ config_am_layervolumeweightedaverage_output_stream = 'layerVolumeWeightedAverageOutput'
+ config_am_layervolumeweightedaverage_write_on_startup = .true.
+/
+&am_zonalmean
+ config_am_zonalmean_compute_interval = '0000-00-00_01:00:00'
+ config_am_zonalmean_compute_on_startup = .true.
+ config_am_zonalmean_enable = .false.
+ config_am_zonalmean_max_bin = -1.0e34
+ config_am_zonalmean_min_bin = -1.0e34
+ config_am_zonalmean_num_bins = 180
+ config_am_zonalmean_output_stream = 'zonalMeanOutput'
+ config_am_zonalmean_write_on_startup = .true.
+/
+&am_okuboweiss
+ config_am_okuboweiss_compute_eddy_census = .true.
+ config_am_okuboweiss_compute_interval = '0000-00-00_01:00:00'
+ config_am_okuboweiss_compute_on_startup = .true.
+ config_am_okuboweiss_directory = 'analysis_members'
+ config_am_okuboweiss_eddy_min_cells = 20
+ config_am_okuboweiss_enable = .false.
+ config_am_okuboweiss_lambda2_normalization = 1e-10
+ config_am_okuboweiss_normalization = 1e-10
+ config_am_okuboweiss_output_stream = 'okuboWeissOutput'
+ config_am_okuboweiss_threshold_value = -0.2
+ config_am_okuboweiss_use_lat_lon_coords = .true.
+ config_am_okuboweiss_write_on_startup = .true.
+/
+&am_meridionalheattransport
+ config_am_meridionalheattransport_compute_interval = '0000-00-00_01:00:00'
+ config_am_meridionalheattransport_compute_on_startup = .true.
+ config_am_meridionalheattransport_enable = .true.
+ config_am_meridionalheattransport_max_bin = -1.0e34
+ config_am_meridionalheattransport_min_bin = -1.0e34
+ config_am_meridionalheattransport_num_bins = 180
+ config_am_meridionalheattransport_output_stream = 'meridionalHeatTransportOutput'
+ config_am_meridionalheattransport_write_on_startup = .true.
+/
+&am_testcomputeinterval
+ config_am_testcomputeinterval_compute_interval = '00-00-01_00:00:00'
+ config_am_testcomputeinterval_compute_on_startup = .true.
+ config_am_testcomputeinterval_enable = .false.
+ config_am_testcomputeinterval_output_stream = 'testComputeIntervalOutput'
+ config_am_testcomputeinterval_write_on_startup = .true.
+/
+&am_highfrequencyoutput
+ config_am_highfrequencyoutput_compute_interval = 'output_interval'
+ config_am_highfrequencyoutput_compute_on_startup = .true.
+ config_am_highfrequencyoutput_enable = .false.
+ config_am_highfrequencyoutput_output_stream = 'highFrequencyOutput'
+ config_am_highfrequencyoutput_write_on_startup = .true.
+/
+&am_timefilters
+ config_am_timefilters_compute_cell_centered_values = .true.
+ config_am_timefilters_compute_interval = 'dt'
+ config_am_timefilters_compute_on_startup = .true.
+ config_am_timefilters_enable = .false.
+ config_am_timefilters_initialize_filters = .true.
+ config_am_timefilters_output_stream = 'timeFiltersOutput'
+ config_am_timefilters_restart_stream = 'timeFiltersRestart'
+ config_am_timefilters_tau = '90_00:00:00'
+ config_am_timefilters_write_on_startup = .true.
+/
+&am_lagrparttrack
+ config_am_lagrparttrack_compute_interval = 'dt'
+ config_am_lagrparttrack_compute_on_startup = .false.
+ config_am_lagrparttrack_enable = .false.
+ config_am_lagrparttrack_filter_number = 0
+ config_am_lagrparttrack_input_stream = 'lagrPartTrackInput'
+ config_am_lagrparttrack_output_stream = 'lagrPartTrackOutput'
+ config_am_lagrparttrack_region_stream = 'lagrPartTrackRegions'
+ config_am_lagrparttrack_reset_criteria = 'none'
+ config_am_lagrparttrack_reset_global_timestamp = '0000_00:00:00'
+ config_am_lagrparttrack_reset_if_inside_region = .false.
+ config_am_lagrparttrack_reset_if_outside_region = .false.
+ config_am_lagrparttrack_restart_stream = 'lagrPartTrackRestart'
+ config_am_lagrparttrack_write_on_startup = .true.
+/
+&am_eliassenpalm
+ config_am_eliassenpalm_compute_interval = 'output_interval'
+ config_am_eliassenpalm_compute_on_startup = .true.
+ config_am_eliassenpalm_debug = .false.
+ config_am_eliassenpalm_enable = .false.
+ config_am_eliassenpalm_nbuoyancylayers = 45
+ config_am_eliassenpalm_output_stream = 'eliassenPalmOutput'
+ config_am_eliassenpalm_restart_stream = 'eliassenPalmRestart'
+ config_am_eliassenpalm_rhomax_buoycoor = 1080
+ config_am_eliassenpalm_rhomin_buoycoor = 900
+ config_am_eliassenpalm_write_on_startup = .true.
+/
+&am_mixedlayerdepths
+ config_am_mixedlayerdepths_compute_interval = '0000-00-00_01:00:00'
+ config_am_mixedlayerdepths_compute_on_startup = .true.
+ config_am_mixedlayerdepths_crit_dens_threshold = 0.03
+ config_am_mixedlayerdepths_crit_temp_threshold = 0.2
+ config_am_mixedlayerdepths_den_gradient_threshold = 5E-8
+ config_am_mixedlayerdepths_dgradient = .true.
+ config_am_mixedlayerdepths_dthreshold = .true.
+ config_am_mixedlayerdepths_enable = .true.
+ config_am_mixedlayerdepths_interp_method = 1
+ config_am_mixedlayerdepths_output_stream = 'mixedLayerDepthsOutput'
+ config_am_mixedlayerdepths_reference_pressure = 1.0E5
+ config_am_mixedlayerdepths_temp_gradient_threshold = 5E-7
+ config_am_mixedlayerdepths_tgradient = .true.
+ config_am_mixedlayerdepths_tthreshold = .true.
+ config_am_mixedlayerdepths_write_on_startup = .true.
+/
+&am_regionalstatsdaily
+ config_am_regionalstatsdaily_1d_weighting_field = 'areaCell'
+ config_am_regionalstatsdaily_1d_weighting_function = 'mul'
+ config_am_regionalstatsdaily_2d_weighting_field = 'volumeCell'
+ config_am_regionalstatsdaily_2d_weighting_function = 'mul'
+ config_am_regionalstatsdaily_compute_interval = 'output_interval'
+ config_am_regionalstatsdaily_compute_on_startup = .false.
+ config_am_regionalstatsdaily_enable = .false.
+ config_am_regionalstatsdaily_input_stream = 'regionalMasksInput'
+ config_am_regionalstatsdaily_operation = 'avg'
+ config_am_regionalstatsdaily_output_stream = 'regionalStatsDailyOutput'
+ config_am_regionalstatsdaily_region_group = 'all'
+ config_am_regionalstatsdaily_region_type = 'cell'
+ config_am_regionalstatsdaily_restart_stream = 'regionalMasksInput'
+ config_am_regionalstatsdaily_vertical_dimension = 'nVertLevels'
+ config_am_regionalstatsdaily_vertical_mask = 'cellMask'
+ config_am_regionalstatsdaily_write_on_startup = .false.
+/
+&am_regionalstatsweekly
+ config_am_regionalstatsweekly_1d_weighting_field = 'areaCell'
+ config_am_regionalstatsweekly_1d_weighting_function = 'mul'
+ config_am_regionalstatsweekly_2d_weighting_field = 'volumeCell'
+ config_am_regionalstatsweekly_2d_weighting_function = 'mul'
+ config_am_regionalstatsweekly_compute_interval = 'output_interval'
+ config_am_regionalstatsweekly_compute_on_startup = .false.
+ config_am_regionalstatsweekly_enable = .false.
+ config_am_regionalstatsweekly_input_stream = 'regionalMasksInput'
+ config_am_regionalstatsweekly_operation = 'avg'
+ config_am_regionalstatsweekly_output_stream = 'regionalStatsWeeklyOutput'
+ config_am_regionalstatsweekly_region_group = 'all'
+ config_am_regionalstatsweekly_region_type = 'cell'
+ config_am_regionalstatsweekly_restart_stream = 'regionalMasksInput'
+ config_am_regionalstatsweekly_vertical_dimension = 'nVertLevels'
+ config_am_regionalstatsweekly_vertical_mask = 'cellMask'
+ config_am_regionalstatsweekly_write_on_startup = .false.
+/
+&am_regionalstatsmonthly
+ config_am_regionalstatsmonthly_1d_weighting_field = 'areaCell'
+ config_am_regionalstatsmonthly_1d_weighting_function = 'mul'
+ config_am_regionalstatsmonthly_2d_weighting_field = 'volumeCell'
+ config_am_regionalstatsmonthly_2d_weighting_function = 'mul'
+ config_am_regionalstatsmonthly_compute_interval = 'output_interval'
+ config_am_regionalstatsmonthly_compute_on_startup = .false.
+ config_am_regionalstatsmonthly_enable = .false.
+ config_am_regionalstatsmonthly_input_stream = 'regionalMasksInput'
+ config_am_regionalstatsmonthly_operation = 'avg'
+ config_am_regionalstatsmonthly_output_stream = 'regionalStatsMonthlyOutput'
+ config_am_regionalstatsmonthly_region_group = 'all'
+ config_am_regionalstatsmonthly_region_type = 'cell'
+ config_am_regionalstatsmonthly_restart_stream = 'regionalMasksInput'
+ config_am_regionalstatsmonthly_vertical_dimension = 'nVertLevels'
+ config_am_regionalstatsmonthly_vertical_mask = 'cellMask'
+ config_am_regionalstatsmonthly_write_on_startup = .false.
+/
+&am_regionalstatscustom
+ config_am_regionalstatscustom_1d_weighting_field = 'areaCell'
+ config_am_regionalstatscustom_1d_weighting_function = 'mul'
+ config_am_regionalstatscustom_2d_weighting_field = 'volumeCell'
+ config_am_regionalstatscustom_2d_weighting_function = 'mul'
+ config_am_regionalstatscustom_compute_interval = 'output_interval'
+ config_am_regionalstatscustom_compute_on_startup = .false.
+ config_am_regionalstatscustom_enable = .false.
+ config_am_regionalstatscustom_input_stream = 'regionalMasksInput'
+ config_am_regionalstatscustom_operation = 'avg'
+ config_am_regionalstatscustom_output_stream = 'regionalStatsCustomOutput'
+ config_am_regionalstatscustom_region_group = 'all'
+ config_am_regionalstatscustom_region_type = 'cell'
+ config_am_regionalstatscustom_restart_stream = 'regionalMasksInput'
+ config_am_regionalstatscustom_vertical_dimension = 'nVertLevels'
+ config_am_regionalstatscustom_vertical_mask = 'cellMask'
+ config_am_regionalstatscustom_write_on_startup = .false.
+/
+&am_timeseriesstatsdaily
+ config_am_timeseriesstatsdaily_backward_output_offset = '00-00-01_00:00:00'
+ config_am_timeseriesstatsdaily_compute_interval = '00-00-00_01:00:00'
+ config_am_timeseriesstatsdaily_compute_on_startup = .false.
+ config_am_timeseriesstatsdaily_duration_intervals = 'repeat_interval'
+ config_am_timeseriesstatsdaily_enable = .false.
+ config_am_timeseriesstatsdaily_operation = 'avg'
+ config_am_timeseriesstatsdaily_output_stream = 'timeSeriesStatsDailyOutput'
+ config_am_timeseriesstatsdaily_reference_times = 'initial_time'
+ config_am_timeseriesstatsdaily_repeat_intervals = 'reset_interval'
+ config_am_timeseriesstatsdaily_reset_intervals = '00-00-01_00:00:00'
+ config_am_timeseriesstatsdaily_restart_stream = 'timeSeriesStatsDailyRestart'
+ config_am_timeseriesstatsdaily_write_on_startup = .false.
+/
+&am_timeseriesstatsmonthly
+ config_am_timeseriesstatsmonthly_backward_output_offset = '00-01-00_00:00:00'
+ config_am_timeseriesstatsmonthly_compute_interval = '00-00-00_01:00:00'
+ config_am_timeseriesstatsmonthly_compute_on_startup = .false.
+ config_am_timeseriesstatsmonthly_duration_intervals = 'repeat_interval'
+ config_am_timeseriesstatsmonthly_enable = .true.
+ config_am_timeseriesstatsmonthly_operation = 'avg'
+ config_am_timeseriesstatsmonthly_output_stream = 'timeSeriesStatsMonthlyOutput'
+ config_am_timeseriesstatsmonthly_reference_times = 'initial_time'
+ config_am_timeseriesstatsmonthly_repeat_intervals = 'reset_interval'
+ config_am_timeseriesstatsmonthly_reset_intervals = '00-01-00_00:00:00'
+ config_am_timeseriesstatsmonthly_restart_stream = 'timeSeriesStatsMonthlyRestart'
+ config_am_timeseriesstatsmonthly_write_on_startup = .true.
+/
+&am_timeseriesstatsclimatology
+ config_am_timeseriesstatsclimatology_backward_output_offset = '00-03-00_00:00:00'
+ config_am_timeseriesstatsclimatology_compute_interval = '00-00-00_01:00:00'
+ config_am_timeseriesstatsclimatology_compute_on_startup = .false.
+ config_am_timeseriesstatsclimatology_duration_intervals = '00-03-00_00:00:00;00-03-00_00:00:00;00-03-00_00:00:00;00-03-00_00:00:00'
+ config_am_timeseriesstatsclimatology_enable = .false.
+ config_am_timeseriesstatsclimatology_operation = 'avg'
+ config_am_timeseriesstatsclimatology_output_stream = 'timeSeriesStatsClimatologyOutput'
+ config_am_timeseriesstatsclimatology_reference_times = '00-03-01_00:00:00;00-06-01_00:00:00;00-09-01_00:00:00;00-12-01_00:00:00'
+ config_am_timeseriesstatsclimatology_repeat_intervals = '01-00-00_00:00:00;01-00-00_00:00:00;01-00-00_00:00:00;01-00-00_00:00:00'
+ config_am_timeseriesstatsclimatology_reset_intervals = '1000-00-00_00:00:00;1000-00-00_00:00:00;1000-00-00_00:00:00;1000-00-00_00:00:00'
+ config_am_timeseriesstatsclimatology_restart_stream = 'timeSeriesStatsClimatologyRestart'
+ config_am_timeseriesstatsclimatology_write_on_startup = .false.
+/
+&am_timeseriesstatscustom
+ config_am_timeseriesstatscustom_backward_output_offset = '00-00-01_00:00:00'
+ config_am_timeseriesstatscustom_compute_interval = '00-00-00_01:00:00'
+ config_am_timeseriesstatscustom_compute_on_startup = .false.
+ config_am_timeseriesstatscustom_duration_intervals = 'repeat_interval'
+ config_am_timeseriesstatscustom_enable = .false.
+ config_am_timeseriesstatscustom_operation = 'avg'
+ config_am_timeseriesstatscustom_output_stream = 'timeSeriesStatsCustomOutput'
+ config_am_timeseriesstatscustom_reference_times = 'initial_time'
+ config_am_timeseriesstatscustom_repeat_intervals = 'reset_interval'
+ config_am_timeseriesstatscustom_reset_intervals = '00-00-07_00:00:00'
+ config_am_timeseriesstatscustom_restart_stream = 'timeSeriesStatsCustomRestart'
+ config_am_timeseriesstatscustom_write_on_startup = .false.
+/
+&am_pointwisestats
+ config_am_pointwisestats_compute_interval = 'output_interval'
+ config_am_pointwisestats_compute_on_startup = .true.
+ config_am_pointwisestats_enable = .false.
+ config_am_pointwisestats_output_stream = 'pointwiseStatsOutput'
+ config_am_pointwisestats_write_on_startup = .true.
+/
+&am_debugdiagnostics
+ config_am_debugdiagnostics_check_state = .true.
+ config_am_debugdiagnostics_compute_interval = 'dt'
+ config_am_debugdiagnostics_compute_on_startup = .true.
+ config_am_debugdiagnostics_enable = .false.
+ config_am_debugdiagnostics_output_stream = 'debugDiagnosticsOutput'
+ config_am_debugdiagnostics_write_on_startup = .false.
+/
+&am_rpncalculator
+ config_am_rpncalculator_compute_interval = '0010-00-00_00:00:00'
+ config_am_rpncalculator_compute_on_startup = .true.
+ config_am_rpncalculator_enable = .false.
+ config_am_rpncalculator_expression_1 = 'a b *'
+ config_am_rpncalculator_expression_2 = 'none'
+ config_am_rpncalculator_expression_3 = 'none'
+ config_am_rpncalculator_expression_4 = 'none'
+ config_am_rpncalculator_output_name_1 = 'volumeCell'
+ config_am_rpncalculator_output_name_2 = 'none'
+ config_am_rpncalculator_output_name_3 = 'none'
+ config_am_rpncalculator_output_name_4 = 'none'
+ config_am_rpncalculator_output_stream = 'none'
+ config_am_rpncalculator_variable_a = 'layerThickness'
+ config_am_rpncalculator_variable_b = 'areaCell'
+ config_am_rpncalculator_variable_c = 'none'
+ config_am_rpncalculator_variable_d = 'none'
+ config_am_rpncalculator_variable_e = 'none'
+ config_am_rpncalculator_variable_f = 'none'
+ config_am_rpncalculator_variable_g = 'none'
+ config_am_rpncalculator_variable_h = 'none'
+ config_am_rpncalculator_write_on_startup = .false.
+/
+&am_transecttransport
+ config_am_transecttransport_compute_interval = 'output_interval'
+ config_am_transecttransport_compute_on_startup = .true.
+ config_am_transecttransport_enable = .false.
+ config_am_transecttransport_output_stream = 'transectTransportOutput'
+ config_am_transecttransport_transect_group = 'all'
+ config_am_transecttransport_write_on_startup = .true.
+/
+&am_eddyproductvariables
+ config_am_eddyproductvariables_compute_interval = 'dt'
+ config_am_eddyproductvariables_compute_on_startup = .true.
+ config_am_eddyproductvariables_enable = .false.
+ config_am_eddyproductvariables_output_stream = 'eddyProductVariablesOutput'
+ config_am_eddyproductvariables_write_on_startup = .false.
+/
+&am_mocstreamfunction
+ config_am_mocstreamfunction_compute_interval = 'output_interval'
+ config_am_mocstreamfunction_compute_on_startup = .true.
+ config_am_mocstreamfunction_enable = .false.
+ config_am_mocstreamfunction_max_bin = -1.0e34
+ config_am_mocstreamfunction_min_bin = -1.0e34
+ config_am_mocstreamfunction_normal_velocity_value = 'normalVelocity'
+ config_am_mocstreamfunction_num_bins = 180
+ config_am_mocstreamfunction_output_stream = 'mocStreamfunctionOutput'
+ config_am_mocstreamfunction_region_group = 'all'
+ config_am_mocstreamfunction_transect_group = 'all'
+ config_am_mocstreamfunction_vertical_velocity_value = 'vertVelocityTop'
+ config_am_mocstreamfunction_write_on_startup = .true.
+/

--- a/mpas_analysis/test/test_climatology/streams.ocean
+++ b/mpas_analysis/test/test_climatology/streams.ocean
@@ -1,0 +1,16 @@
+<streams>
+
+<stream name="timeSeriesStatsMonthlyOutput"
+        type="output"
+        filename_template="timeSeries.$Y-$M-$D.nc"
+        filename_interval="00-01-00_00:00:00"
+        output_interval="00-01-00_00:00:00"
+        clobber_mode="truncate"
+        packages="timeSeriesStatsMonthlyAMPKG"
+        runtime_format="single_file">
+
+    <var name="ssh"/>
+    <var name="tThreshMLD"/>
+</stream>
+
+</streams>

--- a/mpas_analysis/test/test_interpolate.py
+++ b/mpas_analysis/test/test_interpolate.py
@@ -42,8 +42,9 @@ class TestInterp(TestCase):
 
     def get_latlon_file_descriptor(self):
         latLonGridFileName = str(self.datadir.join('SST_annual_1870-1900.nc'))
-        descriptor = LatLonGridDescriptor()
-        descriptor.read(latLonGridFileName, latVarName='lat', lonVarName='lon')
+        descriptor = LatLonGridDescriptor.read(latLonGridFileName,
+                                               latVarName='lat',
+                                               lonVarName='lon')
 
         return (descriptor, latLonGridFileName)
 
@@ -57,8 +58,7 @@ class TestInterp(TestCase):
         lon = numpy.array(config.getExpression('interpolate', 'lon',
                                                usenumpyfunc=True))
 
-        descriptor = LatLonGridDescriptor()
-        descriptor.create(lat, lon, units='degrees')
+        descriptor = LatLonGridDescriptor.create(lat, lon, units='degrees')
         return descriptor
 
     def get_stereographic_array_descriptor(self):
@@ -73,9 +73,9 @@ class TestInterp(TestCase):
         res = 100e3
         nx = 2*int(xMax/res)+1
         x = numpy.linspace(-xMax, xMax, nx)
-        descriptor = ProjectionGridDescriptor(projection)
         meshName = '{}km_Antarctic_stereo'.format(int(res*1e-3))
-        descriptor.create(x, x, meshName)
+        descriptor = ProjectionGridDescriptor.create(projection, x, x,
+                                                     meshName)
         return descriptor
 
     def get_file_names(self, suffix):

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -17,6 +17,7 @@ import sys
 import warnings
 import subprocess
 import time
+from collections import OrderedDict
 
 from mpas_analysis.configuration.MpasAnalysisConfigParser \
     import MpasAnalysisConfigParser
@@ -25,12 +26,139 @@ from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories
 
 
+def build_analysis_list(config, isSubtask):  # {{{
+    """
+    Build a list of analysis tasks based on the 'generate' config option.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+    """
+
+    # choose the right rendering backend, depending on whether we're displaying
+    # to the screen
+    if not config.getboolean('plot', 'displayToScreen'):
+        mpl.use('Agg')
+
+    # analysis can only be imported after the right MPL renderer is selected
+    from mpas_analysis import ocean
+    from mpas_analysis import sea_ice
+    from mpas_analysis.shared.cache_dataset_times_task \
+        import CacheDatasetTimesTask
+
+    # analyses will be a list of analysis classes
+    analyses = []
+
+    # add cacheOceanTimeSeriesStatsTimes task for caching the times in
+    # MPAS-Ocean timeSeriesStatsMonthly output files.  This is a prerequisite
+    # for all ocean analysis.
+    analyses.append(CacheDatasetTimesTask(
+            config=config,
+            componentName='ocean',
+            streamName='timeSeriesStats',
+            startAndEndDateSections=['climatology', 'timeSeries', 'index'],
+            namelistOption='config_am_timeseriesstatsmonthly_enable'))
+
+    # add cacheSeaIceTimeSeriesStatsTimes task for caching the times in
+    # MPAS-Ocean timeSeriesStatsMonthly output files.  This is a prerequisite
+    # for all sea ice analysis.
+    analyses.append(CacheDatasetTimesTask(
+            config=config,
+            componentName='seaIce',
+            streamName='timeSeriesStats',
+            startAndEndDateSections=['climatology', 'timeSeries'],
+            namelistOption='config_am_timeseriesstatsmonthly_enable'))
+
+    # Ocean Analyses
+    analyses.append(ocean.TimeSeriesOHC(config))
+    analyses.append(ocean.TimeSeriesSST(config))
+    analyses.append(ocean.IndexNino34(config))
+    analyses.append(ocean.MeridionalHeatTransport(config))
+    analyses.append(ocean.StreamfunctionMOC(config))
+
+    analyses.append(ocean.ClimatologyMapSST(config))
+    analyses.append(ocean.ClimatologyMapMLD(config))
+    analyses.append(ocean.ClimatologyMapSSS(config))
+
+    # Sea Ice Analyses
+    analyses.append(sea_ice.TimeSeriesSeaIce(config))
+    analyses.append(sea_ice.ClimatologyMapSeaIce(config))
+
+    possibleAnalyses = OrderedDict()
+    for analysisTask in analyses:
+        possibleAnalyses[analysisTask.taskName] = analysisTask
+
+    # check which analysis we actually want to generate and only keep those
+    analysesToGenerate = OrderedDict()
+    for analysisTask in possibleAnalyses.itervalues():
+        # update the dictionary with this task and perhaps its prerequisites
+        analysesToAdd = add_task_and_prereqisites(analysisTask,
+                                                  possibleAnalyses,
+                                                  analysesToGenerate,
+                                                  isPrerequisite=False,
+                                                  isSubtask=isSubtask)
+        analysesToGenerate.update(analysesToAdd)
+
+    return analysesToGenerate  # }}}
+
+
+def add_task_and_prereqisites(analysisTask, possibleAnalyses,
+                              analysesToGenerate, isPrerequisite,
+                              isSubtask):  # {{{
+    """
+    If a task has been requested through the generate config option or
+    if it is a prerequisite of a requested task, add it to the dictionary of
+    tasks to generate.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+    """
+
+    analysesToAdd = OrderedDict()
+    # for each anlaysis task, check if we want to generate this task
+    # and if the analysis task has a valid configuration
+    if isPrerequisite or analysisTask.check_generate():
+        add = False
+        try:
+            analysisTask.setup_and_check()
+            add = True
+        except:
+            traceback.print_exc(file=sys.stdout)
+            print "ERROR: analysis task {} failed during check and " \
+                "will not be run".format(analysisTask.taskName)
+        if add and not isSubtask:
+            # first, we should try to add the prerequisites
+            prereqs = analysisTask.prerequisiteTasks
+            if prereqs is not None:
+                for prereq in prereqs:
+                    if prereq not in analysesToGenerate.keys():
+                        prereqToAdd = add_task_and_prereqisites(
+                                possibleAnalyses[prereq], possibleAnalyses,
+                                analysesToGenerate, isPrerequisite=True)
+                        if len(prereqToAdd.keys()) == 0:
+                            # a prerequisite failed setup_and_check
+                            print "ERROR: a prerequisite of analysis task {}" \
+                                  " failed during check and will not be" \
+                                  " run".format(analysisTask.taskName)
+                            add = False
+                            break
+                        # the prerequisite (and its prerequisites) should be
+                        # added
+                        analysesToAdd.update(prereqToAdd)
+        if add:
+            analysesToAdd[analysisTask.taskName] = analysisTask
+
+    return analysesToAdd  # }}}
+
+
 def update_generate(config, generate):  # {{{
     """
     Update the 'generate' config option using a string from the command line.
 
-    Author: Xylar Asay-Davis
-    Last Modified: 03/07/2017
+    Authors
+    -------
+    Xylar Asay-Davis
     """
 
     # overwrite the 'generate' in config with a string that parses to
@@ -42,8 +170,7 @@ def update_generate(config, generate):  # {{{
     config.set('output', 'generate', generateString)  # }}}
 
 
-def run_parallel_tasks(config, analyses, configFiles, taskCount):
-    # {{{
+def run_analysis(config, analyses, configFiles, isSubtask):  # {{{
     """
     Run this script once each for several parallel tasks.
 
@@ -52,40 +179,99 @@ def run_parallel_tasks(config, analyses, configFiles, taskCount):
     Xylar Asay-Davis
     """
 
-    taskNames = [analysisTask.taskName for analysisTask in analyses]
+    taskCount = config.getWithDefault('execute', 'parallelTaskCount',
+                                      default=1)
 
-    taskCount = min(taskCount, len(taskNames))
+    isParallel = not isSubtask and taskCount > 1 and len(analyses) > 1
 
-    (processes, logs) = launch_tasks(taskNames[0:taskCount], config,
-                                     configFiles)
-    remainingTasks = taskNames[taskCount:]
-    while len(processes) > 0:
-        (taskName, process) = wait_for_task(processes)
-        if process.returncode == 0:
-            print "Task {} has finished successfully.".format(taskName)
+    for analysisTask in analyses.itervalues():
+        if analysisTask.prerequisiteTasks is None or isSubtask:
+            analysisTask.status = 'ready'
         else:
-            print "ERROR in task {}.  See log file {} for details".format(
-                taskName, logs[taskName].name)
-        logs[taskName].close()
-        # remove the process from the process dictionary (no need to bother)
-        processes.pop(taskName)
+            analysisTask.status = 'blocked'
 
-        if len(remainingTasks) > 0:
-            (process, log) = launch_tasks(remainingTasks[0:1], config,
-                                          configFiles)
-            # merge the new process and log into these dictionaries
-            processes.update(process)
-            logs.update(log)
-            remainingTasks = remainingTasks[1:]
+    processes = {}
+    logs = {}
+
+    # run each analysis task
+    lastException = None
+
+    runningCount = 0
+    while True:
+        # we still have tasks to run
+        for analysisTask in analyses.itervalues():
+            if analysisTask.status == 'blocked':
+                prereqStatus = [analyses[prereq].status for prereq in
+                                analysisTask.prerequisiteTasks]
+                if any([status == 'fail' for status in prereqStatus]):
+                    # a prerequisite failed so this task cannot succeed
+                    analysisTask.status = 'fail'
+                if all([status == 'success' for status in prereqStatus]):
+                    # no unfinished prerequisites so we can run this task
+                    analysisTask.status = 'ready'
+
+        unfinishedCount = 0
+        for analysisTask in analyses.itervalues():
+            if analysisTask.status not in ['success', 'fail']:
+                unfinishedCount += 1
+
+        if unfinishedCount <= 0:
+            # we're done
+            break
+
+        # launch new tasks
+        for taskName, analysisTask in analyses.items():
+            if analysisTask.status == 'ready':
+                if isParallel:
+                    process, logFile = launch_task(taskName, config,
+                                                   configFiles)
+                    processes[taskName] = process
+                    logs[taskName] = logFile
+                    analysisTask.status = 'running'
+                    runningCount += 1
+                    if runningCount >= taskCount:
+                        break
+                else:
+                    exception = run_task(config, analysisTask)
+                    if exception is None:
+                        analysisTask.status = 'success'
+                    else:
+                        lastException = exception
+                        analysisTask.status = 'fail'
+
+        if isParallel:
+            # wait for a task to finish
+            (taskName, process) = wait_for_task(processes)
+            analysisTask = analyses[taskName]
+            runningCount -= 1
+            processes.pop(taskName)
+            if process.returncode == 0:
+                print "Task {} has finished successfully.".format(taskName)
+                analysisTask.status = 'success'
+            else:
+                print "ERROR in task {}.  See log file {} for details".format(
+                    taskName, logs[taskName].name)
+                analysisTask.status = 'fail'
+            logs[taskName].close()
+
+    if not isParallel and config.getboolean('plot', 'displayToScreen'):
+        import matplotlib.pyplot as plt
+        plt.show()
+
+    # raise the last exception so the process exits with an error
+    if lastException is not None:
+        raise lastException
+
     # }}}
 
 
-def launch_tasks(taskNames, config, configFiles):  # {{{
+def launch_task(taskName, config, configFiles):  # {{{
     """
-    Launch one or more tasks
+    Launch a parallel tasks
 
-    Author: Xylar Asay-Davis
-    Last Modified: 03/08/2017
+    Authors
+    -------
+    Xylar Asay-Davis
     """
     thisFile = os.path.realpath(__file__)
 
@@ -96,25 +282,21 @@ def launch_tasks(taskNames, config, configFiles):  # {{{
     else:
         commandPrefix = commandPrefix.split(' ')
 
-    processes = {}
-    logs = {}
-    for taskName in taskNames:
-        args = commandPrefix + [thisFile, '--generate', taskName] + configFiles
+    args = commandPrefix + [thisFile, '--subtask', '--generate', taskName] \
+        + configFiles
 
-        logFileName = '{}/{}.log'.format(logsDirectory, taskName)
+    logFileName = '{}/{}.log'.format(logsDirectory, taskName)
 
-        # write the command to the log file
-        logFile = open(logFileName, 'w')
-        logFile.write('Command: {}\n'.format(' '.join(args)))
-        # make sure the command gets written before the rest of the log
-        logFile.flush()
-        print 'Running {}'.format(taskName)
-        process = subprocess.Popen(args, stdout=logFile,
-                                   stderr=subprocess.STDOUT)
-        processes[taskName] = process
-        logs[taskName] = logFile
+    # write the command to the log file
+    logFile = open(logFileName, 'w')
+    logFile.write('Command: {}\n'.format(' '.join(args)))
+    # make sure the command gets written before the rest of the log
+    logFile.flush()
+    print 'Running {}'.format(taskName)
+    process = subprocess.Popen(args, stdout=logFile,
+                               stderr=subprocess.STDOUT)
 
-    return (processes, logs)  # }}}
+    return (process, logFile)  # }}}
 
 
 def wait_for_task(processes):  # {{{
@@ -122,8 +304,9 @@ def wait_for_task(processes):  # {{{
     Wait for the next process to finish and check its status.  Returns both the
     task name and the process that finished.
 
-    Author: Xylar Asay-Davis
-    Last Modified: 03/08/2017
+    Authors
+    -------
+    Xylar Asay-Davis
     """
 
     # first, check if any process has already finished
@@ -144,8 +327,9 @@ def is_running(process):  # {{{
     """
     Returns whether a given process is currently running
 
-    Author: Xylar Asay-Davis
-    Last Modified: 03/08/2017
+    Authors
+    -------
+    Xylar Asay-Davis
     """
 
     try:
@@ -156,108 +340,56 @@ def is_running(process):  # {{{
         return True  # }}}
 
 
-def build_analysis_list(config):  # {{{
+def run_task(config, analysisTask):  # {{{
     """
-    Build a list of analysis modules based on the 'generate' config option.
+    Run a single analysis task, time the task, write out the config file
+    (including any modifications specific to the task) and return the exception
+    raised (if any)
 
-    Author: Xylar Asay-Davis
-    Last Modified: 03/07/2017
+    Authors
+    -------
+    Xylar Asay-Davis
     """
 
-    # choose the right rendering backend, depending on whether we're displaying
-    # to the screen
-    if not config.getboolean('plot', 'displayToScreen'):
-        mpl.use('Agg')
+    # write out a copy of the configuration to document the run
+    logsDirectory = build_config_full_path(config, 'output',
+                                           'logsSubdirectory')
+    exception = None
+    try:
+        startTime = time.clock()
+        analysisTask.run()
+        runDuration = time.clock() - startTime
+        m, s = divmod(runDuration, 60)
+        h, m = divmod(int(m), 60)
+        print 'Execution time: {}:{:02d}:{:05.2f}'.format(h, m, s)
+    except (Exception, BaseException) as e:
+        if isinstance(e, KeyboardInterrupt):
+            raise e
+        traceback.print_exc(file=sys.stdout)
+        print "ERROR: analysis task {} failed during run".format(
+            analysisTask.taskName)
+        exception = e
 
-    # analysis can only be imported after the right MPL renderer is selected
-    from mpas_analysis import ocean
-    from mpas_analysis import sea_ice
+    configFileName = '{}/configs/config.{}'.format(logsDirectory,
+                                                   analysisTask.taskName)
+    configFile = open(configFileName, 'w')
+    config.write(configFile)
+    configFile.close()
 
-    # analyses will be a list of analysis classes
-    analyses = []
-
-    # Ocean Analyses
-    analyses.append(ocean.TimeSeriesOHC(config))
-    analyses.append(ocean.TimeSeriesSST(config))
-    analyses.append(ocean.IndexNino34(config))
-    analyses.append(ocean.MeridionalHeatTransport(config))
-    analyses.append(ocean.StreamfunctionMOC(config))
-
-    analyses.append(ocean.ClimatologyMapSST(config))
-    analyses.append(ocean.ClimatologyMapMLD(config))
-    analyses.append(ocean.ClimatologyMapSSS(config))
-
-    # Sea Ice Analyses
-    analyses.append(sea_ice.TimeSeriesSeaIce(config))
-    analyses.append(sea_ice.ClimatologyMapSeaIce(config))
-
-    # check which analysis we actually want to generate and only keep those
-    analysesToGenerate = []
-    for analysisTask in analyses:
-        # for each anlaysis module, check if we want to generate this task
-        # and if the analysis task has a valid configuration
-        if analysisTask.check_generate():
-            add = False
-            try:
-                analysisTask.setup_and_check()
-                add = True
-            except:
-                traceback.print_exc(file=sys.stdout)
-                print "ERROR: analysis module {} failed during check and " \
-                    "will not be run".format(analysisTask.taskName)
-            if add:
-                analysesToGenerate.append(analysisTask)
-
-    return analysesToGenerate  # }}}
-
-
-def run_analysis(config, analyses):  # {{{
-
-    # run each analysis task
-    lastException = None
-    for analysisTask in analyses:
-        # write out a copy of the configuration to document the run
-        logsDirectory = build_config_full_path(config, 'output',
-                                               'logsSubdirectory')
-        try:
-            startTime = time.clock()
-            analysisTask.run()
-            runDuration = time.clock() - startTime
-            m, s = divmod(runDuration, 60)
-            h, m = divmod(int(m), 60)
-            print 'Execution time: {}:{:02d}:{:05.2f}'.format(h, m, s)
-        except (Exception, BaseException) as e:
-            if isinstance(e, KeyboardInterrupt):
-                raise e
-            traceback.print_exc(file=sys.stdout)
-            print "ERROR: analysis module {} failed during run".format(
-                analysisTask.taskName)
-            lastException = e
-
-        configFileName = '{}/configs/config.{}'.format(logsDirectory,
-                                                       analysisTask.taskName)
-        configFile = open(configFileName, 'w')
-        config.write(configFile)
-        configFile.close()
-
-    if config.getboolean('plot', 'displayToScreen'):
-        import matplotlib.pyplot as plt
-        plt.show()
-
-    # raise the last exception so the process exits with an error
-    if lastException is not None:
-        raise lastException
-
-    return  # }}}
+    return exception  # }}}
 
 
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("--subtask", dest="subtask", action='store_true',
+                        help="If this is a subtask when running parallel "
+                             "tasks")
     parser.add_argument("-g", "--generate", dest="generate",
                         help="A list of analysis modules to generate "
-                        "(nearly identical generate option in config file).",
+                             "(nearly identical generate option in config "
+                             "file).",
                         metavar="ANALYSIS1[,ANALYSIS2,ANALYSIS3,...]")
     parser.add_argument('configFiles', metavar='CONFIG',
                         type=str, nargs='+', help='config file')
@@ -286,14 +418,8 @@ if __name__ == "__main__":
     make_directories(logsDirectory)
     make_directories('{}/configs/'.format(logsDirectory))
 
-    analyses = build_analysis_list(config)
+    analyses = build_analysis_list(config, args.subtask)
 
-    parallelTaskCount = config.getWithDefault('execute', 'parallelTaskCount',
-                                              default=1)
-
-    if parallelTaskCount <= 1 or len(analyses) == 1:
-        run_analysis(config, analyses)
-    else:
-        run_parallel_tasks(config, analyses, configFiles, parallelTaskCount)
+    run_analysis(config, analyses, configFiles, args.subtask)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
Change functionality of the climatology module to be handled by
3 new classes:

- Climatology - the base class
- MpasClimatology - for computing, caching and/or remapping MPAS climatologies
- ObservationClimatology - for computing and/or remapping observational climatologies

These classes know more about tasks than the previous standalone functions,
and can therefore automatically handle much more of the process of setting
up climatologies.  This makes the tasks themselves shorter and cleaner, and
hopefully easier to understand.

Functionality has been added to `AnalysisTask` to cache the times only from
a given stream.  This is useful for later determining which files need
to be opened when computing a given climatology or time series and which
have already been cached.  Climatology caching in the `MpasClimatology`
class has been updated to use the time cache.  Note: the time cache is a
dictionary, and thus has been stored in a python ".pickle" file, since
NetCDF doesn't support python dictionaries.

All analysis tasks that use the climatology module have been updated to
use the new classes.

All tests related to climatologies and the `AnalysisTask` base class have been
updated.

The functions "read" and "create" in `MeshDescriptors` have been made static
functions that return an instance of the class, saving the need to call the
empty constructor before calling these methods.

mpas_xarray has been updated so that a coordinate can be passed to the variable
list.  This is useful if the only information needed from a data set is the
Time coordinate (as is the case for time caching).

Cleanup in config.default:
* rename regridded to remapped
* remove overwrite flags (we assume they are false and the better
  way to handle this is to delete the cache files)