### PR TITLE
Fix path to namelist files

### DIFF
--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -114,9 +114,10 @@ class AnalysisTask(object):  # {{{
 
         self.plotsDirectory = build_config_full_path(self.config, 'output',
                                                      'plotsSubdirectory')
-        namelistFileName = self.config.get(
-            'input', '{}NamelistFileName'.format(self.componentName))
-        self.namelist = NameList(namelistFileName, path=self.runDirectory)
+        namelistFileName = build_config_full_path(
+            self.config,  'input',
+            '{}NamelistFileName'.format(self.componentName))
+        self.namelist = NameList(namelistFileName)
 
         streamsFileName = build_config_full_path(
             self.config, 'input',


### PR DESCRIPTION
The path is now be relative to the baseDirectory, not to the
runDirectory, as specified in the comment in config.default.

This error was not detected in MPAS-Analysis tests because they
all use the same baseDirectory and runDirectory, but the same
is not true of A-Prime.  Probably a standard test that simulates
ACME short-term archiving is needed.