### PR TITLE
General clean-up PR

### DIFF
--- a/config.default
+++ b/config.default
@@ -99,9 +99,10 @@ scratchSubdirectory = scratch
 plotsSubdirectory = plots
 logsSubdirectory = logs
 mpasClimatologySubdirectory = clim/mpas
-mpasRegriddedClimSubdirectory = clim/mpas/regridded
+mpasRemappedClimSubdirectory = clim/mpas/remapped
 mappingSubdirectory = mapping
 timeSeriesSubdirectory = timeseries
+timeCacheSubdirectory = timecache
 
 # a list of analyses to generate.  Valid names are:
 #   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
@@ -152,9 +153,6 @@ comparisonLonResolution = 0.5
 # generated based on the MPAS mesh name, the comparison grid resolution, and
 # the interpolation method
 # mpasMappingFile = /path/to/mapping/file
-
-# overwrite files when building climatologies?
-overwriteMpasClimatology = False
 
 # interpolation order for model and observation results. Likely values are
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
@@ -230,14 +228,11 @@ interpolationMethod = bilinear
 # The directories where observation climatologies will be stored if they need
 # to be computed.  If a relative path is supplied, it is relative to the output
 # base directory.  If an absolute path is supplied, this should point to
-# cached climatology files on the desired comparison grid, in which case
-# overwriteObsClimatology should be False.  If cached regridded files are
-# supplied, there is no need to provide cached files before regridding.
+# cached climatology files on the desired comparison grid.  If cached remapped
+# files are supplied, there is no need to provide cached files before
+# remapping.
 climatologySubdirectory = clim/obs
-regriddedClimSubdirectory = clim/obs/regridded
-
-# overwrite files when building climatologies?
-overwriteObsClimatology = False
+remappedClimSubdirectory = clim/obs/remapped
 
 [oceanReference]
 ## options related to ocean reference run with which the results will be
@@ -290,14 +285,11 @@ interpolationMethod = bilinear
 # The directories where observation climatologies will be stored if they need
 # to be computed.  If a relative path is supplied, it is relative to the output
 # base directory.  If an absolute path is supplied, this should point to
-# cached climatology files on the desired comparison grid, in which case
-# overwriteObsClimatology should be False.  If cached regridded files are
-# supplied, there is no need to provide cached files before regridding.
+# cached climatology files on the desired comparison grid.  If cached remapped
+# files are supplied, there is no need to provide cached files before
+# remapping.
 climatologySubdirectory = clim/obs
-regriddedClimSubdirectory = clim/obs/regridded
-
-# overwrite files when building climatologies?
-overwriteObsClimatology = False
+remappedClimSubdirectory = clim/obs/remapped
 
 [seaIceReference]
 ## options related to sea ice reference run with which the results will be
@@ -450,7 +442,7 @@ titleFontSize = 18
 polarPlot = False
 
 [climatologyMapSST]
-## options related to plotting horizontally regridded climatologies of
+## options related to plotting horizontally remapped climatologies of
 ## sea surface temperature (SST) against reference model results and
 ## observations
 
@@ -473,7 +465,7 @@ colorbarLevelsDifference = [-5, -3, -2, -1, 0, 1, 2, 3, 5]
 comparisonTimes =  ['JFM', 'JAS', 'ANN']
 
 [climatologyMapSSS]
-## options related to plotting horizontally regridded climatologies of
+## options related to plotting horizontally remapped climatologies of
 ## sea surface salinity (SSS) against reference model results and observations
 
 # colormap for model/observations
@@ -495,7 +487,7 @@ colorbarLevelsDifference = [-3, -2, -1, -0.5, 0, 0.5, 1, 2, 3]
 comparisonTimes =  ['JFM', 'JAS', 'ANN']
 
 [climatologyMapMLD]
-## options related to plotting horizontally regridded climatologies of
+## options related to plotting horizontally remapped climatologies of
 ## mixed layer depth (MLD) against reference model results and observations
 
 # colormap for model/observations
@@ -517,7 +509,7 @@ colorbarLevelsDifference = [-150, -80, -30, -10, 0, 10, 30, 80, 150]
 comparisonTimes =  ['JFM', 'JAS', 'ANN']
 
 [climatologyMapSeaIceConcThick]
-## options related to plotting horizontally regridded climatologies of
+## options related to plotting horizontally remapped climatologies of
 ## sea ice concentration and thickness against reference model results and
 ## observations
 

--- a/config.default
+++ b/config.default
@@ -47,7 +47,7 @@ commandPrefix =
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /dir/to/model/output
+baseDirectory = /dir/for/model/output
 
 # Note: an absolute path can be supplied for any of these subdirectories.
 # A relative path is assumed to be relative to baseDirectory.
@@ -86,13 +86,18 @@ autocloseFileLimitFraction = 0.5
 # with a single time slice.
 maxChunkSize = 10000
 
+# Directory for mapping files (if they have been generated already). If mapping
+# files needed by the analysis are not found here, they will be generated and
+# placed in the output mappingSubdirectory
+# mappingDirectory = /dir/for/mapping/files
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.
 
 # directory where analysis should be written
 # NOTE: This directory path must be specific to each test case.
-baseDirectory = /dir/to/analysis/output
+baseDirectory = /dir/for/analysis/output
 
 # subdirectories within baseDirectory for analysis output
 scratchSubdirectory = scratch
@@ -146,13 +151,6 @@ endYear = 20
 # The comparison grid resolution in degrees
 comparisonLatResolution = 0.5
 comparisonLonResolution = 0.5
-
-# The names of the mapping file used for interpolation.  If a mapping file has
-# already been generated, supplying the absolute path can save the time of
-# generating a new one.  If nothing is supplied, the file name is automatically
-# generated based on the MPAS mesh name, the comparison grid resolution, and
-# the interpolation method
-# mpasMappingFile = /path/to/mapping/file
 
 # interpolation order for model and observation results. Likely values are
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
@@ -211,16 +209,6 @@ sstClimatologyEndYear = 1900
 #sstClimatologyStartYear = 1990
 #sstClimatologyEndYear = 2011
 
-# The name of mapping files used for interpolating observations to the
-# comparison grid.  Interpolation is only performed if the observation grid has
-# a different resolution from the comparison grid. If nothing is supplied, the
-# file name is automatically generated based on the MPAS mesh name, the
-# comparison grid resolution, and the interpolation method
-# sstClimatologyMappingFile = /path/to/mapping/file
-# sssClimatologyMappingFile = /path/to/mapping/file
-# mldClimatologyMappingFile = /path/to/mapping/file
-
-
 # interpolation order for observations. Likely values are
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
 interpolationMethod = bilinear
@@ -270,13 +258,6 @@ thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
 thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
 thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
 thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
-
-# The name of mapping files used for interpolating observations to the
-# comparison grid.  Interpolation is only performed if the observation grid has
-# a different resolution from the comparison grid. If nothing is supplied, the
-# file name is automatically generated based on the MPAS mesh name, the
-# comparison grid resolution, and the interpolation method
-# seaIceClimatologyMappingFile = /path/to/mapping/file
 
 # interpolation order for observations. Likely values are
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
@@ -381,7 +362,7 @@ compareWithObservations = True
 regionNames = ['Atlantic']
 
 # Mask file for post-processing regional MOC computation
-regionMaskFiles = /path/to/MOCregional/mapping/file
+regionMaskFiles = /path/to/MOCregional/mask/file
 
 # xarray (with dask) divides data sets into "chunks", allowing computations
 # to be made on data that is larger than the available memory.  MPAS-Analysis

--- a/mpas_analysis/ocean/climatology_map.py
+++ b/mpas_analysis/ocean/climatology_map.py
@@ -116,12 +116,6 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
 
         mainRunName = config.get('runs', 'mainRunName')
 
-        overwriteMpasClimatology = config.getWithDefault(
-            'climatology', 'overwriteMpasClimatology', False)
-
-        overwriteObsClimatology = config.getWithDefault(
-            'oceanObservations', 'overwriteObsClimatology', False)
-
         try:
             restartFileName = self.runStreams.readpath('restart')[0]
         except ValueError:
@@ -192,8 +186,7 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
                     mpasMeshName=mpasDescriptor.meshName,
                     comparisonGridName=comparisonDescriptor.meshName)
 
-            if (overwriteMpasClimatology or
-                    not os.path.exists(remappedFileName)):
+            if not os.path.exists(remappedFileName):
                 seasonalClimatology = cache_climatologies(
                     ds, monthValues, config, climatologyPrefix, calendar,
                     printProgress=True)
@@ -225,8 +218,7 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
                     config=config, fieldName=fieldName, monthNames=months,
                     componentName='ocean', remapper=origObsRemapper)
 
-            if (overwriteObsClimatology or
-                    not os.path.exists(remappedFileName)):
+            if not os.path.exists(remappedFileName):
 
                 if dsObs is None:
                     # load the observations the first time

--- a/mpas_analysis/ocean/climatology_map.py
+++ b/mpas_analysis/ocean/climatology_map.py
@@ -184,7 +184,7 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
         for months in outputTimes:
             monthValues = constants.monthDictionary[months]
 
-            (climatologyFileName, climatologyPrefix, regriddedFileName) = \
+            (climatologyFileName, climatologyPrefix, remappedFileName) = \
                 get_mpas_climatology_file_names(
                     config=config,
                     fieldName=fieldName,
@@ -193,7 +193,7 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
                     comparisonGridName=comparisonDescriptor.meshName)
 
             if (overwriteMpasClimatology or
-                    not os.path.exists(regriddedFileName)):
+                    not os.path.exists(remappedFileName)):
                 seasonalClimatology = cache_climatologies(
                     ds, monthValues, config, climatologyPrefix, calendar,
                     printProgress=True)
@@ -207,11 +207,11 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
 
                 remappedClimatology = remap_and_write_climatology(
                     config, seasonalClimatology, climatologyFileName,
-                    regriddedFileName, mpasRemapper)
+                    remappedFileName, mpasRemapper)
 
             else:
 
-                remappedClimatology = xr.open_dataset(regriddedFileName)
+                remappedClimatology = xr.open_dataset(remappedFileName)
 
             modelOutput = remappedClimatology[fieldName].values
             lon = remappedClimatology['lon'].values
@@ -220,13 +220,13 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
             lonTarg, latTarg = np.meshgrid(lon, lat)
 
             # now the observations
-            (climatologyFileName, regriddedFileName) = \
+            (climatologyFileName, remappedFileName) = \
                 get_observation_climatology_file_names(
                     config=config, fieldName=fieldName, monthNames=months,
                     componentName='ocean', remapper=origObsRemapper)
 
             if (overwriteObsClimatology or
-                    not os.path.exists(regriddedFileName)):
+                    not os.path.exists(remappedFileName)):
 
                 if dsObs is None:
                     # load the observations the first time
@@ -265,11 +265,11 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
                     remappedClimatology = \
                         remap_and_write_climatology(
                             config, seasonalClimatology, climatologyFileName,
-                            regriddedFileName, obsRemapper)
+                            remappedFileName, obsRemapper)
 
             else:
 
-                remappedClimatology = xr.open_dataset(regriddedFileName)
+                remappedClimatology = xr.open_dataset(remappedFileName)
             observations = remappedClimatology[self.obsFieldName].values
 
             bias = modelOutput - observations

--- a/mpas_analysis/ocean/climatology_map.py
+++ b/mpas_analysis/ocean/climatology_map.py
@@ -151,8 +151,6 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
         mpasRemapper = get_remapper(
             config=config, sourceDescriptor=mpasDescriptor,
             comparisonDescriptor=comparisonDescriptor,
-            mappingFileSection='climatology',
-            mappingFileOption='mpasMappingFile',
             mappingFilePrefix=mappingFilePrefix,
             method=config.get('climatology', 'mpasInterpolationMethod'))
 
@@ -236,9 +234,6 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
                     obsRemapper = get_remapper(
                         config=config, sourceDescriptor=obsDescriptor,
                         comparisonDescriptor=comparisonDescriptor,
-                        mappingFileSection='oceanObservations',
-                        mappingFileOption='{}ClimatologyMappingFile'.format(
-                            fieldName),
                         mappingFilePrefix='map_obs_{}'.format(fieldName),
                         method=config.get('oceanObservations',
                                           'interpolationMethod'))

--- a/mpas_analysis/ocean/climatology_map.py
+++ b/mpas_analysis/ocean/climatology_map.py
@@ -93,10 +93,6 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
         Authors
         -------
         Luke Van Roekel, Xylar Asay-Davis, Milena Veneziani
-
-        Last Modified
-        -------------
-        03/16/2017
         """
 
         print "\nPlotting 2-d maps of {} climatologies...".format(

--- a/mpas_analysis/ocean/climatology_map.py
+++ b/mpas_analysis/ocean/climatology_map.py
@@ -21,6 +21,7 @@ from ..shared.plot.plotting import plot_global_comparison, \
 from ..shared.constants import constants
 
 from ..shared.io.utility import build_config_full_path
+from ..shared.io import write_netcdf
 
 from ..shared.generalized_reader.generalized_reader \
     import open_multifile_dataset
@@ -237,7 +238,7 @@ class ClimatologyMapOcean(AnalysisTask):  # {{{
                 if not obsRemapperBuilt:
                     seasonalClimatology.load()
                     seasonalClimatology.close()
-                    seasonalClimatology.to_netcdf(climatologyFileName)
+                    write_netcdf(seasonalClimatology, climatologyFileName)
                     # make the remapper for the climatology
                     obsDescriptor = LatLonGridDescriptor()
                     obsDescriptor.read(fileName=climatologyFileName,

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -457,10 +457,6 @@ class IndexNino34(AnalysisTask):  # {{{
         Author
         ------
         Luke Van Roekel
-
-        Last Modified
-        -------------
-        04/07/2017
         """
 
         fig = plt.figure(figsize=figsize, dpi=dpi)
@@ -606,10 +602,6 @@ class IndexNino34(AnalysisTask):  # {{{
         Author
         ------
         Luke Van Roekel
-
-        Last Modified
-        -------------
-        04/07/2017
         """
         fig = plt.figure(figsize=figsize, dpi=dpi)
 
@@ -687,10 +679,6 @@ class IndexNino34(AnalysisTask):  # {{{
         Author
         ------
         Luke Van Roekel
-
-        Last Modified
-        -------------
-        04/07/2017
         '''
         plt.title(panelTitle, y=1.06, **axis_font)
         y1 = ninoIndex

--- a/mpas_analysis/sea_ice/climatology_map.py
+++ b/mpas_analysis/sea_ice/climatology_map.py
@@ -175,11 +175,6 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
         mainRunName = config.get('runs', 'mainRunName')
         startYear = config.getint('climatology', 'startYear')
         endYear = config.getint('climatology', 'endYear')
-        overwriteMpasClimatology = config.getWithDefault(
-            'climatology', 'overwriteMpasClimatology', False)
-
-        overwriteObsClimatology = config.getWithDefault(
-            'seaIceObservations', 'overwriteObsClimatology', False)
 
         subtitle = 'Ice concentration'
 
@@ -194,7 +189,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
 
         comparisonDescriptor = self.mpasRemapper.destinationDescriptor
 
-        buildObsClimatologies = overwriteObsClimatology
+        buildObsClimatologies = False
         for months in hemisphereSeasons:
             hemisphere, season = hemisphereSeasons[months]
             climFieldName = 'iceConcentration'
@@ -253,8 +248,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
                     mpasMeshName=mpasMeshName,
                     comparisonGridName=comparisonGridName)
 
-            if (overwriteMpasClimatology or
-                    not os.path.exists(remappedFileName)):
+            if not os.path.exists(remappedFileName):
                 seasonalClimatology = cache_climatologies(
                     ds, monthValues, config, climatologyPrefix, calendar,
                     printProgress=True)
@@ -369,11 +363,6 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
         mainRunName = config.get('runs', 'mainRunName')
         startYear = config.getint('climatology', 'startYear')
         endYear = config.getint('climatology', 'endYear')
-        overwriteMpasClimatology = config.getWithDefault(
-            'climatology', 'overwriteMpasClimatology', False)
-
-        overwriteObsClimatology = config.getWithDefault(
-            'seaIceObservations', 'overwriteObsClimatology', False)
 
         obsFileNames = {}
         remappedObsFileNames = {}
@@ -382,7 +371,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
         comparisonDescriptor = self.mpasRemapper.destinationDescriptor
 
         # build a list of remapped observations files
-        buildObsClimatologies = overwriteObsClimatology
+        buildObsClimatologies = False
         for months in ['FM', 'ON']:
             climFieldName = 'iceThickness'
             for hemisphere in ['NH', 'SH']:
@@ -437,8 +426,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
                     mpasMeshName=mpasMeshName,
                     comparisonGridName=comparisonGridName)
 
-            if (overwriteMpasClimatology or
-                    not os.path.exists(climatologyFileName)):
+            if not os.path.exists(climatologyFileName):
                 seasonalClimatology = cache_climatologies(
                     ds, monthValues, config, climatologyPrefix, calendar,
                     printProgress=True)

--- a/mpas_analysis/sea_ice/climatology_map.py
+++ b/mpas_analysis/sea_ice/climatology_map.py
@@ -147,8 +147,6 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
         self.mpasRemapper = get_remapper(
             config=self.config, sourceDescriptor=mpasDescriptor,
             comparisonDescriptor=comparisonDescriptor,
-            mappingFileSection='climatology',
-            mappingFileOption='mpasMappingFile',
             mappingFilePrefix=mappingFilePrefix,
             method=self.config.get('climatology', 'mpasInterpolationMethod'))
 
@@ -207,8 +205,6 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
                 obsRemapper = get_remapper(
                         config=config, sourceDescriptor=obsDescriptor,
                         comparisonDescriptor=comparisonDescriptor,
-                        mappingFileSection='seaIceObservations',
-                        mappingFileOption='seaIceClimatologyMappingFile',
                         mappingFilePrefix='map_obs_seaIce',
                         method=config.get('seaIceObservations',
                                           'interpolationMethod'))
@@ -390,8 +386,6 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
                 obsRemapper = get_remapper(
                         config=config, sourceDescriptor=obsDescriptor,
                         comparisonDescriptor=comparisonDescriptor,
-                        mappingFileSection='seaIceObservations',
-                        mappingFileOption='seaIceClimatologyMappingFile',
                         mappingFilePrefix='map_obs_seaIce',
                         method=config.get('seaIceObservations',
                                           'interpolationMethod'))

--- a/mpas_analysis/sea_ice/climatology_map.py
+++ b/mpas_analysis/sea_ice/climatology_map.py
@@ -189,7 +189,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
                              'JJA': ('SH', 'Summer')}
 
         obsFileNames = {}
-        regriddedObsFileNames = {}
+        remappedObsFileNames = {}
         obsRemappers = {}
 
         comparisonDescriptor = self.mpasRemapper.destinationDescriptor
@@ -223,16 +223,16 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
                     raise OSError('Obs file {} not found.'.format(
                         obsFileName))
 
-                (climatologyFileName, regriddedFileName) = \
+                (climatologyFileName, remappedFileName) = \
                     get_observation_climatology_file_names(
                         config=config, fieldName=obsFieldName,
                         monthNames=months, componentName=self.componentName,
                         remapper=obsRemapper)
 
                 obsFileNames[key] = obsFileName
-                regriddedObsFileNames[key] = regriddedFileName
+                remappedObsFileNames[key] = remappedFileName
 
-                if not os.path.exists(regriddedFileName):
+                if not os.path.exists(remappedFileName):
                     buildObsClimatologies = True
 
         for months in hemisphereSeasons:
@@ -245,7 +245,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
             mpasMeshName = self.mpasRemapper.sourceDescriptor.meshName
             comparisonGridName = \
                 self.mpasRemapper.destinationDescriptor.meshName
-            (climatologyFileName, climatologyPrefix, regriddedFileName) = \
+            (climatologyFileName, climatologyPrefix, remappedFileName) = \
                 get_mpas_climatology_file_names(
                     config=config,
                     fieldName=climFieldName,
@@ -254,7 +254,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
                     comparisonGridName=comparisonGridName)
 
             if (overwriteMpasClimatology or
-                    not os.path.exists(regriddedFileName)):
+                    not os.path.exists(remappedFileName)):
                 seasonalClimatology = cache_climatologies(
                     ds, monthValues, config, climatologyPrefix, calendar,
                     printProgress=True)
@@ -267,11 +267,11 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
 
                 remappedClimatology = remap_and_write_climatology(
                     config, seasonalClimatology, climatologyFileName,
-                    regriddedFileName, self.mpasRemapper)
+                    remappedFileName, self.mpasRemapper)
 
             else:
 
-                remappedClimatology = xr.open_dataset(regriddedFileName)
+                remappedClimatology = xr.open_dataset(remappedFileName)
 
             iceConcentration = remappedClimatology[field].values
             lon = remappedClimatology['lon'].values
@@ -305,7 +305,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
                 obsFieldName = 'AICE'
 
                 key = (months, obsName)
-                regriddedFileName = regriddedObsFileNames[key]
+                remappedFileName = remappedObsFileNames[key]
 
                 if buildObsClimatologies:
                     obsFileName = obsFileNames[key]
@@ -314,7 +314,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
 
                     remappedClimatology = remap_and_write_climatology(
                             config, seasonalClimatology,  climatologyFileName,
-                            regriddedFileName, obsRemappers[key])
+                            remappedFileName, obsRemappers[key])
 
                 obsIceConcentration = remappedClimatology[obsFieldName].values
 
@@ -376,12 +376,12 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
             'seaIceObservations', 'overwriteObsClimatology', False)
 
         obsFileNames = {}
-        regriddedObsFileNames = {}
+        remappedObsFileNames = {}
         obsRemappers = {}
 
         comparisonDescriptor = self.mpasRemapper.destinationDescriptor
 
-        # build a list of regridded observations files
+        # build a list of remapped observations files
         buildObsClimatologies = overwriteObsClimatology
         for months in ['FM', 'ON']:
             climFieldName = 'iceThickness'
@@ -408,16 +408,16 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
                                           'interpolationMethod'))
                 obsRemappers[key] = obsRemapper
 
-                (climatologyFileName, regriddedFileName) = \
+                (climatologyFileName, remappedFileName) = \
                     get_observation_climatology_file_names(
                         config=config, fieldName=obsFieldName,
                         monthNames=months, componentName=self.componentName,
                         remapper=obsRemapper)
 
                 obsFileNames[key] = obsFileName
-                regriddedObsFileNames[key] = regriddedFileName
+                remappedObsFileNames[key] = remappedFileName
 
-                if not os.path.exists(regriddedFileName):
+                if not os.path.exists(remappedFileName):
                     buildObsClimatologies = True
 
         for months in ['FM', 'ON']:
@@ -429,7 +429,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
             mpasMeshName = self.mpasRemapper.sourceDescriptor.meshName
             comparisonGridName = \
                 self.mpasRemapper.destinationDescriptor.meshName
-            (climatologyFileName, climatologyPrefix, regriddedFileName) = \
+            (climatologyFileName, climatologyPrefix, remappedFileName) = \
                 get_mpas_climatology_file_names(
                     config=config,
                     fieldName=climFieldName,
@@ -451,11 +451,11 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
 
                 remappedClimatology = remap_and_write_climatology(
                     config, seasonalClimatology, climatologyFileName,
-                    regriddedFileName, self.mpasRemapper)
+                    remappedFileName, self.mpasRemapper)
 
             else:
 
-                remappedClimatology = xr.open_dataset(regriddedFileName)
+                remappedClimatology = xr.open_dataset(remappedFileName)
 
             iceThickness = remappedClimatology[field].values
             iceThickness = ma.masked_values(iceThickness, 0)
@@ -485,7 +485,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
 
                 # now the observations
                 key = (months, hemisphere)
-                regriddedFileName = regriddedObsFileNames[key]
+                remappedFileName = remappedObsFileNames[key]
 
                 if buildObsClimatologies:
                     obsFileName = obsFileNames[key]
@@ -494,7 +494,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
 
                     remappedClimatology = remap_and_write_climatology(
                             config, seasonalClimatology, climatologyFileName,
-                            regriddedFileName, obsRemappers[key])
+                            remappedFileName, obsRemappers[key])
 
                 obsIceThickness = remappedClimatology[obsFieldName].values
 

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -19,7 +19,9 @@ from ..constants import constants
 
 from ..timekeeping.utility import days_to_datetime
 
-from ..io.utility import build_config_full_path, make_directories, fingerprint_generator
+from ..io.utility import build_config_full_path, make_directories, \
+    fingerprint_generator
+from ..io import write_netcdf
 
 from ..interpolation import Remapper
 from ..grid import LatLonGridDescriptor, ProjectionGridDescriptor
@@ -679,7 +681,7 @@ def remap_and_write_climatology(config, climatologyDataSet,
     else:
         if useNcremap:
             if not os.path.exists(climatologyFileName):
-                climatologyDataSet.to_netcdf(climatologyFileName)
+                write_netcdf(climatologyDataSet, climatologyFileName)
             remapper.remap_file(inFileName=climatologyFileName,
                                 outFileName=regriddedFileName,
                                 overwrite=True)
@@ -690,7 +692,7 @@ def remap_and_write_climatology(config, climatologyDataSet,
 
             remappedClimatology = remapper.remap(climatologyDataSet,
                                                  renormalizationThreshold)
-            remappedClimatology.to_netcdf(regriddedFileName)
+            write_netcdf(remappedClimatology, regriddedFileName)
     return remappedClimatology  # }}}
 
 
@@ -882,7 +884,7 @@ def _cache_individual_climatologies(ds, cacheInfo, printProgress,
         climatology.attrs['totalMonths'] = monthCount
         climatology.attrs['fingerprintClimo'] = fingerprint_generator()
 
-        climatology.to_netcdf(outputFileClimo)
+        write_netcdf(climatology, outputFileClimo)
         climatology.close()
 
     # }}}
@@ -965,7 +967,7 @@ def _cache_aggregated_climatology(startYearClimo, endYearClimo, cachePrefix,
         climatology.attrs['totalMonths'] = totalMonths
         climatology.attrs['fingerprintClimo'] = fingerprint_generator()
 
-        climatology.to_netcdf(outputFileClimo)
+        write_netcdf(climatology, outputFileClimo)
 
     return climatology  # }}}
 

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -4,10 +4,6 @@ Functions for creating climatologies from monthly time series data
 Authors
 -------
 Xylar Asay-Davis
-
-Last Modified
--------------
-04/13/2017
 """
 
 import xarray as xr
@@ -45,10 +41,6 @@ def get_lat_lon_comparison_descriptor(config):  # {{{
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/13/2017
     """
     climSection = 'climatology'
 
@@ -112,10 +104,6 @@ def get_remapper(config, sourceDescriptor, comparisonDescriptor,
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/13/2017
     """
 
     if config.has_option(mappingFileSection, mappingFileOption):
@@ -268,10 +256,6 @@ def get_observation_climatology_file_names(config, fieldName, monthNames,
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    03/03/2017
     """
 
     obsSection = '{}Observations'.format(componentName)
@@ -339,10 +323,6 @@ def compute_monthly_climatology(ds, calendar=None, maskVaries=True):  # {{{
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/08/2017
     """
 
     def compute_one_month_climatology(ds):
@@ -397,10 +377,6 @@ def compute_climatology(ds, monthValues, calendar=None,
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/08/2017
     """
 
     ds = add_years_months_days_in_month(ds, calendar)
@@ -463,10 +439,6 @@ def cache_climatologies(ds, monthValues, config, cachePrefix, calendar,
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/11/2017
     '''
     startYearClimo = config.getint('climatology', 'startYear')
     endYearClimo = config.getint('climatology', 'endYear')
@@ -581,10 +553,6 @@ def add_years_months_days_in_month(ds, calendar=None):  # {{{
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/08/2017
     '''
 
     if ('year' in ds.coords and 'month' in ds.coords and
@@ -668,10 +636,6 @@ def remap_and_write_climatology(config, climatologyDataSet,
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/13/2017
     """
     useNcremap = config.getboolean('climatology', 'useNcremap')
 
@@ -705,10 +669,6 @@ def _compute_masked_mean(ds, maskVaries):  # {{{
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/08/2017
     '''
     def ds_to_weights(ds):
         # make an identical data set to ds but replacing all data arrays with
@@ -791,10 +751,6 @@ def _setup_climatology_caching(ds, startYearClimo, endYearClimo,
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/08/2017
     '''
 
     cacheInfo = []
@@ -858,10 +814,6 @@ def _cache_individual_climatologies(ds, cacheInfo, printProgress,
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/19/2017
     '''
 
     for cacheIndex, info in enumerate(cacheInfo):
@@ -899,10 +851,6 @@ def _cache_aggregated_climatology(startYearClimo, endYearClimo, cachePrefix,
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/19/2017
     '''
 
     yearString, fileSuffix = _get_year_string(startYearClimo, endYearClimo)

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -156,7 +156,7 @@ def get_mpas_climatology_file_names(config, fieldName, monthNames,
     """
     Given config options, the name of a field and a string identifying the
     months in a seasonal climatology, returns the full path for MPAS
-    climatology files before and after regridding.
+    climatology files before and after remapping.
 
     Parameters
     ----------
@@ -180,15 +180,15 @@ def get_mpas_climatology_file_names(config, fieldName, monthNames,
     -------
     climatologyFileName : str
         The absolute path to a file where the climatology should be stored
-        before regridding.
+        before remapping.
 
     climatologyPrefix : str
         The prfix including absolute path for climatology cache files before
-        regridding.
+        remapping.
 
-    regriddedFileName : str
+    remappedFileName : str
         The absolute path to a file where the climatology should be stored
-        after regridding if ``comparisonGridName`` is supplied
+        after remapping if ``comparisonGridName`` is supplied
 
     Authors
     -------
@@ -217,17 +217,17 @@ def get_mpas_climatology_file_names(config, fieldName, monthNames,
     if comparisonGridName is None:
         return (climatologyFileName, climatologyPrefix)
     else:
-        regriddedDirectory = build_config_full_path(
-            config, 'output', 'mpasRegriddedClimSubdirectory')
+        remappedDirectory = build_config_full_path(
+            config, 'output', 'mpasRemappedClimSubdirectory')
 
-        make_directories(regriddedDirectory)
+        make_directories(remappedDirectory)
 
-        regriddedFileName = '{}/{}_{}_to_{}_{}_{}.nc'.format(
-                regriddedDirectory, fieldName, mpasMeshName,
+        remappedFileName = '{}/{}_{}_to_{}_{}_{}.nc'.format(
+                remappedDirectory, fieldName, mpasMeshName,
                 comparisonGridName, monthNames, fileSuffix)
 
         return (climatologyFileName, climatologyPrefix,
-                regriddedFileName)
+                remappedFileName)
 
     # }}}
 
@@ -237,7 +237,7 @@ def get_observation_climatology_file_names(config, fieldName, monthNames,
     """
     Given config options, the name of a field and a string identifying the
     months in a seasonal climatology, returns the full path for observation
-    climatology files before and after regridding.
+    climatology files before and after remapping.
 
     Parameters
     ----------
@@ -259,11 +259,11 @@ def get_observation_climatology_file_names(config, fieldName, monthNames,
     -------
     climatologyFileName : str
         The absolute path to a file where the climatology should be stored
-        before regridding.
+        before remapping.
 
-    regriddedFileName : str
+    remappedFileName : str
         The absolute path to a file where the climatology should be stored
-        after regridding.
+        after remapping.
 
     Authors
     -------
@@ -281,9 +281,9 @@ def get_observation_climatology_file_names(config, fieldName, monthNames,
         relativePathOption='climatologySubdirectory',
         relativePathSection=obsSection)
 
-    regriddedDirectory = build_config_full_path(
+    remappedDirectory = build_config_full_path(
         config=config, section='output',
-        relativePathOption='regriddedClimSubdirectory',
+        relativePathOption='remappedClimSubdirectory',
         relativePathSection=obsSection)
 
     obsGridName = remapper.sourceDescriptor.meshName
@@ -291,17 +291,17 @@ def get_observation_climatology_file_names(config, fieldName, monthNames,
 
     climatologyFileName = '{}/{}_{}_{}.nc'.format(
         climatologyDirectory, fieldName, obsGridName, monthNames)
-    regriddedFileName = '{}/{}_{}_to_{}_{}.nc'.format(
-        regriddedDirectory, fieldName, obsGridName, comparisonGridName,
+    remappedFileName = '{}/{}_{}_to_{}_{}.nc'.format(
+        remappedDirectory, fieldName, obsGridName, comparisonGridName,
         monthNames)
 
     make_directories(climatologyDirectory)
 
     if not _matches_comparison(remapper.sourceDescriptor,
                                remapper.destinationDescriptor):
-        make_directories(regriddedDirectory)
+        make_directories(remappedDirectory)
 
-    return (climatologyFileName, regriddedFileName)  # }}}
+    return (climatologyFileName, remappedFileName)  # }}}
 
 
 def compute_monthly_climatology(ds, calendar=None, maskVaries=True):  # {{{
@@ -625,17 +625,17 @@ def add_years_months_days_in_month(ds, calendar=None):  # {{{
 
 
 def remap_and_write_climatology(config, climatologyDataSet,
-                                climatologyFileName, regriddedFileName,
+                                climatologyFileName, remappedFileName,
                                 remapper):  # {{{
     """
     Given a field in a climatology data set, use the ``remapper`` to regrid
     horizontal dimensions of all fields, write the results to an output file,
-    and return the regridded data set.
+    and return the remapped data set.
 
-    Note that ``climatologyFileName`` and ``regriddedFileName`` will be
+    Note that ``climatologyFileName`` and ``remappedFileName`` will be
     overwritten if they exist, so if this behavior is not desired, the calling
     code should skip this call if the files exist and simply load the contents
-    of ``regriddedFileName``.
+    of ``remappedFileName``.
 
     Parameters
     ----------
@@ -650,10 +650,10 @@ def remap_and_write_climatology(config, climatologyDataSet,
 
     climatologyFileName : str
         The name of the output file to which the data set should be written
-        before regridding (if using ncremap).
+        before remapping (if using ncremap).
 
-    regriddedFileName : str
-        The name of the output file to which the regridded data set should
+    remappedFileName : str
+        The name of the output file to which the remapped data set should
         be written.
 
     remapper : ``Remapper`` object
@@ -683,16 +683,16 @@ def remap_and_write_climatology(config, climatologyDataSet,
             if not os.path.exists(climatologyFileName):
                 write_netcdf(climatologyDataSet, climatologyFileName)
             remapper.remap_file(inFileName=climatologyFileName,
-                                outFileName=regriddedFileName,
+                                outFileName=remappedFileName,
                                 overwrite=True)
-            remappedClimatology = xr.open_dataset(regriddedFileName)
+            remappedClimatology = xr.open_dataset(remappedFileName)
         else:
             renormalizationThreshold = config.getfloat(
                 'climatology', 'renormalizationThreshold')
 
             remappedClimatology = remapper.remap(climatologyDataSet,
                                                  renormalizationThreshold)
-            write_netcdf(remappedClimatology, regriddedFileName)
+            write_netcdf(remappedClimatology, remappedFileName)
     return remappedClimatology  # }}}
 
 

--- a/mpas_analysis/shared/grid/grid.py
+++ b/mpas_analysis/shared/grid/grid.py
@@ -14,10 +14,6 @@ ProjectionGridDescriptor - describes a logically rectangular grid on a pyproj
 Author
 ------
 Xylar Asay-Davis
-
-Last Modified
--------------
-04/16/2017
 '''
 
 import netCDF4
@@ -34,10 +30,6 @@ class MeshDescriptor(object):  # {{{
     Author
     ------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/13/2017
     '''
 
     def __init__(self):  # {{{
@@ -49,10 +41,6 @@ class MeshDescriptor(object):  # {{{
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/13/2017
         '''
 
         self.meshName = None  # }}}
@@ -70,10 +58,6 @@ class MeshDescriptor(object):  # {{{
         Authors
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        03/17/2017
         '''
 
         return  # }}}
@@ -88,10 +72,6 @@ class MpasMeshDescriptor(MeshDescriptor):  # {{{
     Author
     ------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/16/2017
     '''
 
     def __init__(self, fileName, meshName=None):  # {{{
@@ -112,10 +92,6 @@ class MpasMeshDescriptor(MeshDescriptor):  # {{{
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/16/2017
         '''
 
         ds = xarray.open_dataset(fileName)
@@ -153,10 +129,6 @@ class MpasMeshDescriptor(MeshDescriptor):  # {{{
         Authors
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/16/2017
         '''
         self.scripFileName = scripFileName
 
@@ -222,10 +194,6 @@ class LatLonGridDescriptor(MeshDescriptor):  # {{{
     Author
     ------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/16/2017
     '''
     def __init__(self):  # {{{
         '''
@@ -239,10 +207,6 @@ class LatLonGridDescriptor(MeshDescriptor):  # {{{
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/05/2017
         '''
         self.regional = False
         self.meshName = None  # }}}
@@ -262,10 +226,6 @@ class LatLonGridDescriptor(MeshDescriptor):  # {{{
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        03/17/2017
         '''
         ds = xarray.open_dataset(fileName)
 
@@ -309,10 +269,6 @@ class LatLonGridDescriptor(MeshDescriptor):  # {{{
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        03/17/2017
         '''
 
         self.latCorner = latCorner
@@ -335,10 +291,6 @@ class LatLonGridDescriptor(MeshDescriptor):  # {{{
         Authors
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/16/2017
         '''
         self.scripFileName = scripFileName
 
@@ -407,10 +359,6 @@ class ProjectionGridDescriptor(MeshDescriptor):  # {{{
     Author
     ------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/16/2017
     '''
 
     def __init__(self, projection):  # {{{
@@ -426,10 +374,6 @@ class ProjectionGridDescriptor(MeshDescriptor):  # {{{
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/05/2017
         '''
         self.projection = projection
         self.latLonProjection = pyproj.Proj(proj='latlong', datum='WGS84')
@@ -457,10 +401,6 @@ class ProjectionGridDescriptor(MeshDescriptor):  # {{{
         Authors
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/16/2017
         '''
 
         ds = xarray.open_dataset(fileName)
@@ -508,10 +448,6 @@ class ProjectionGridDescriptor(MeshDescriptor):  # {{{
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        03/20/2017
         '''
 
         self.meshName = meshName
@@ -538,10 +474,6 @@ class ProjectionGridDescriptor(MeshDescriptor):  # {{{
         Authors
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/16/2017
         '''
         self.scripFileName = scripFileName
 
@@ -594,10 +526,6 @@ class ProjectionGridDescriptor(MeshDescriptor):  # {{{
         Authors
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        03/20/2017
         '''
 
         Lon, Lat = pyproj.transform(self.projection, self.latLonProjection,
@@ -659,10 +587,6 @@ def _create_scrip(outFile, grid_size, grid_corners, grid_rank, units,
     Authors
     ------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/16/2017
     '''
     # Write to output file
     # Dimensions

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -456,7 +456,7 @@ class Remapper(object):
 
     def _remap_data_array(self, dataArray, renormalizationThreshold):  # {{{
         '''
-        Regrids a single xarray data array
+        Remap a single xarray data array
 
         Author
         ------
@@ -531,7 +531,7 @@ class Remapper(object):
     def _remap_numpy_array(self, inField, remapAxes,
                            renormalizationThreshold):  # {{{
         '''
-        Regrids a single numpy array
+        Remap a single numpy array
 
         Author
         ------

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -176,7 +176,11 @@ class Remapper(object):
         # subprocess
         sys.stdout.flush()
         sys.stderr.flush()
-        subprocess.check_call(args)
+
+        # throw out the standard output from ESMF_RegridWeightGen, as it's
+        # rather verbose but keep stderr
+        DEVNULL = open(os.devnull, 'wb')
+        subprocess.check_call(args, stdout=DEVNULL)
 
         # remove the temporary SCRIP files
         os.remove(self.sourceDescriptor.scripFileName)

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -256,6 +256,7 @@ class Remapper(object):
         args = ['ncremap',
                 '-i', inFileName,
                 '-m', self.mappingFileName,
+                '--vrb=1',
                 '-o', outFileName]
 
         if isinstance(self.sourceDescriptor, LatLonGridDescriptor):

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -11,10 +11,6 @@ remap - perform horizontal interpolation on a data sets, given a mapping file
 Author
 ------
 Xylar Asay-Davis
-
-Last Modified
--------------
-04/13/2017
 '''
 
 import subprocess
@@ -38,10 +34,6 @@ class Remapper(object):
     Author
     ------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/13/2017
     '''
 
     def __init__(self, sourceDescriptor, destinationDescriptor,
@@ -75,10 +67,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/13/2017
         '''
 
         if not isinstance(sourceDescriptor,
@@ -128,10 +116,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/13/2017
         '''
 
         if self.mappingFileName is None or \
@@ -228,10 +212,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/13/2017
         '''
 
         if self.mappingFileName is None:
@@ -333,10 +313,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/13/2017
         '''
 
         if self.mappingFileName is None:
@@ -386,10 +362,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/06/2017
         '''
 
         if self.mappingLoaded:
@@ -461,10 +433,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/05/2017
         '''
 
         sourceDims = self.sourceDescriptor.dims
@@ -536,10 +504,6 @@ class Remapper(object):
         Author
         ------
         Xylar Asay-Davis
-
-        Last Modified
-        -------------
-        04/05/2017
         '''
 
         # permute the dimensions of inField so the axes to remap are first,

--- a/mpas_analysis/shared/io/__init__.py
+++ b/mpas_analysis/shared/io/__init__.py
@@ -1,2 +1,3 @@
 from .namelist_streams_interface import NameList, StreamsFile
 from .utility import paths
+from .write_netcdf import write_netcdf

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -2,8 +2,6 @@
 IO utility functions
 
 Phillip J. Wolfram, Xylar Asay-Davis
-
-Last Modified: 03/23/2017
 """
 
 import glob
@@ -18,7 +16,6 @@ def paths(*args): # {{{
     Note, each expanded set of paths is sorted.
 
     Phillip J. Wolfram
-    10/25/2016
     """
     paths = []
     for aargs in args:
@@ -29,13 +26,12 @@ def paths(*args): # {{{
 def fingerprint_generator(size=12,
                           chars=string.ascii_uppercase + string.digits): # {{{
     """
-    Returns a random string that can be used as a unique fingerprint 
+    Returns a random string that can be used as a unique fingerprint
 
     Reference:
     http://stackoverflow.com/questions/2257441/random-string-generation-with-upper-case-letters-and-digits-in-python
-    
+
     Phillip J. Wolfram
-    04/27/2017
     """
     return ''.join(random.choice(chars) for _ in range(size)) # }}}
 
@@ -47,7 +43,6 @@ def make_directories(path):  # {{{
     Returns the path unchanged.
 
     Author: Xylar Asay-Davis
-    Last Modified: 02/02/2017
     """
 
     try:
@@ -85,10 +80,6 @@ def build_config_full_path(config, section, relativePathOption,
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    03/23/2017
     """
     if relativePathSection is None:
         relativePathSection = section

--- a/mpas_analysis/shared/io/write_netcdf.py
+++ b/mpas_analysis/shared/io/write_netcdf.py
@@ -1,0 +1,54 @@
+'''
+Functions for writing data sets
+
+Functions
+---------
+write_netcdf - write an xarray data set to a NetCDF file using finite fill
+    values
+
+Author
+------
+Xylar Asay-Davis
+
+'''
+
+import netCDF4
+import numpy
+
+
+def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals):  # {{{
+    '''
+    Write an xarray data set to a NetCDF file using finite fill values
+
+    Parameters
+    ----------
+    ds : xarray.Dataset object
+        The xarray data set to be written to a file
+
+    fileName : str
+        The fileName to write the data set to
+
+    fillValues : dict
+        A dictionary of fill values for each supported data type.  By default,
+        this is the dictionary used by the netCDF4 package.  Key entries should
+        be of the form 'f8' (for float64), 'i4' (for int32), etc.
+
+    Author
+    ------
+    Xylar Asay-Davis
+
+    '''
+    encodingDict = {}
+    for variableName in ds:
+        dtype = ds[variableName].dtype
+        for fillType in fillValues:
+            if dtype == numpy.dtype(fillType):
+                encodingDict[variableName] = \
+                    {'_FillValue': fillValues[fillType]}
+                break
+
+    ds.to_netcdf(fileName, encoding=encodingDict)
+
+    # }}}
+
+# vim: ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -8,10 +8,6 @@ Plotting utilities, including routines for plotting:
 Authors
 -------
 Xylar Asay-Davis, Milena Veneziani, Luke Van Roekel
-
-Last Modified
--------------
-04/07/2017
 """
 
 import matplotlib.pyplot as plt
@@ -78,10 +74,6 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
     Authors
     -------
     Xylar Asay-Davis, Milena Veneziani
-
-    Last Modified
-    -------------
-    03/14/2017
     """
     plt.figure(figsize=figsize, dpi=dpi)
 
@@ -170,10 +162,6 @@ def timeseries_analysis_plot_polar(config, dsvalues, N, title,
     Authors
     -------
     Adrian K. Turner
-
-    Last Modified
-    -------------
-    03/15/2017
     """
     plt.figure(figsize=figsize, dpi=dpi)
 
@@ -315,10 +303,6 @@ def plot_polar_comparison(
     Authors
     -------
     Xylar Asay-Davis, Milena Veneziani
-
-    Last Modified
-    -------------
-    03/17/2017
     """
 
     # set up figure
@@ -466,10 +450,6 @@ def plot_global_comparison(
     Authors
     -------
     Xylar Asay-Davis, Milena Veneziani
-
-    Last Modified
-    -------------
-    04/20/2017
     """
 
     # set up figure
@@ -608,10 +588,6 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
     Authors
     -------
     Mark Petersen, Milena Veneziani
-
-    Last Modified
-    -------------
-    04/20/2017
     """
 
     # set up figure
@@ -747,10 +723,6 @@ def plot_vertical_section(
     Authors
     -------
     Milena Veneziani, Mark Petersen
-
-    Last Modified
-    -------------
-    03/13/2017
     """
 
     # set up figure
@@ -825,10 +797,6 @@ def setup_colormap(config, configSectionName, suffix=''):
     Authors
     -------
     Xylar Asay-Davis, Milena Veneziani
-
-    Last modified
-    -------------
-    03/17/2017
     '''
 
     colormap = plt.get_cmap(config.get(configSectionName,
@@ -869,10 +837,6 @@ def plot_size_y_axis(plt, xaxisValues, **data):
     Author
     ------
     Luke Van Roekel
-
-    Last modified
-    -------------
-    04/07/2017
     '''
 
     ax = plt.gca()
@@ -910,7 +874,6 @@ def plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks):
     Author
     ------
     Xylar Asay-Davis
-
     '''
     ax = plt.gca()
 

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -1,7 +1,7 @@
 """
 Plotting utilities, including routines for plotting:
     * time series (and comparing with reference data sets)
-    * regridded horizontal fields (and comparing with reference data sets)
+    * remapped horizontal fields (and comparing with reference data sets)
     * vertical sections on native grid
     * NINO34 time series and spectra
 

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -4,10 +4,6 @@ Utility functions related to time-series data sets
 Authors
 -------
 Xylar Asay-Davis
-
-Last Modified
--------------
-04/08/2017
 """
 
 import xarray as xr
@@ -70,11 +66,6 @@ def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
     Authors
     -------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    04/08/2017
-
     '''
 
     timesProcessed = numpy.zeros(len(timesInDataSet), bool)

--- a/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
+++ b/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
@@ -16,10 +16,6 @@ class MpasRelativeDelta(relativedelta):
     Author
     ------
     Xylar Asay-Davis
-
-    Last Modified
-    -------------
-    02/09/2017
     """
 
     def __init__(self, dt1=None, dt2=None, years=0, months=0, days=0,

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -4,10 +4,6 @@ Time keeping utility functions
 Author
 ------
 Xylar Asay-Davis
-
-Last Modified
--------------
-02/11/2017
 """
 
 import datetime
@@ -41,10 +37,6 @@ def get_simulation_start_time(streams):
     Author
     ------
     Xylar Asay-Davis
-
-    Last modified
-    -------------
-    02/11/2017
     """
 
     try:
@@ -99,10 +91,6 @@ def string_to_datetime(dateString):  # {{{
     Author
     ------
     Xylar Asay-Davis
-
-    Last modified
-    -------------
-    02/04/2017
     """
 
     (year, month, day, hour, minute, second) = \
@@ -151,10 +139,6 @@ def string_to_relative_delta(dateString, calendar='gregorian'):  # {{{
     Author
     ------
     Xylar Asay-Davis
-
-    Last modified
-    -------------
-    02/04/2017
     """
 
     (years, months, days, hours, minutes, seconds) = \
@@ -214,10 +198,6 @@ def string_to_days_since_date(dateString, calendar='gregorian',
     Author
     ------
     Xylar Asay-Davis
-
-    Last modified
-    -------------
-    02/04/2017
     """
 
     isSingleString = isinstance(dateString, str)
@@ -267,10 +247,6 @@ def days_to_datetime(days, calendar='gregorian', referenceDate='0001-01-01'):
     Author
     ------
     Xylar Asay-Davis
-
-    Last modified
-    -------------
-    02/04/2017
     """
 
     datetimes = netCDF4.num2date(days,
@@ -324,10 +300,6 @@ def datetime_to_days(dates, calendar='gregorian', referenceDate='0001-01-01'):
     Author
     ------
     Xylar Asay-Davis
-
-    Last modified
-    -------------
-    02/11/2017
     """
 
     isSingleDate = False
@@ -377,10 +349,6 @@ def date_to_days(year=1, month=1, day=1, hour=0, minute=0, second=0,
     Author
     ------
     Xylar Asay-Davis
-
-    Last modified
-    -------------
-    02/11/2017
     """
 
     calendar = _mpas_to_netcdf_calendar(calendar)
@@ -432,10 +400,6 @@ def _parse_date_string(dateString, isInterval=False):  # {{{
     Author
     ------
     Xylar Asay-Davis
-
-    Last modified
-    -------------
-    02/04/2017
     """
     if isInterval:
         offset = 0

--- a/mpas_analysis/shared/variable_namelist_stream_maps/ocean_maps.py
+++ b/mpas_analysis/shared/variable_namelist_stream_maps/ocean_maps.py
@@ -5,10 +5,6 @@ MPAS-O versions to those used by mpas_analysis
 Authors
 -------
 Xylar Asay-Davis
-
-Last Modified
--------------
-03/29/2017
 '''
 
 oceanNamelistMap = {

--- a/mpas_analysis/test/test_analysis_task.py
+++ b/mpas_analysis/test/test_analysis_task.py
@@ -31,13 +31,13 @@ class TestAnalysisTask(TestCase):
         # Comments from config.template about how generate works:
         #
         # a list of analyses to generate.  Valid names are:
-        #   'timeSeriesOHC', 'timeSeriesSST', 'regriddedSST',
-        #   'regriddedSSS', 'regriddedMLD', 'timeSeriesSeaIceAreaVol',
-        #   'regriddedSeaIceConcThick'
+        #   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
+        #   'climatologyMapSSS', 'climatologyMapMLD', 'timeSeriesSeaIceAreaVol',
+        #   'climatologyMapSeaIceConcThick'
         # the following shortcuts exist:
         #   'all' -- all analyses will be run
         #   'all_timeSeries' -- all time-series analyses will be run
-        #   'all_regriddedHorizontal' -- all analyses involving regridded
+        #   'all_horizontalMap' -- all analyses involving remapped
         #                                horizontal fields will be run
         #   'all_ocean' -- all ocean analyses will be run
         #   'all_seaIce' -- all sea-ice analyses will be run

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -59,8 +59,6 @@ class TestClimatology(TestCase):
         config.set('climatology', 'comparisonLatResolution', '0.5')
         config.set('climatology', 'comparisonLonResolution', '0.5')
 
-        config.set('climatology', 'overwriteMapping', 'False')
-        config.set('climatology', 'overwriteMpasClimatology', 'False')
         config.set('climatology', 'mpasInterpolationMethod', 'bilinear')
 
         config.add_section('oceanObservations')

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -50,8 +50,8 @@ class TestClimatology(TestCase):
         config.set('output', 'baseDirectory', self.test_dir)
         config.set('output', 'mappingSubdirectory', '.')
         config.set('output', 'mpasClimatologySubdirectory', 'clim/mpas')
-        config.set('output', 'mpasRegriddedClimSubdirectory',
-                   'clim/mpas/regrid')
+        config.set('output', 'mpasRemappedClimSubdirectory',
+                   'clim/mpas/remap')
 
         config.add_section('climatology')
         config.set('climatology', 'startYear', '2')
@@ -66,8 +66,8 @@ class TestClimatology(TestCase):
         config.add_section('oceanObservations')
         config.set('oceanObservations', 'interpolationMethod', 'bilinear')
         config.set('oceanObservations', 'climatologySubdirectory', 'clim/obs')
-        config.set('oceanObservations', 'regriddedClimSubdirectory',
-                   'clim/obs/regrid')
+        config.set('oceanObservations', 'remappedClimSubdirectory',
+                   'clim/obs/remap')
 
         return config
 
@@ -191,7 +191,7 @@ class TestClimatology(TestCase):
 
         remapper = self.setup_mpas_remapper(config)
 
-        (climatologyFileName, climatologyPrefix, regriddedFileName) = \
+        (climatologyFileName, climatologyPrefix, remappedFileName) = \
             get_mpas_climatology_file_names(
                 config, fieldName, monthNames,
                 remapper.sourceDescriptor.meshName,
@@ -204,10 +204,10 @@ class TestClimatology(TestCase):
                                     'JFM'.format(self.test_dir)
         self.assertEqual(climatologyPrefix, expectedClimatologyPrefix)
 
-        expectedRegriddedFileName = '{}/clim/mpas/regrid/sst_QU240_to_' \
+        expectedRemappedFileName = '{}/clim/mpas/remap/sst_QU240_to_' \
                                     '0.5x0.5degree_JFM_' \
                                     'year0002.nc'.format(self.test_dir)
-        self.assertEqual(regriddedFileName, expectedRegriddedFileName)
+        self.assertEqual(remappedFileName, expectedRemappedFileName)
 
     def test_get_observation_climatology_file_names(self):
         config = self.setup_config()
@@ -217,17 +217,17 @@ class TestClimatology(TestCase):
 
         remapper = self.setup_obs_remapper(config, fieldName)
 
-        (climatologyFileName, regriddedFileName) = \
+        (climatologyFileName, remappedFileName) = \
             get_observation_climatology_file_names(
                 config, fieldName, monthNames, componentName, remapper)
         expectedClimatologyFileName = '{}/clim/obs/sst_1.0x1.0degree_' \
                                       'JFM.nc'.format(self.test_dir)
         self.assertEqual(climatologyFileName, expectedClimatologyFileName)
 
-        expectedRegriddedFileName = '{}/clim/obs/regrid/sst_1.0x1.0degree_' \
+        expectedRemappedFileName = '{}/clim/obs/remap/sst_1.0x1.0degree_' \
                                     'to_0.5x0.5degree_' \
                                     'JFM.nc'.format(self.test_dir)
-        self.assertEqual(regriddedFileName, expectedRegriddedFileName)
+        self.assertEqual(remappedFileName, expectedRemappedFileName)
 
     def test_compute_climatology(self):
         config = self.setup_config()

--- a/mpas_analysis/test/test_timekeeping.py
+++ b/mpas_analysis/test/test_timekeeping.py
@@ -4,10 +4,6 @@ Unit test infrastructure for the Date class
 Author
 ------
 Xylar Asay-Davis
-
-Last Modified
--------------
-02/17/2017
 """
 
 import pytest

--- a/run_analysis.py
+++ b/run_analysis.py
@@ -30,7 +30,6 @@ def update_generate(config, generate):  # {{{
     Update the 'generate' config option using a string from the command line.
 
     Author: Xylar Asay-Davis
-    Last Modified: 03/07/2017
     """
 
     # overwrite the 'generate' in config with a string that parses to
@@ -85,7 +84,6 @@ def launch_tasks(taskNames, config, configFiles):  # {{{
     Launch one or more tasks
 
     Author: Xylar Asay-Davis
-    Last Modified: 03/08/2017
     """
     thisFile = os.path.realpath(__file__)
 
@@ -123,7 +121,6 @@ def wait_for_task(processes):  # {{{
     task name and the process that finished.
 
     Author: Xylar Asay-Davis
-    Last Modified: 03/08/2017
     """
 
     # first, check if any process has already finished
@@ -145,7 +142,6 @@ def is_running(process):  # {{{
     Returns whether a given process is currently running
 
     Author: Xylar Asay-Davis
-    Last Modified: 03/08/2017
     """
 
     try:
@@ -161,7 +157,6 @@ def build_analysis_list(config):  # {{{
     Build a list of analysis modules based on the 'generate' config option.
 
     Author: Xylar Asay-Davis
-    Last Modified: 03/07/2017
     """
 
     # choose the right rendering backend, depending on whether we're displaying


### PR DESCRIPTION
This merge performs various types of cleanup to the repo.

It sets the level of output from `ncremap` to a near minimal level.  It suppresses all non-error output from `ESMF_RegridWeightGen`.  

A new function, `shared.io.write_netcdf`, is introduced for writing `xarray` data sets with finite `_FillValue`, taken by default from the `netCDF4` package.  This change makes various NCO calls happier and suppresses warnings about non-finite `_FillValue`.

With these changes, calls to `ncremap` produce output like:
```
Input #00: /media/xylar/extra_data/analysis/output/GMPAS-QU240/simplify_ncremap_output/clim/mpas/mld_oQU240_JAS_years0002-0005.nc
Map/Wgt  : /media/xylar/extra_data/analysis/output/GMPAS-QU240/simplify_ncremap_output/mapping/map_climatologyMapMLD_oQU240_to_0.5x0.5degree_bilinear.nc
Regridded: /media/xylar/extra_data/analysis/output/GMPAS-QU240/simplify_ncremap_output/clim/mpas/regridded/mld_oQU240_to_0.5x0.5degree_JAS_years0002-0005.nc
```

In the config file, the `overwrite*` options have been removed and the behavior is now that climatologies and cached time series are not overwritten.

Variables and config options named "regrid*" have been renamed "remap*" for consistent naming throughout the repo.

"Last Modified" entries in docstring have been removed.  These are hard to maintain consistently and the information about when a file or function was last modified is typically available through the "blame" view on GitHub.

Removes config paths to individual mapping files. Instead, the config file supplies an option for a directory with existing mapping files, requiring that all mapping files follow the MPAS-Analysis naming
conventions.  If no mapping directory is supplied or mapping files are not found in the supplied directory, they are created in the mappingSubdirectory of the output directory.