### PR TITLE
Check if files are found within requested time range

### DIFF
--- a/mpas_analysis/ocean/climatology_map.py
+++ b/mpas_analysis/ocean/climatology_map.py
@@ -342,7 +342,7 @@ class ClimatologyMapSST(ClimatologyMapOcean):  # {{{
         #     self.runDirectory , self.historyDirectory, self.plotsDirectory,
         #     self.namelist, self.runStreams, self.historyStreams,
         #     self.calendar, self.namelistMap, self.streamMap, self.variableMap
-        super(ClimatologyMapOcean, self).setup_and_check()
+        super(ClimatologyMapSST, self).setup_and_check()
 
         observationsDirectory = build_config_full_path(
             self.config, 'oceanObservations',
@@ -451,7 +451,7 @@ class ClimatologyMapSSS(ClimatologyMapOcean):  # {{{
         #     self.runDirectory , self.historyDirectory, self.plotsDirectory,
         #     self.namelist, self.runStreams, self.historyStreams,
         #     self.calendar, self.namelistMap, self.streamMap, self.variableMap
-        super(ClimatologyMapOcean, self).setup_and_check()
+        super(ClimatologyMapSSS, self).setup_and_check()
 
         observationsDirectory = build_config_full_path(
             self.config, 'oceanObservations',
@@ -543,7 +543,7 @@ class ClimatologyMapMLD(ClimatologyMapOcean):  # {{{
         #     self.runDirectory , self.historyDirectory, self.plotsDirectory,
         #     self.namelist, self.runStreams, self.historyStreams,
         #     self.calendar, self.namelistMap, self.streamMap, self.variableMap
-        super(ClimatologyMapOcean, self).setup_and_check()
+        super(ClimatologyMapMLD, self).setup_and_check()
 
         observationsDirectory = build_config_full_path(
             self.config, 'oceanObservations',

--- a/mpas_analysis/ocean/climatology_map.py
+++ b/mpas_analysis/ocean/climatology_map.py
@@ -68,6 +68,21 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
             analysisOptionName='config_am_timeseriesstatsmonthly_enable',
             raiseException=True)
 
+        # get a list of timeSeriesStats output files from the streams file,
+        # reading only those that are between the start and end dates
+        self.startDate = self.config.get('climatology', 'startDate')
+        self.endDate = self.config.get('climatology', 'endDate')
+        streamName = \
+            self.historyStreams.find_stream(self.streamMap['timeSeriesStats'])
+        self.inputFiles = self.historyStreams.readpath(
+                streamName, startDate=self.startDate, endDate=self.endDate,
+                calendar=self.calendar)
+
+        if len(self.inputFiles) == 0:
+            raise IOError('No files were found in stream {} between {} and '
+                          '{}.'.format(streamName, self.startDate,
+                                       self.endDate))
+
         # }}}
 
     def run(self):  # {{{
@@ -93,20 +108,10 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
 
         simulationStartTime = get_simulation_start_time(self.runStreams)
 
-        # get a list of timeSeriesStats output files from the streams file,
-        # reading only those that are between the start and end dates
-        startDate = config.get('climatology', 'startDate')
-        endDate = config.get('climatology', 'endDate')
-        streamName = \
-            self.historyStreams.find_stream(self.streamMap['timeSeriesStats'])
-        inputFiles = self.historyStreams.readpath(streamName,
-                                                  startDate=startDate,
-                                                  endDate=endDate,
-                                                  calendar=calendar)
         print '\n  Reading files:\n' \
               '    {} through\n    {}'.format(
-                  os.path.basename(inputFiles[0]),
-                  os.path.basename(inputFiles[-1]))
+                  os.path.basename(self.inputFiles[0]),
+                  os.path.basename(self.inputFiles[-1]))
 
         mainRunName = config.get('runs', 'mainRunName')
 
@@ -128,7 +133,7 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
 
         varList = [fieldName]
 
-        ds = open_multifile_dataset(fileNames=inputFiles,
+        ds = open_multifile_dataset(fileNames=self.inputFiles,
                                     calendar=calendar,
                                     config=config,
                                     simulationStartTime=simulationStartTime,
@@ -136,8 +141,8 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
                                     variableList=varList,
                                     iselValues=self.iselValues,
                                     variableMap=self.variableMap,
-                                    startDate=startDate,
-                                    endDate=endDate)
+                                    startDate=self.startDate,
+                                    endDate=self.endDate)
 
         changed, startYear, endYear = update_start_end_year(ds, config,
                                                             calendar)

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -15,7 +15,8 @@ from ..shared.generalized_reader.generalized_reader \
 
 from ..shared.timekeeping.utility import get_simulation_start_time
 
-from ..shared.climatology.climatology import cache_climatologies
+from ..shared.climatology.climatology import update_start_end_year, \
+    cache_climatologies
 
 from ..shared.analysis_task import AnalysisTask
 
@@ -201,6 +202,9 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             startDate=self.startDate,
             endDate=self.endDate)
 
+        changed, startYear, endYear = update_start_end_year(ds, config,
+                                                            self.calendar)
+
         # Compute annual climatology
         cachePrefix = '{}/meridionalHeatTransport'.format(outputDirectory)
         annualClimatology = cache_climatologies(ds, monthDictionary['ANN'],
@@ -222,10 +226,10 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
         xLabel = 'latitude [deg]'
         yLabel = 'meridional heat transport [PW]'
         title = 'Global MHT (ANN, years {:04d}-{:04d})\n {}'.format(
-                 self.startYear, self.endYear, mainRunName)
+                 startYear, endYear, mainRunName)
         figureName = '{}/mht_{}_years{:04d}-{:04d}.png'.format(
                       self.plotsDirectory, mainRunName,
-                      self.startYear, self.endYear)
+                      startYear, endYear)
         if self.observationsFile is not None:
             # Load in observations
             dsObs = xr.open_dataset(self.observationsFile)
@@ -267,10 +271,10 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
         xLabel = 'latitude [deg]'
         yLabel = 'depth [m]'
         title = 'Global MHT (ANN, years {:04d}-{:04d})\n {}'.format(
-                 self.startYear, self.endYear, mainRunName)
+                 startYear, endYear, mainRunName)
         figureName = '{}/mhtZ_{}_years{:04d}-{:04d}.png'.format(
                       self.plotsDirectory, mainRunName,
-                      self.startYear, self.endYear)
+                      startYear, endYear)
         colorbarLabel = '[PW/m]'
         contourLevels = config.getExpression(self.sectionName,
                                              'contourLevelsGlobal',

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -82,7 +82,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
 
         # Get a list of timeSeriesStats output files from the streams file,
         # reading only those that are between the start and end dates
-        #   First a list necessary for theMHT climatology
+        #   First a list necessary for the MHT climatology
         streamName = self.historyStreams.find_stream(
             self.streamMap['timeSeriesStats'])
         self.startDate = config.get('climatology', 'startDate')
@@ -92,6 +92,12 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
                                          startDate=self.startDate,
                                          endDate=self.endDate,
                                          calendar=self.calendar)
+
+        if len(self.inputFiles) == 0:
+            raise IOError('No files were found in stream {} between {} and '
+                          '{}.'.format(streamName, self.startDate,
+                                       self.endDate))
+
         self.simulationStartTime = get_simulation_start_time(self.runStreams)
 
         self.startYear = config.getint('climatology', 'startYear')

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -99,6 +99,16 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
                           '{}.'.format(streamName, self.startDate,
                                        self.endDate))
 
+        # Later, we will read in depth and MHT latitude points
+        # from mpaso.hist.am.meridionalHeatTransport.*.nc
+        mhtFiles = self.historyStreams.readpath(
+                'meridionalHeatTransportOutput')
+        if len(mhtFiles) == 0:
+            raise IOError('No MPAS-O MHT history file found: need at least '
+                          'one ')
+
+        self.mhtFile = mhtFiles[0]
+
         self.simulationStartTime = get_simulation_start_time(self.runStreams)
 
         self.startYear = config.getint('climatology', 'startYear')
@@ -144,15 +154,9 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
         #  mpaso.hist.am.meridionalHeatTransport.*.nc
         # Depth is from refZMid, also in
         # mpaso.hist.am.meridionalHeatTransport.*.nc
-        try:
-            mhtFile = self.historyStreams.readpath(
-                'meridionalHeatTransportOutput')[0]
-        except ValueError:
-            raise IOError('No MPAS-O MHT history file found: need at least '
-                          'one ')
 
         print '  Read in depth and latitude...'
-        ncFile = netCDF4.Dataset(mhtFile, mode='r')
+        ncFile = netCDF4.Dataset(self.mhtFile, mode='r')
         # reference depth [m]
         refZMid = ncFile.variables['refZMid'][:]
         refBottomDepth = ncFile.variables['refBottomDepth'][:]

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -270,6 +270,8 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
         # update the start and end year in config based on the real extend of
         # ds
         update_start_end_year(ds, config, self.calendar)
+        self.startYearClimo = config.getint('climatology', 'startYear')
+        self.endYearClimo = config.getint('climatology', 'endYear')
 
         cachePrefix = '{}/meanVelocity'.format(outputDirectory)
 

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -105,6 +105,11 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
                                          startDate=self.startDateClimo,
                                          endDate=self.endDateClimo,
                                          calendar=self.calendar)
+        if len(self.inputFilesClimo) == 0:
+            raise IOError('No files were found in stream {} between {} and '
+                          '{}.'.format(streamName, self.startDateClimo,
+                                       self.endDateClimo))
+
         self.simulationStartTime = get_simulation_start_time(self.runStreams)
 
         self.startYearClimo = config.getint('climatology', 'startYear')
@@ -118,6 +123,10 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
                                          startDate=self.startDateTseries,
                                          endDate=self.endDateTseries,
                                          calendar=self.calendar)
+        if len(self.inputFilesTseries) == 0:
+            raise IOError('No files were found in stream {} between {} and '
+                          '{}.'.format(streamName, self.startDateTseries,
+                                       self.endDateTseries))
 
         self.startYearTseries = config.getint('timeSeries', 'startYear')
         self.endYearTseries = config.getint('timeSeries', 'endYear')

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -183,8 +183,9 @@ def open_multifile_dataset(fileNames, calendar, config,
 
     if ds.dims['Time'] == 0:
         raise ValueError('The data set contains no Time entries between dates\n'
-                         '{} and {}.'.format(days_to_datetime(startDate),
-                                             days_to_datetime(endDate)))
+                         '{} and {}.'.format(
+                             days_to_datetime(startDate, calendar=calendar),
+                             days_to_datetime(endDate, calendar=calendar)))
     # process chunking
     if chunking is True:
         # limit chunk size to prevent memory error

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -259,37 +259,15 @@ class StreamsFile:
         if (startDate is None) and (endDate is None):
             return fileList
 
-        output_interval = self.read(streamName, 'output_interval')
-        if output_interval is None:
-            # There's no file interval, so hard to know what to do
-            # let's put a buffer of a year on each side to be safe
-            offsetDate = string_to_relative_delta(dateString='0001-00-00',
-                                                  calendar=calendar)
-        else:
-            offsetDate = string_to_relative_delta(dateString=output_interval,
-                                                  calendar=calendar)
-
         if startDate is not None:
             # read one extra file before the start date to be on the safe side
             if isinstance(startDate, str):
                 startDate = string_to_datetime(startDate)
-            try:
-                startDate -= offsetDate
-            except (ValueError, OverflowError):
-                # if the startDate would be out of range after subtracting
-                # the offset, we'll stick with the starDate as it is
-                pass
 
         if endDate is not None:
             # read one extra file after the end date to be on the safe side
             if isinstance(endDate, str):
                 endDate = string_to_datetime(endDate)
-            try:
-                endDate += offsetDate
-            except (ValueError, OverflowError):
-                # if the endDate would be out of range after adding
-                # the offset, we'll stick with the endDate as it is
-                pass
 
         # remove any path that's part of the template
         template = os.path.basename(template)

--- a/mpas_analysis/test/test_namelist_streams_interface.py
+++ b/mpas_analysis/test/test_namelist_streams_interface.py
@@ -57,7 +57,7 @@ class TestNamelist(TestCase):
         self.assertEqual(files, expectedFiles)
 
         files = self.sf.readpath('output',
-                                 startDate='0001-01-03',
+                                 startDate='0001-01-02',
                                  endDate='0001-12-30',
                                  calendar='gregorian_noleap')
         expectedFiles = []
@@ -67,7 +67,7 @@ class TestNamelist(TestCase):
         self.assertEqual(files, expectedFiles)
 
         files = self.sf.readpath('output',
-                                 startDate='0001-01-03',
+                                 startDate='0001-01-02',
                                  calendar='gregorian_noleap')
         expectedFiles = []
         for date in ['0001-01-02', '0001-02-01', '0002-01-01']:


### PR DESCRIPTION
With this merge, each task gets a list of files from the appropriate stream during its `setup_and_check` phase.  If no files are found within the appropriate time range (i.e. between the startYear and endYear for a climatology, time series or climate index), an exception is raised to say that no files were found.

This new behavior is intended to provide a clearer error message when a user selects a range for which no files are available.

Three other small bugs have been fixed along the way:
* in the `streamfunctionMOC` task, when the climatology start and end years are updated based on the range of the actual climatology, the copy of the start and end years stored in the task itself (`self.startYearClimo` and `self.endYearClimo`) are now also updated.  This ensures that the task attempts to load the correct cache file, which is not the case in the current `develop`.
* similarly, in the `meridionalHeatTransport` task, `startYear` and `endYear` are now being updated to the range actually present in the climatology data set.  The title of the plots and the names of the image files have been changed accordingly.
* in `climatologyMap*` tasks, the individual `setup_and_check` functions were calling the the `super` version of the same function with the incorrect class name, meaning they were skipping `ClimatologyMapOcean.setup_and_check()` and going straight to `AnalysisTask.setup_and_check()`.  This has been fixed.