### PR TITLE
MOC with ncclimo

### DIFF
--- a/config.default
+++ b/config.default
@@ -43,6 +43,11 @@ parallelTaskCount = 1
 # Default is no prefix (run_analysis.py is executed directly)
 commandPrefix =
 
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" if running on a machine that can handle 12 simultaneous
+# processes, one for each monthly climatology.
+ncclimoParallelMode = serial
+
 [input]
 ## options related to reading in the results to be analyzed
 

--- a/config.default
+++ b/config.default
@@ -44,8 +44,8 @@ parallelTaskCount = 1
 commandPrefix =
 
 # the parallelism mode in ncclimo ("serial" or "bck")
-# Set this to "bck" if running on a machine that can handle 12 simultaneous
-# processes, one for each monthly climatology.
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = serial
 
 [input]

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -322,6 +322,7 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
             make_directories(outputDirectory)
 
             compute_climatologies_with_ncclimo(
+                    config=config,
                     inDirectory=self.historyDirectory,
                     outDirectory=outputDirectory,
                     startYear=self.startYearClimo,

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -5,8 +5,7 @@ import netCDF4
 import os
 from functools import partial
 
-from ..shared.constants.constants import m3ps_to_Sv, \
-    monthDictionary
+from ..shared.constants.constants import m3ps_to_Sv
 from ..shared.plot.plotting import plot_vertical_section,\
     timeseries_analysis_plot, setup_colormap
 
@@ -18,9 +17,9 @@ from ..shared.generalized_reader.generalized_reader \
 from ..shared.timekeeping.utility import get_simulation_start_time, \
     days_to_datetime
 
-from ..shared.climatology.climatology import \
-    update_climatology_bounds_from_file_names, \
-    cache_climatologies
+from ..shared.climatology.climatology \
+    import update_climatology_bounds_from_file_names, \
+    compute_climatologies_with_ncclimo
 
 from ..shared.analysis_task import AnalysisTask
 
@@ -197,7 +196,7 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
             #                                      sectionName, dictClimo,
             #                                      dictTseries)
         else:
-            self._cache_velocity_climatologies()
+            self._compute_velocity_climatologies()
             self._compute_moc_climo_postprocess()
             dsMOCTimeSeries = self._compute_moc_time_series_postprocess()
 
@@ -301,7 +300,7 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
             refTopDepth, refLayerThickness
         # }}}
 
-    def _cache_velocity_climatologies(self):  # {{{
+    def _compute_velocity_climatologies(self):  # {{{
         '''compute yearly velocity climatologies and cache them'''
 
         variableList = ['timeMonthly_avg_normalVelocity',
@@ -309,36 +308,27 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
 
         config = self.config
 
-        outputDirectory = build_config_full_path(config, 'output',
-                                                 'mpasClimatologySubdirectory')
+        outputRoot = build_config_full_path(config, 'output',
+                                            'mpasClimatologySubdirectory')
 
-        make_directories(outputDirectory)
+        outputDirectory = '{}/meanVelocity'.format(outputRoot)
 
-        if config.has_option(self.sectionName, 'maxChunkSize'):
-            chunking = config.getExpression(self.sectionName, 'maxChunkSize')
-        else:
-            chunking = None
+        self.velClimoFile = \
+            '{}/mpaso_ANN_{:04d}01_{:04d}12_climo.nc'.format(
+                    outputDirectory, self.startYearClimo,
+                    self.endYearClimo)
 
-        ds = open_multifile_dataset(
-            fileNames=self.inputFilesClimo,
-            calendar=self.calendar,
-            config=config,
-            simulationStartTime=self.simulationStartTime,
-            timeVariableName=['xtime_startMonthly', 'xtime_endMonthly'],
-            variableList=variableList,
-            startDate=self.startDateClimo,
-            endDate=self.endDateClimo,
-            chunking=chunking)
+        if not os.path.exists(self.velClimoFile):
+            make_directories(outputDirectory)
 
-        self.startYearClimo = config.getint('climatology', 'startYear')
-        self.endYearClimo = config.getint('climatology', 'endYear')
-
-        cachePrefix = '{}/meanVelocity'.format(outputDirectory)
-
-        # compute and cache the velocity climatology
-        cache_climatologies(ds, monthDictionary['ANN'],
-                            config, cachePrefix, self.calendar,
-                            printProgress=True)
+            compute_climatologies_with_ncclimo(
+                    inDirectory=self.historyDirectory,
+                    outDirectory=outputDirectory,
+                    startYear=self.startYearClimo,
+                    endYear=self.endYearClimo,
+                    variableList=variableList,
+                    modelName='mpaso',
+                    decemberMode='sdd')
         # }}}
 
     def _compute_moc_climo_postprocess(self):  # {{{
@@ -404,24 +394,17 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
         if not os.path.exists(outputFileClimo):
             print '   Load data...'
 
-            cachePrefix = '{}/meanVelocity'.format(outputDirectory)
-
-            if self.startYearClimo == self.endYearClimo:
-                yearString = '{:04d}'.format(self.startYearClimo)
-                velClimoFile = '{}_year{}.nc'.format(cachePrefix, yearString)
-            else:
-                yearString = '{:04d}-{:04d}'.format(self.startYearClimo,
-                                                    self.endYearClimo)
-                velClimoFile = '{}_years{}.nc'.format(cachePrefix, yearString)
-
-            annualClimatology = xr.open_dataset(velClimoFile)
+            annualClimatology = xr.open_dataset(self.velClimoFile)
+            # rename some variables for convenience
+            annualClimatology = annualClimatology.rename(
+                    {'timeMonthly_avg_normalVelocity': 'avgNormalVelocity',
+                     'timeMonthly_avg_vertVelocityTop': 'avgVertVelocityTop'})
+            annualClimatology = annualClimatology.isel(Time=0)
 
             # Convert to numpy arrays
             # (can result in a memory error for large array size)
-            horizontalVel = \
-                annualClimatology.timeMonthly_avg_normalVelocity.values
-            verticalVel = \
-                annualClimatology.timeMonthly_avg_vertVelocityTop.values
+            horizontalVel = annualClimatology.avgNormalVelocity.values
+            verticalVel = annualClimatology.avgVertVelocityTop.values
             velArea = verticalVel * areaCell[:, np.newaxis]
 
             # Create dictionary for MOC climatology (NB: need this form

--- a/mpas_analysis/shared/climatology/__init__.py
+++ b/mpas_analysis/shared/climatology/__init__.py
@@ -2,5 +2,6 @@ from .climatology import get_lat_lon_comparison_descriptor, get_remapper, \
     get_mpas_climatology_file_names, get_observation_climatology_file_names, \
     compute_monthly_climatology, compute_climatology, cache_climatologies, \
     update_climatology_bounds_from_file_names, \
-    add_years_months_days_in_month, \
-    remap_and_write_climatology
+    add_years_months_days_in_month, remap_and_write_climatology, \
+    compute_climatologies_with_ncclimo
+

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -223,7 +223,7 @@ def get_mpas_climatology_file_names(config, fieldName, monthNames,
     # }}}
 
 
-def compute_climatologies_with_ncclimo(inDirectory, outDirectory,
+def compute_climatologies_with_ncclimo(config, inDirectory, outDirectory,
                                        startYear, endYear,
                                        variableList, modelName,
                                        decemberMode='scd'):  # {{{
@@ -233,6 +233,9 @@ def compute_climatologies_with_ncclimo(inDirectory, outDirectory,
 
     Parameters
     ----------
+    config :  instance of MpasAnalysisConfigParser
+        Contains configuration options
+
     inDirectory : str
         The run directory containing timeSeriesStatsMonthly output
 
@@ -273,10 +276,13 @@ def compute_climatologies_with_ncclimo(inDirectory, outDirectory,
                       'Note: this presumes use of the conda-forge '
                       'channel.')
 
+    parallelMode = config.get('execute', 'ncclimoParallelMode')
+
     args = ['ncclimo',
             '--clm_md=mth',
             '-a', decemberMode,
             '-m', modelName,
+            '-p', parallelMode,
             '-v', ','.join(variableList),
             '-s', '{:04d}'.format(startYear),
             '-e', '{:04d}'.format(endYear),

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -9,6 +9,9 @@ Xylar Asay-Davis
 import xarray as xr
 import os
 import numpy
+from distutils.spawn import find_executable
+import sys
+import subprocess
 
 from ..constants import constants
 
@@ -218,6 +221,76 @@ def get_mpas_climatology_file_names(config, fieldName, monthNames,
                 remappedFileName)
 
     # }}}
+
+
+def compute_climatologies_with_ncclimo(inDirectory, outDirectory,
+                                       startYear, endYear,
+                                       variableList, modelName,
+                                       decemberMode='scd'):  # {{{
+    '''
+    Uses ncclimo to compute monthly, seasonal (DJF, MAM, JJA, SON) and annual
+    climatologies.
+
+    Parameters
+    ----------
+    inDirectory : str
+        The run directory containing timeSeriesStatsMonthly output
+
+    outDirectory : str
+        The output directory where climatologies will be written
+
+
+    startYear, endYear : int
+        The start and end years of the climatology
+
+    variableList : list of str
+        A list of variables to include in the climatology
+
+    modeName : ['mpaso', 'mpascice']
+        The name of the component for which the climatology is to be computed
+
+    decemberMode : ['scd', 'sdd']
+        Whether years start in December (scd - seasonally continuous December)
+        or January (sdd - seasonally discontinuous December).  If the former,
+        the data set begins with December of the year before startYear and ends
+        with November of endYear.  Otherwise, goes from January of startYear to
+        December of endYear.
+
+    Raises
+    ------
+    OSError
+        If ``ncclimo`` is not in the system path.
+
+    Author
+    ------
+    Xylar Asay-Davis
+    '''
+
+    if find_executable('ncclimo') is None:
+        raise OSError('ncclimo not found. Make sure the latest nco '
+                      'package is installed: \n'
+                      'conda install nco\n'
+                      'Note: this presumes use of the conda-forge '
+                      'channel.')
+
+    args = ['ncclimo',
+            '--clm_md=mth',
+            '-a', decemberMode,
+            '-m', modelName,
+            '-v', ','.join(variableList),
+            '-s', '{:04d}'.format(startYear),
+            '-e', '{:04d}'.format(endYear),
+            '-i', inDirectory,
+            '-o', outDirectory]
+
+    print 'running: {}'.format(' '.join(args))
+
+    # make sure any output is flushed before we add output from the
+    # subprocess
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    subprocess.check_call(args)  # }}}
 
 
 def get_observation_climatology_file_names(config, fieldName, monthNames,
@@ -496,7 +569,6 @@ def update_climatology_bounds_from_file_names(inputFiles, config):  # {{{
     Authors
     -------
     Xylar Asay-Davis
-
     """
     requestedStartYear = config.getint('climatology', 'startYear')
     requestedEndYear = config.getint('climatology', 'endYear')


### PR DESCRIPTION
This merge uses `ncclimo` to compute an annual climatology of velocity, which is subsequently used to compute the MOC streamfunction.

A function for calling `ncclimo` has been added to the `climatology` module, and another has been added for updating `startYear` and `endYear` for climatologies based on the list of files that are actually available.

Since `ncclimo` does not support renaming variables according to the `variableMap`, variables have been manually renamed using the names supported by ACME beta1 and later.