### PR TITLE
Fix confusing None return from getExpression

### DIFF
--- a/mpas_analysis/configuration/MpasAnalysisConfigParser.py
+++ b/mpas_analysis/configuration/MpasAnalysisConfigParser.py
@@ -5,7 +5,6 @@ the capabilities to get an option including a default value
 that are lists, tuples, dicts, etc (`getExpression(section, option)`).
 
 Author: Xylar Asay-Davis, Phillip J. Wolfram
-Last Modified: 02/27/2017
 """
 
 import numbers
@@ -29,7 +28,6 @@ class MpasAnalysisConfigParser(ConfigParser):
         is present in the config file.
 
         Author: Xylar Asay-Davis
-        Last Modified: 02/27/2017
         """
         if self.has_section(section):
             if self.has_option(section, option):
@@ -66,29 +64,24 @@ class MpasAnalysisConfigParser(ConfigParser):
         of having selected numpy and / or np functionality available.
 
         Author: Xylar Asay-Davis, Phillip J. Wolfram
-        Last Modified: 04/10/2017
         """
-        if self.has_section(section):
-            if self.has_option(section, option):
-                expressionString = self.get(section, option)
-                if usenumpyfunc:
-                    assert '__' not in expressionString, \
-                            "'__' is not allowed in {} "\
-                            "for `usenumpyfunc=True`".format(expressionString)
-                    sanitizedstr = expressionString.replace('np.', '')\
-                                                   .replace('numpy.', '')\
-                                                   .replace('__', '')
-                    result = eval(sanitizedstr, npallow)
-                else:
-                    result = ast.literal_eval(expressionString)
-
-                if elementType is not None:
-                    if isinstance(result, (list, tuple)):
-                        result = [elementType(element) for element in result]
-                    elif isinstance(result, dict):
-                        for key in result:
-                            result[key] = elementType(result[key])
-
-                return result
+        expressionString = self.get(section, option)
+        if usenumpyfunc:
+            assert '__' not in expressionString, \
+                    "'__' is not allowed in {} "\
+                    "for `usenumpyfunc=True`".format(expressionString)
+            sanitizedstr = expressionString.replace('np.', '')\
+                                           .replace('numpy.', '')\
+                                           .replace('__', '')
+            result = eval(sanitizedstr, npallow)
         else:
-            return None
+            result = ast.literal_eval(expressionString)
+
+        if elementType is not None:
+            if isinstance(result, (list, tuple)):
+                result = [elementType(element) for element in result]
+            elif isinstance(result, dict):
+                for key in result:
+                    result[key] = elementType(result[key])
+
+        return result

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -263,7 +263,11 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
 
         make_directories(outputDirectory)
 
-        chunking = config.getExpression(self.sectionName, 'maxChunkSize')
+        if config.has_option(self.sectionName, 'maxChunkSize'):
+            chunking = config.getExpression(self.sectionName, 'maxChunkSize')
+        else:
+            chunking = None
+
         ds = open_multifile_dataset(
             fileNames=self.inputFilesClimo,
             calendar=self.calendar,
@@ -474,7 +478,11 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
         dvEdge, areaCell, refBottomDepth, latCell, nVertLevels, \
             refTopDepth, refLayerThickness = self._load_mesh()
 
-        chunking = config.getExpression(self.sectionName, 'maxChunkSize')
+        if config.has_option(self.sectionName, 'maxChunkSize'):
+            chunking = config.getExpression(self.sectionName, 'maxChunkSize')
+        else:
+            chunking = None
+
         ds = open_multifile_dataset(
             fileNames=self.inputFilesTseries,
             calendar=self.calendar,

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -6,6 +6,7 @@ Xylar Asay-Davis, Phillip J. Wolfram
 """
 
 import pytest
+import ConfigParser
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.configuration.MpasAnalysisConfigParser \
     import MpasAnalysisConfigParser
@@ -73,8 +74,10 @@ class TestMPASAnalysisConfigParser(TestCase):
                                     'key2': -12,
                                     'key3': False})
 
-        testNone = self.config.getExpression('Test', 'doesntexist')
-        assert testNone is None
+        with self.assertRaisesRegexp(
+                ConfigParser.NoOptionError,
+                "No option 'doesntexist' in section: 'Test'"):
+            self.config.getExpression('Test', 'doesntexist')
 
     @requires_numpy
     def test_read_config_numpy(self):


### PR DESCRIPTION
The `getExpression` method from the `MpasAnalysisConfigParser` was
returning `None` when the config option was not present.  This was
confusing when the option was not intentionally left out, leading
to non-intuitive error messages.  Now, `getExpression` will raise
a `NoOptionError` (as do all `get*` methods) when the option is missing.

To accommodate the special needs of chunking, the `chunking` option
of the generalize reader has been set to `None` if no chunking is
specified in the config file.

CI tests have been updated accordingly.