### PR TITLE
Renormalize climatologies also when using ncremap

### DIFF
--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -644,16 +644,17 @@ def remap_and_write_climatology(config, climatologyDataSet,
         # no remapping is needed
         remappedClimatology = climatologyDataSet
     else:
+        renormalizationThreshold = config.getfloat(
+            'climatology', 'renormalizationThreshold')
         if useNcremap:
             if not os.path.exists(climatologyFileName):
                 write_netcdf(climatologyDataSet, climatologyFileName)
             remapper.remap_file(inFileName=climatologyFileName,
                                 outFileName=remappedFileName,
-                                overwrite=True)
+                                overwrite=True,
+                                renormalize=renormalizationThreshold)
             remappedClimatology = xr.open_dataset(remappedFileName)
         else:
-            renormalizationThreshold = config.getfloat(
-                'climatology', 'renormalizationThreshold')
 
             remappedClimatology = remapper.remap(climatologyDataSet,
                                                  renormalizationThreshold)


### PR DESCRIPTION
With the change to `write_netcdf`, `ncremap` now extrapolates with
bilinear remapping but does not normalize by default.  This leads
to values closer to zero than expected in extrapolated regions.
When we do not use `ncremap`, we renormalize these values based on
only the weights of unmasked source grid cells.  With this merge,
we do the same when using `ncremap`.