### PR TITLE
Add antarctic melt time series

### DIFF
--- a/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+++ b/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
@@ -59,9 +59,9 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not
-# include ice-shelf cavities.`
-generate = ['all', 'no_climatologyMapAntarcticMelt']
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_landIceCavities']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -164,6 +164,14 @@ depths = ['top', -200, -400, -600, -800, 'bot']
 # plot on polar plot
 polarPlot = False
 
+[timeSeriesAntarcticMelt]
+## options related to plotting time series of melt below Antarctic ice shelves
+
+# list of ice shelves to plot or ['all'] for all 106 ice shelves and regions.
+# See "regionNames" in the ice shelf masks file in regionMaskDirectory for
+# details.
+iceShelvesToPlot = ['Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Filchner', 'Ronne', 'Brunt_Stancomb', 'Fimbul', 'Amery', 'Totten', 'Ross_West', 'Ross_East', 'Getz', 'Thwaites', 'Pine_Island', 'Abbot', 'George_VI']
+
 [regions]
 ## options related to ocean regions used in several analysis modules
 

--- a/configs/edison/config.20170807.beta1.G_oQU240.edison
+++ b/configs/edison/config.20170807.beta1.G_oQU240.edison
@@ -60,9 +60,9 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not
-# include ice-shelf cavities.`
-generate = ['all', 'no_climatologyMapAntarcticMelt']
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_landIceCavities']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/edison/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -75,9 +75,9 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not
-# include ice-shelf cavities.`
-generate = ['all', 'no_climatologyMapAntarcticMelt']
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_landIceCavities']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/edison/config.20171102.beta3rc02_1850.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20171102.beta3rc02_1850.ne30_oECv3_ICG.edison
@@ -61,9 +61,9 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not
-# include ice-shelf cavities.`
-generate = ['all', 'no_climatologyMapAntarcticMelt']
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_landIceCavities']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -168,6 +168,14 @@ depths = ['top', -200, -400, -600, -800, 'bot']
 # plot on polar plot
 polarPlot = False
 
+[timeSeriesAntarcticMelt]
+## options related to plotting time series of melt below Antarctic ice shelves
+
+# list of ice shelves to plot or ['all'] for all 106 ice shelves and regions.
+# See "regionNames" in the ice shelf masks file in regionMaskDirectory for
+# details.
+iceShelvesToPlot = ['Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Filchner', 'Ronne', 'Brunt_Stancomb', 'Fimbul', 'Amery', 'Totten', 'Ross_West', 'Ross_East', 'Getz', 'Thwaites', 'Pine_Island', 'Abbot', 'George_VI']
+
 [regions]
 ## options related to ocean regions used in several analysis modules
 

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -55,9 +55,9 @@ baseDirectory = /dir/to/analysis/output
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not
-# include ice-shelf cavities.`
-generate = ['all', 'no_climatologyMapAntarcticMelt']
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_landIceCavities']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -60,9 +60,9 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not
-# include ice-shelf cavities.`
-generate = ['all', 'no_climatologyMapAntarcticMelt']
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_landIceCavities']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -77,9 +77,9 @@ htmlSubdirectory = html
 #                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
-#    ./run_mpas_analysis config.analysis --generate \
-#         all,no_ocean,all_timeSeries
-generate = ['all', 'no_climatologyMapAntarcticMelt']
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_landIceCavities']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -64,9 +64,9 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not
-# include ice-shelf cavities.`
-generate = ['all', 'no_climatologyMapAntarcticMelt']
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_landIceCavities']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -172,4 +172,4 @@ depths = ['top', -200, -400, -600, -800, 'bot']
 
 [timeSeriesAntarcticMelt]
 # a list of ice shelves to plot
-iceShelvesToPlot = ['Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Larsen_D', 'Ronne', 'Filchner', 'Brunt_Stancomb', 'Fimbul', 'Riiser-Larsen', 'Baudouin', 'Amery', 'West', 'Shackleton', 'Totten', 'Mertz', 'Ross_East', 'Ross_West', 'Getz', 'Dotson', 'Crosson', 'Thwaites', 'Pine_Island', 'Abbot', 'Stange', 'George_VI', 'Wilkins']
+iceShelvesToPlot = ['Antarctica', 'Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Filchner-Ronne', 'Brunt_Stancomb', 'Fimbul', 'Amery', 'Totten', 'Ross', 'Getz', 'Thwaites', 'Pine_Island', 'Abbot', 'George_VI']

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -605,6 +605,17 @@ normArgsDifference = {'linthresh': 1., 'linscale': 0.5, 'vmin': -100.,
 colorbarTicksDifference = [-100., -50., -20., -10., -5., -2., -1., 0., 1., 2.,
                            5., 10., 20., 50., 100.]
 
+[timeSeriesAntarcticMelt]
+## options related to plotting time series of melt below Antarctic ice shelves
+
+# list of ice shelves to plot or ['all'] for all 106 ice shelves and regions.
+# See "regionNames" in the ice shelf masks file in regionMaskDirectory for
+# details.
+iceShelvesToPlot = ['Antarctica']
+
+# Number of months over which to compute moving average
+movingAverageMonths = 1
+
 [climatologyMapSoseTemperature]
 ## options related to plotting climatology maps of Antarctic
 ## potential temperature at various levels, including the sea floor against

--- a/mpas_analysis/ocean/__init__.py
+++ b/mpas_analysis/ocean/__init__.py
@@ -10,3 +10,4 @@ from .time_series_sst import TimeSeriesSST
 from .index_nino34 import IndexNino34
 from .streamfunction_moc import StreamfunctionMOC
 from .meridional_heat_transport import MeridionalHeatTransport
+from .time_series_antarctic_melt import TimeSeriesAntarcticMelt

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -194,16 +194,12 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                            'Rignot_2013_melt_rates.csv',
                            'Rignot et al. (2013) SS':
                            'Rignot_2013_melt_rates_SS.csv'}
-        obsFileNameList = list(obsFileNameDict.values())
-        obsFileNameDesc = list(obsFileNameDict.keys())
 
-        obsDictDict = {}  # dict for storing dict of obs data
-        fileCount = 0     # counter for uniquely identifying obs data set
-        while len(obsFileNameList) > 0:
+        obsDict = {}  # dict for storing dict of obs data
+        for obsName in obsFileNameDict:
             obsFileName = '{}/{}'.format(observationsDirectory,
-                                         obsFileNameList.pop(0))
-            fileCount = fileCount + 1
-            obsDictTemp = {}
+                                         obsFileNameDict[obsName])
+            obsDict[obsName] = {}
             obsFile = csv.reader(open(obsFileName, 'rU'))
             next(obsFile, None)  # skip the header line
             for line in obsFile:  # some later useful values commented out
@@ -217,14 +213,11 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
 
                 # build dict of obs. keyed to filename description
                 # (which will be used for plotting)
-                obsDictTemp[shelfName] = {'meltFlux': meltFlux,
-                                          'meltFluxUncertainty':
-                                              meltFluxUncertainty,
-                                          'meltRate': meltRate,
-                                          'meltRateUncertainty':
-                                              meltRateUncertainty}
-                obsDictDict['{}'.format(
-                        obsFileNameDesc[fileCount-1])] = obsDictTemp
+                obsDict[obsName][shelfName] = {
+                        'meltFlux': meltFlux,
+                        'meltFluxUncertainty': meltFluxUncertainty,
+                        'meltRate': meltRate,
+                        'meltRateUncertainty': meltRateUncertainty}
 
         # If areas from obs file used need to be converted from sq km to sq m
 
@@ -264,7 +257,6 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
 
         make_directories(outputDirectory)
 
-        obsCount = len(obsDictDict)
         self.logger.info('  Make plots...')
         for iRegion in range(nRegions):
 
@@ -275,19 +267,15 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
             obsMeltFluxUnc = []
             obsMeltRate = []
             obsMeltRateUnc = []
-            for iObs in range(obsCount):
-                dictName = '{}'.format(obsFileNameDesc[iObs])
+            for obsName in obsDict:
                 obsMeltFlux.append(
-                        obsDictDict[dictName][regionName]
-                        ['meltFlux'])
+                    obsDict[obsName][regionName]['meltFlux'])
                 obsMeltFluxUnc.append(
-                        obsDictDict[dictName][regionName]
-                        ['meltFluxUncertainty'])
+                    obsDict[obsName][regionName]['meltFluxUncertainty'])
                 obsMeltRate.append(
-                        obsDictDict[dictName][regionName]['meltRate'])
+                    obsDict[obsName][regionName]['meltRate'])
                 obsMeltRateUnc.append(
-                        obsDictDict[dictName][regionName]
-                        ['meltRateUncertainty'])
+                    obsDict[obsName][regionName]['meltRateUncertainty'])
 
             title = regionName.replace('_', ' ')
 
@@ -307,7 +295,7 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                                      legendText=[mainRunName],
                                      calendar=calendar, obsMean=obsMeltFlux,
                                      obsUncertainty=obsMeltFluxUnc,
-                                     obsLegend=obsFileNameDesc)
+                                     obsLegend=list(obsDict.keys()))
 
             caption = 'Running Mean of Total Melt Flux  under Ice ' \
                       'Shelves in the {} Region'.format(title)
@@ -337,7 +325,7 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                                      legendText=[mainRunName],
                                      calendar=calendar, obsMean=obsMeltRate,
                                      obsUncertainty=obsMeltRateUnc,
-                                     obsLegend=obsFileNameDesc)
+                                     obsLegend=list(obsDict.keys()))
 
             caption = 'Running Mean of Area-averaged Melt Rate under Ice ' \
                       'Shelves in the {} Region'.format(title)

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, \
 
 import os
 import xarray
-
+import numpy
 
 from ..shared.analysis_task import AnalysisTask
 
@@ -268,14 +268,23 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
             obsMeltRate = []
             obsMeltRateUnc = []
             for obsName in obsDict:
-                obsMeltFlux.append(
-                    obsDict[obsName][regionName]['meltFlux'])
-                obsMeltFluxUnc.append(
-                    obsDict[obsName][regionName]['meltFluxUncertainty'])
-                obsMeltRate.append(
-                    obsDict[obsName][regionName]['meltRate'])
-                obsMeltRateUnc.append(
-                    obsDict[obsName][regionName]['meltRateUncertainty'])
+                if regionName in obsDict[obsName]:
+                    obsMeltFlux.append(
+                        obsDict[obsName][regionName]['meltFlux'])
+                    obsMeltFluxUnc.append(
+                        obsDict[obsName][regionName]['meltFluxUncertainty'])
+                    obsMeltRate.append(
+                        obsDict[obsName][regionName]['meltRate'])
+                    obsMeltRateUnc.append(
+                        obsDict[obsName][regionName]['meltRateUncertainty'])
+                else:
+                    # append NaN so this particular obs won't plot
+                    self.logger.warning('{} observations not available for '
+                                        '{}'.format(obsName, regionName))
+                    obsMeltFlux.append(None)
+                    obsMeltFluxUnc.append(None)
+                    obsMeltRate.append(None)
+                    obsMeltRateUnc.append(None)
 
             title = regionName.replace('_', ' ')
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -150,21 +150,32 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                                     endDate=self.endDate)
 
 
-        # Load observations:
+        # Load observations and put in dictionary based on shelf keyname
         observationsDirectory = build_config_full_path(config, 'oceanObservations', 'meltSubdirectory')
         obsFileName = '{}/Rignot_2013_melt_rates.csv'.format(observationsDirectory)
         
-        obsFile = csv.reader( open(obsFileName, 'rU') )	
+        obsFile = csv.reader( open(obsFileName, 'rU') )	 
         obsDict = {}
-        for line in obsFile:
-	    shelfName = line[0]         	
-            shelfArea = line[3]		# NOTE: this is in km - needs converting to m!
- 	    meltFlux = line[11]
-            meltRate = line[12]
-            obsDict[shelfName] = { 'meltFlux': meltFlux, 'meltRate': meltRate, 'shelfArea': shelfArea}
+	for line in obsFile:		# some possibly useful values are left commented out for now
+            shelfName = line[0]
+            #surveyArea = line[1]
+            #SSmeltFlux = line[2]
 
-        #print(obsDict)	# SFP for debug
-
+            #SSmeltFluxUncertainty = line[3]
+            #SSmeltRate = line[4]                                                                                 
+            #SSmeltRateUncertainty = line[5]
+            meltFlux = line[6] 
+            meltFluxUncertainty = line[7]
+            meltRate = line[8]
+            meltRateUncertainty = line[9]
+            #actualArea = line[10]
+        #    obsDict[shelfName] = { 'surveyArea': surveyArea, 'SSmeltFlux': SSmeltFlux, 'SSmeltFluxUncertainty': 
+	#	SSmeltFluxUncertainty, 'SSmeltRate': SSmeltRate, 'SSmeltRateUncertainty': SSmeltRateUncertainty,
+	#	'meltFlux': meltFlux, 'meltFluxUncertainty': meltFluxUncertainty, 'meltRate': meltRate, 
+	#	'meltRateUncertainty': meltRateUncertainty, 'actualArea': actualArea }
+            obsDict[shelfName] = { 'meltFlux': meltFlux, 'meltFluxUncertainty': meltFluxUncertainty, 
+		'meltRate': meltRate, 'meltRateUncertainty': meltRateUncertainty }
+	# Note that if areas from obs file are used they need to be converted from sq km to sq m
 
         # work on data from simulations
         freshwaterFlux = ds.timeMonthly_avg_landIceFreshwaterFlux
@@ -185,6 +196,7 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
         if 'all' in iceShelvesToPlot:
             iceShelvesToPlot = regionNames
             regionIndices = [iRegion for iRegion in range(nRegions)]
+
         else:
             regionIndices = []
             for regionName in iceShelvesToPlot:
@@ -219,14 +231,22 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
 
         print '  Make plots...'
         for iRegion in range(nRegions):
+
             regionName = iceShelvesToPlot[iRegion]
+
+            # get obs melt flux and obs melt flux unc. for shelf (similar for rates) 
+            obsMeltFlux = float( obsDict[regionName]['meltFlux'] ) 
+            obsMeltFluxUnc = float( obsDict[regionName]['meltFluxUncertainty'] ) 
+            obsMeltRate = float( obsDict[regionName]['meltRate'] ) 
+            obsMeltRateUnc = float( obsDict[regionName]['meltRateUncertainty'] ) 
 
             title = regionName.replace('_', ' ')
 
             regionName = regionName.replace(' ', '_')
 
             xLabel = 'Time (yr)'
-            yLabel = 'Melt Flux (GT/yr)'
+#            yLabel = 'Melt Flux (GT/yr)'
+            yLabel = 'Melt Flux (GT/yr) (obs={} Gt/yr)'.format(obsMeltFlux)	# SFP - test pulling obs melt flux info into fig
 
             timeSeries = totalMeltFlux.isel(nRegions=iRegion)
 
@@ -239,7 +259,8 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                                      calendar=calendar)
 
             xLabel = 'Time (yr)'
-            yLabel = 'Melt Rate (m/yr)'
+#            yLabel = 'Melt Rate (m/yr)'
+            yLabel = 'Melt Rate (m/yr) (obs={} m/yr)'.format(obsMeltRate)	#SFP - test pulling obs melt rate info into fig
 
             timeSeries = meltRates.isel(nRegions=iRegion)
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -20,14 +20,14 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
 
     Authors
     -------
-    Xylar Asay-Davis
+    Xylar Asay-Davis, Stephen Price
     """
 
     def __init__(self, config):  # {{{
         """
         Construct the analysis task.
 
-        Parameters, Milena Veneziani
+        Parameters
         ----------
         config :  instance of MpasAnalysisConfigParser
             Contains configuration options
@@ -157,7 +157,7 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                                                 'iceShelvesToPlot')
 
         dsRestart = xarray.open_dataset(self.restartFileName)
-        areaCell = dsRestart.areaCell
+        areaCell = dsRestart.landIceFraction.isel(Time=0)*dsRestart.areaCell
 
         dsRegionMask = xarray.open_dataset(self.regionMaskFileName)
         regionNames = list(dsRegionMask.regionNames.values)

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -338,22 +338,33 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
         minDays = modelValues.Time.min()
         maxDays = modelValues.Time.max()
         plt.plot(modelValues.Time.values, modelValues.values, modelLineStyle,
-                 linewidth=modelLineWidth)
+                 linewidth=modelLineWidth, label='model')
 
         ax = plt.gca()
 
         # this makes a "patch" with a single rectangular polygon, where the pairs are time and melt 
         # rate for the 4 corners, and "True" means it is a closed polygon:
-        patches = [Polygon([[minDays, obsMean-obsUncertainty], [maxDays, obsMean-obsUncertainty],
-                        [maxDays, obsMean+obsUncertainty], [minDays, obsMean+obsUncertainty]])]
+#        patches = [Polygon([[minDays, obsMean-obsUncertainty], [maxDays, obsMean-obsUncertainty],
+#                        [maxDays, obsMean+obsUncertainty], [minDays, obsMean+obsUncertainty]])]
 
         # make the polygon gray and mostly transparent
-        p = PatchCollection(patches, color=obsColor, alpha=0.15)
+#        p = PatchCollection(patches, color=obsColor, alpha=0.15)
         # add it to the plot on the current axis
-        ax.add_collection(p)
+#        ax.add_collection(p)
 
         # also plot a line
-        plt.plot([minDays, maxDays], [obsMean, obsMean], color=obsColor, linewidth=obsLineWidth)
+#        plt.plot([minDays, maxDays], [obsMean, obsMean], color=obsColor, linewidth=obsLineWidth)
+
+	# plot error bars rather than the "patch" used above
+	plt.errorbar( (maxDays - minDays)/3+minDays, obsMean, yerr=obsUncertainty, fmt='o', ecolor='k', 
+			capthick=2, label='obs1')
+	plt.errorbar( (maxDays - minDays)/3+minDays+1.0*(maxDays - minDays)/10, obsMean, yerr=obsUncertainty/3.0, 
+			fmt='s', ecolor='g', capthick=2, label='obs2')  # example of a 2nd set of obs error bars
+	plt.errorbar( (maxDays - minDays)/3+minDays+2.0*(maxDays - minDays)/10, obsMean, yerr=obsUncertainty/2.0, 
+			fmt='^', ecolor='r', capthick=2, label='obs3')  # example of a 3rd set of obs error bars
+
+        # add legend
+	plt.legend( loc='lower right' )
 
         # this will need to be imported from shared.plot.plotting
         _plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -4,18 +4,12 @@ from __future__ import absolute_import, division, print_function, \
 import os
 import xarray
 
-# SFP: the following are only needed for the stop-gap local plotting routine
-# used here
-import matplotlib.pyplot as plt
 
 from ..shared.analysis_task import AnalysisTask
 
 from ..shared.constants import constants
 
-# BELOW IS IMPORTED BUT NOT CURRENTLY USED
-# from ..shared.plot.plotting import timeseries_analysis_plot
-
-from ..shared.plot.plotting import plot_xtick_format
+from ..shared.plot.plotting import timeseries_analysis_plot
 
 from ..shared.io import open_mpas_dataset
 
@@ -237,9 +231,9 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
         # work on data from simulations
         freshwaterFlux = ds.timeMonthly_avg_landIceFreshwaterFlux
 
-        # BELOW ASSIGNED BUT NOT USED
-        # movingAverageMonths = config.getint('timeSeriesAntarcticMelt',
-        #                                    'movingAverageMonths')
+        mainRunName = config.get('runs', 'mainRunName')
+        movingAverageMonths = config.getint('timeSeriesAntarcticMelt',
+                                            'movingAverageMonths')
 
         iceShelvesToPlot = self.iceShelvesToPlot
 
@@ -307,13 +301,13 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
             filePrefix = 'melt_flux_{}'.format(regionName)
             figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
-#           timeseries_analysis_plot(config, [timeSeries], movingAverageMonths,
-#                                     title, xLabel, yLabel, figureName,
-#                                     lineStyles=['b-'], lineWidths=[1.2],
-#                                     calendar=calendar)
-            self.plot(config, timeSeries, obsFileNameDesc, obsCount,
-                      obsMeltFlux, obsMeltFluxUnc, title,
-                      xLabel, yLabel, figureName)
+            timeseries_analysis_plot(config, [timeSeries], movingAverageMonths,
+                                     title, xLabel, yLabel, figureName,
+                                     lineStyles=['b-'], lineWidths=[1.2],
+                                     legendText=[mainRunName],
+                                     calendar=calendar, obsMean=obsMeltFlux,
+                                     obsUncertainty=obsMeltFluxUnc,
+                                     obsLegend=obsFileNameDesc)
 
             caption = 'Running Mean of Total Melt Flux  under Ice ' \
                       'Shelves in the {} Region'.format(title)
@@ -337,13 +331,13 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
             filePrefix = 'melt_rate_{}'.format(regionName)
             figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
-#           timeseries_analysis_plot(config, [timeSeries], movingAverageMonths,
-#                                     title, xLabel, yLabel, figureName,
-#                                     lineStyles=['b-'], lineWidths=[1.2],
-#                                     calendar=calendar)
-            self.plot(config, timeSeries, obsFileNameDesc, obsCount,
-                      obsMeltRate, obsMeltRateUnc, title,
-                      xLabel, yLabel, figureName)
+            timeseries_analysis_plot(config, [timeSeries], movingAverageMonths,
+                                     title, xLabel, yLabel, figureName,
+                                     lineStyles=['b-'], lineWidths=[1.2],
+                                     legendText=[mainRunName],
+                                     calendar=calendar, obsMean=obsMeltRate,
+                                     obsUncertainty=obsMeltRateUnc,
+                                     obsLegend=obsFileNameDesc)
 
             caption = 'Running Mean of Area-averaged Melt Rate under Ice ' \
                       'Shelves in the {} Region'.format(title)
@@ -358,112 +352,6 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                 thumbnailDescription=title,
                 imageDescription=caption,
                 imageCaption=caption)
-
-    def plot(self, config, modelValues, obsFileNameDesc, obsCount, obsMean,
-             obsUncertainty, title, xlabel, ylabel, fileout):
-
-        """
-        Plots the list of time series data sets and stores the result in
-        an image file.
-        Parameters
-        ----------
-        config : instance of ConfigParser
-            the configuration, containing a [plot] section with options that
-            control plotting
-
-        modelValues : xarray DataSet
-            the data set to be plotted
-
-        obsMean : float
-            a single observed mean value to plot as a constant line
-
-        obsUncertainty : float
-            The observed uncertainty, to plot as a shaded rectangle
-            around the mean
-
-        title : str
-            the title of the plot
-
-        xlabel, ylabel : str
-            axis labels
-
-        fileout : str
-            the file name to be written
-
-        Authors
-        -------
-        Xylar Asay-Davis, Stephen Price
-        """
-
-        # play with these as you need
-        figsize = (15, 6)
-        dpi = 300
-        modelLineStyle = 'b-'
-        modelLineWidth = 2
-        # BELOW ARE ASSIGNED BUT NOT USED
-        # obsColor = 'gray'
-        # obsLineWidth = 1
-
-        maxXTicks = 20
-        calendar = self.calendar
-
-        axis_font = {'size': config.get('plot', 'axisFontSize')}
-        title_font = {'size': config.get('plot', 'titleFontSize'),
-                      'color': config.get('plot', 'titleFontColor'),
-                      'weight': config.get('plot', 'titleFontWeight')}
-
-        plt.figure(figsize=figsize, dpi=dpi)
-
-        minDays = modelValues.Time.min()
-        maxDays = modelValues.Time.max()
-        plt.plot(modelValues.Time.values, modelValues.values, modelLineStyle,
-                 linewidth=modelLineWidth, label='model')
-
-        # MUCH OF (COMMENTED OUT)BELOW IS ASSIGNED BUT NOT USED
-#        ax = plt.gca()
-
-        # this makes a "patch" with a single rectangular polygon, where the
-        # pairs are time and melt rate for the 4 corners, and "True" means it
-        # is a closed polygon:
-#        patches = [Polygon([[minDays, obsMean-obsUncertainty],
-#                            [maxDays, obsMean-obsUncertainty],
-#                            [maxDays, obsMean+obsUncertainty],
-#                            [minDays, obsMean+obsUncertainty]])]
-
-        # make the polygon gray and mostly transparent
-#        p = PatchCollection(patches, color=obsColor, alpha=0.15)
-        # add it to the plot on the current axis
-#        ax.add_collection(p)
-
-        # also plot a line
-#        plt.plot([minDays, maxDays], [obsMean, obsMean],
-#                 color=obsColor, linewidth=obsLineWidth)
-
-        # plot error bars rather than the "patch" used above
-        symbol = ['o', '^', 's', 'D', '*']
-        for iObs in range(obsCount):
-            plt.errorbar(((maxDays - minDays)/5)*(iObs+1)+minDays,
-                         obsMean[iObs], yerr=obsUncertainty[iObs],
-                         fmt=symbol[iObs], ecolor='k',
-                         capthick=2, label='{}'.format(obsFileNameDesc[iObs]))
-        # add legend
-        plt.legend(loc='lower right', numpoints=1)
-
-        # this will need to be imported from shared.plot.plotting
-        plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)
-
-        if title is not None:
-            plt.title(title, **title_font)
-        if xlabel is not None:
-            plt.xlabel(xlabel, **axis_font)
-        if ylabel is not None:
-            plt.ylabel(ylabel, **axis_font)
-        if fileout is not None:
-            plt.savefig(fileout, dpi=dpi, bbox_inches='tight', pad_inches=0.1)
-
-        if not config.getboolean('plot', 'displayToScreen'):
-            plt.close()
-
         # }}}
 
 # }}}

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -4,7 +4,7 @@ import xarray
 # SFP: the following are only needed for the stop-gap local plotting routine used here
 import matplotlib.pyplot as plt
 from matplotlib.collections import PatchCollection
-from shapely.geometry.polygon import Polygon
+from matplotlib.patches import Polygon
 
 from ..shared.analysis_task import AnalysisTask
 
@@ -321,9 +321,9 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
         figsize = (15, 6)
         dpi = 300
         modelLineStyle = 'b-'
-        modelLineWidth = 1.2
+        modelLineWidth = 2
         obsColor = 'gray'
-        obsLineWidth = 2
+        obsLineWidth = 1 
 
         maxXTicks = 20
         calendar = self.calendar
@@ -348,9 +348,9 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                         [maxDays, obsMean+obsUncertainty], [minDays, obsMean+obsUncertainty]])]
 
         # make the polygon gray and mostly transparent
-#        p = PatchCollection(patches, color=obsColor, alpha=0.4)
+        p = PatchCollection(patches, color=obsColor, alpha=0.15)
         # add it to the plot on the current axis
-#        ax.add_collection(p)
+        ax.add_collection(p)
 
         # also plot a line
         plt.plot([minDays, maxDays], [obsMean, obsMean], color=obsColor, linewidth=obsLineWidth)

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -180,6 +180,10 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
 	#	SSmeltFluxUncertainty, 'SSmeltRate': SSmeltRate, 'SSmeltRateUncertainty': SSmeltRateUncertainty,
 	#	'meltFlux': meltFlux, 'meltFluxUncertainty': meltFluxUncertainty, 'meltRate': meltRate, 
 	#	'meltRateUncertainty': meltRateUncertainty, 'actualArea': actualArea }
+        #    obsDict[shelfName] = { 'SSmeltFlux': SSmeltFlux, 'SSmeltFluxUncertainty': 
+	#	SSmeltFluxUncertainty, 'SSmeltRate': SSmeltRate, 'SSmeltRateUncertainty': SSmeltRateUncertainty,
+	#	'meltFlux': meltFlux, 'meltFluxUncertainty': meltFluxUncertainty, 'meltRate': meltRate, 
+	#	'meltRateUncertainty': meltRateUncertainty }
             obsDict[shelfName] = { 'meltFlux': meltFlux, 'meltFluxUncertainty': meltFluxUncertainty, 
 		'meltRate': meltRate, 'meltRateUncertainty': meltRateUncertainty }
 	# Note that if areas from obs file are used they need to be converted from sq km to sq m
@@ -242,6 +246,11 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
             regionName = iceShelvesToPlot[iRegion]
 
             # get obs melt flux and obs melt flux unc. for shelf (similar for rates) 
+            #SSMeltFlux = obsDict[regionName]['SSmeltFlux']
+            #SSMeltFluxUnc = obsDict[regionName]['SSmeltFluxUncertainty']
+            #SSMeltRate = obsDict[regionName]['SSmeltRate']
+            #SSMeltRateUnc = obsDict[regionName]['SSmeltRateUncertainty']
+            
             obsMeltFlux = obsDict[regionName]['meltFlux']
             obsMeltFluxUnc = obsDict[regionName]['meltFluxUncertainty']
             obsMeltRate = obsDict[regionName]['meltRate']
@@ -357,11 +366,11 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
 
 	# plot error bars rather than the "patch" used above
 	plt.errorbar( (maxDays - minDays)/3+minDays, obsMean, yerr=obsUncertainty, fmt='o', ecolor='k', 
-			capthick=2, label='obs1')
-	plt.errorbar( (maxDays - minDays)/3+minDays+1.0*(maxDays - minDays)/10, obsMean, yerr=obsUncertainty/3.0, 
-			fmt='s', ecolor='g', capthick=2, label='obs2')  # example of a 2nd set of obs error bars
-	plt.errorbar( (maxDays - minDays)/3+minDays+2.0*(maxDays - minDays)/10, obsMean, yerr=obsUncertainty/2.0, 
-			fmt='^', ecolor='r', capthick=2, label='obs3')  # example of a 3rd set of obs error bars
+			capthick=2, label='Rignot et al. (2013)')
+#	plt.errorbar( (maxDays - minDays)/3+minDays+1.0*(maxDays - minDays)/10, obsMean, yerr=obsUncertainty/3.0, 
+#			fmt='s', ecolor='g', capthick=2, label='obs2')  # example of a 2nd set of obs error bars
+#	plt.errorbar( (maxDays - minDays)/3+minDays+2.0*(maxDays - minDays)/10, obsMean, yerr=obsUncertainty/2.0, 
+#			fmt='^', ecolor='r', capthick=2, label='obs3')  # example of a 3rd set of obs error bars
 
         # add legend
 	plt.legend( loc='lower right' )

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -12,6 +12,7 @@ from ..shared.generalized_reader.generalized_reader \
 
 from ..shared.io.utility import build_config_full_path, make_directories
 
+import csv	# SFP added
 
 class TimeSeriesAntarcticMelt(AnalysisTask):
     """
@@ -148,6 +149,24 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                                     startDate=self.startDate,
                                     endDate=self.endDate)
 
+
+        # Load observations:
+        observationsDirectory = build_config_full_path(config, 'oceanObservations', 'meltSubdirectory')
+        obsFileName = '{}/Rignot_2013_melt_rates.csv'.format(observationsDirectory)
+        
+        obsFile = csv.reader( open(obsFileName, 'rU') )	
+        obsDict = {}
+        for line in obsFile:
+	    shelfName = line[0]         	
+            shelfArea = line[3]		# NOTE: this is in km - needs converting to m!
+ 	    meltFlux = line[11]
+            meltRate = line[12]
+            obsDict[shelfName] = { 'meltFlux': meltFlux, 'meltRate': meltRate, 'shelfArea': shelfArea}
+
+        #print(obsDict)	# SFP for debug
+
+
+        # work on data from simulations
         freshwaterFlux = ds.timeMonthly_avg_landIceFreshwaterFlux
 
         movingAverageMonths = config.getint('timeSeriesAntarcticMelt',

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -4,14 +4,16 @@ from __future__ import absolute_import, division, print_function, \
 import os
 import xarray
 
-# SFP: the following are only needed for the stop-gap local plotting routine used here
+# SFP: the following are only needed for the stop-gap local plotting routine
+# used here
 import matplotlib.pyplot as plt
 
 from ..shared.analysis_task import AnalysisTask
 
 from ..shared.constants import constants
 
-from ..shared.plot.plotting import timeseries_analysis_plot
+# BELOW IS IMPORTED BUT NOT CURRENTLY USED
+# from ..shared.plot.plotting import timeseries_analysis_plot
 
 from ..shared.plot.plotting import plot_xtick_format
 
@@ -189,41 +191,55 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                                startDate=self.startDate,
                                endDate=self.endDate)
 
-        # Load observations from multiple files and put in dictionary based on shelf keyname
-        observationsDirectory = build_config_full_path(config, 'oceanObservations', 'meltSubdirectory')
-        obsFileNameDict = { 'Rignot et al. (2013)': 'Rignot_2013_melt_rates.csv', 'Rignot et al. (2013) SS': 'Rignot_2013_melt_rates_SS.csv' }
+        # Load observations from multiple files and put in dictionary based
+        # on shelf keyname
+        observationsDirectory = build_config_full_path(config,
+                                                       'oceanObservations',
+                                                       'meltSubdirectory')
+        obsFileNameDict = {'Rignot et al. (2013)':
+                           'Rignot_2013_melt_rates.csv',
+                           'Rignot et al. (2013) SS':
+                           'Rignot_2013_melt_rates_SS.csv'}
         obsFileNameList = list(obsFileNameDict.values())
         obsFileNameDesc = list(obsFileNameDict.keys())
 
-        obsDictDict = {} # dict for storing dict of obs data
-        fileCount = 0    # counter for uniquely identifying obs data set
-        while len(obsFileNameList)>0:
-            obsFileName = '{}/{}'.format( observationsDirectory, obsFileNameList.pop(0) )
+        obsDictDict = {}  # dict for storing dict of obs data
+        fileCount = 0     # counter for uniquely identifying obs data set
+        while len(obsFileNameList) > 0:
+            obsFileName = '{}/{}'.format(observationsDirectory,
+                                         obsFileNameList.pop(0))
             fileCount = fileCount + 1
             obsDictTemp = {}
-            obsFile = csv.reader( open(obsFileName, 'rU') )
+            obsFile = csv.reader(open(obsFileName, 'rU'))
             next(obsFile, None)  # skip the header line
-            for line in obsFile:  # some possibly useful values are left commented out for now
+            for line in obsFile:  # some later useful values commented out
                 shelfName = line[0]
-                #surveyArea = line[1]
-                meltFlux = float( line[2] )
-                meltFluxUncertainty = float( line[3] )
-                meltRate = float( line[4] )
-                meltRateUncertainty = float( line[5] )
-                #actualArea = float( line[6] )  # actual area here is in sq km
+                # surveyArea = line[1]
+                meltFlux = float(line[2])
+                meltFluxUncertainty = float(line[3])
+                meltRate = float(line[4])
+                meltRateUncertainty = float(line[5])
+                # actualArea = float( line[6] )  # actual area here is in sq km
 
-                # build dict of obs. keyed to filename description (which will be used for plotting)
-                obsDictTemp[shelfName] = {'meltFlux': meltFlux, 'meltFluxUncertainty': meltFluxUncertainty,
-                                          'meltRate': meltRate, 'meltRateUncertainty': meltRateUncertainty}
-                obsDictDict[ '{}'.format( obsFileNameDesc[fileCount-1] ) ] = obsDictTemp
+                # build dict of obs. keyed to filename description
+                # (which will be used for plotting)
+                obsDictTemp[shelfName] = {'meltFlux': meltFlux,
+                                          'meltFluxUncertainty':
+                                              meltFluxUncertainty,
+                                          'meltRate': meltRate,
+                                          'meltRateUncertainty':
+                                              meltRateUncertainty}
+                obsDictDict['{}'.format(
+                        obsFileNameDesc[fileCount-1])] = obsDictTemp
 
-        # Note that if areas from obs file are used they need to be converted from sq km to sq m
+        # If areas from obs file used need to be converted from sq km to sq m
 
         # work on data from simulations
         freshwaterFlux = ds.timeMonthly_avg_landIceFreshwaterFlux
 
-        movingAverageMonths = config.getint('timeSeriesAntarcticMelt',
-                                            'movingAverageMonths')
+        # BELOW ASSIGNED BUT NOT USED
+        # movingAverageMonths = config.getint('timeSeriesAntarcticMelt',
+        #                                    'movingAverageMonths')
 
         iceShelvesToPlot = self.iceShelvesToPlot
 
@@ -254,21 +270,30 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
 
         make_directories(outputDirectory)
 
-
-        obsCount = len( obsDictDict )
+        obsCount = len(obsDictDict)
         self.logger.info('  Make plots...')
         for iRegion in range(nRegions):
 
             regionName = iceShelvesToPlot[iRegion]
 
-            # get obs melt flux and obs melt flux unc. for shelf (similar for rates)
-            obsMeltFlux = []; obsMeltFluxUnc = []; obsMeltRate = []; obsMeltRateUnc = []
-            for iObs in range( obsCount ):
-                dictName = '{}'.format( obsFileNameDesc[iObs] )
-                obsMeltFlux.append( obsDictDict[dictName][regionName]['meltFlux'] )
-                obsMeltFluxUnc.append( obsDictDict[dictName][regionName]['meltFluxUncertainty'] )
-                obsMeltRate.append( obsDictDict[dictName][regionName]['meltRate'] )
-                obsMeltRateUnc.append( obsDictDict[dictName][regionName]['meltRateUncertainty'] )
+            # get obs melt flux and unc. for shelf (similar for rates)
+            obsMeltFlux = []
+            obsMeltFluxUnc = []
+            obsMeltRate = []
+            obsMeltRateUnc = []
+            for iObs in range(obsCount):
+                dictName = '{}'.format(obsFileNameDesc[iObs])
+                obsMeltFlux.append(
+                        obsDictDict[dictName][regionName]
+                        ['meltFlux'])
+                obsMeltFluxUnc.append(
+                        obsDictDict[dictName][regionName]
+                        ['meltFluxUncertainty'])
+                obsMeltRate.append(
+                        obsDictDict[dictName][regionName]['meltRate'])
+                obsMeltRateUnc.append(
+                        obsDictDict[dictName][regionName]
+                        ['meltRateUncertainty'])
 
             title = regionName.replace('_', ' ')
 
@@ -279,15 +304,16 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
 
             timeSeries = totalMeltFlux.isel(nRegions=iRegion)
 
-
             filePrefix = 'melt_flux_{}'.format(regionName)
             figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
-#            timeseries_analysis_plot(config, [timeSeries], movingAverageMonths,
+#           timeseries_analysis_plot(config, [timeSeries], movingAverageMonths,
 #                                     title, xLabel, yLabel, figureName,
 #                                     lineStyles=['b-'], lineWidths=[1.2],
 #                                     calendar=calendar)
-            self.plot(config, timeSeries, obsFileNameDesc,  obsCount, obsMeltFlux, obsMeltFluxUnc, title, xLabel, yLabel, figureName )
+            self.plot(config, timeSeries, obsFileNameDesc, obsCount,
+                      obsMeltFlux, obsMeltFluxUnc, title,
+                      xLabel, yLabel, figureName)
 
             caption = 'Running Mean of Total Melt Flux  under Ice ' \
                       'Shelves in the {} Region'.format(title)
@@ -303,21 +329,21 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                 imageDescription=caption,
                 imageCaption=caption)
 
-
             xLabel = 'Time (yr)'
             yLabel = 'Melt Rate (m/yr)'
 
             timeSeries = meltRates.isel(nRegions=iRegion)
 
-
             filePrefix = 'melt_rate_{}'.format(regionName)
             figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
-#            timeseries_analysis_plot(config, [timeSeries], movingAverageMonths,
+#           timeseries_analysis_plot(config, [timeSeries], movingAverageMonths,
 #                                     title, xLabel, yLabel, figureName,
 #                                     lineStyles=['b-'], lineWidths=[1.2],
 #                                     calendar=calendar)
-            self.plot(config, timeSeries, obsFileNameDesc, obsCount, obsMeltRate, obsMeltRateUnc, title, xLabel, yLabel, figureName )
+            self.plot(config, timeSeries, obsFileNameDesc, obsCount,
+                      obsMeltRate, obsMeltRateUnc, title,
+                      xLabel, yLabel, figureName)
 
             caption = 'Running Mean of Area-averaged Melt Rate under Ice ' \
                       'Shelves in the {} Region'.format(title)
@@ -333,13 +359,12 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                 imageDescription=caption,
                 imageCaption=caption)
 
-
     def plot(self, config, modelValues, obsFileNameDesc, obsCount, obsMean,
              obsUncertainty, title, xlabel, ylabel, fileout):
 
         """
-        Plots the list of time series data sets and stores the result in an image
-        file.
+        Plots the list of time series data sets and stores the result in
+        an image file.
         Parameters
         ----------
         config : instance of ConfigParser
@@ -353,7 +378,8 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
             a single observed mean value to plot as a constant line
 
         obsUncertainty : float
-            The observed uncertainty, to plot as a shaded rectangle around the mean
+            The observed uncertainty, to plot as a shaded rectangle
+            around the mean
 
         title : str
             the title of the plot
@@ -374,8 +400,9 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
         dpi = 300
         modelLineStyle = 'b-'
         modelLineWidth = 2
-        obsColor = 'gray'
-        obsLineWidth = 1
+        # BELOW ARE ASSIGNED BUT NOT USED
+        # obsColor = 'gray'
+        # obsLineWidth = 1
 
         maxXTicks = 20
         calendar = self.calendar
@@ -392,12 +419,16 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
         plt.plot(modelValues.Time.values, modelValues.values, modelLineStyle,
                  linewidth=modelLineWidth, label='model')
 
-        ax = plt.gca()
+        # MUCH OF (COMMENTED OUT)BELOW IS ASSIGNED BUT NOT USED
+#        ax = plt.gca()
 
-        # this makes a "patch" with a single rectangular polygon, where the pairs are time and melt
-        # rate for the 4 corners, and "True" means it is a closed polygon:
-#        patches = [Polygon([[minDays, obsMean-obsUncertainty], [maxDays, obsMean-obsUncertainty],
-#                        [maxDays, obsMean+obsUncertainty], [minDays, obsMean+obsUncertainty]])]
+        # this makes a "patch" with a single rectangular polygon, where the
+        # pairs are time and melt rate for the 4 corners, and "True" means it
+        # is a closed polygon:
+#        patches = [Polygon([[minDays, obsMean-obsUncertainty],
+#                            [maxDays, obsMean-obsUncertainty],
+#                            [maxDays, obsMean+obsUncertainty],
+#                            [minDays, obsMean+obsUncertainty]])]
 
         # make the polygon gray and mostly transparent
 #        p = PatchCollection(patches, color=obsColor, alpha=0.15)
@@ -405,15 +436,18 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
 #        ax.add_collection(p)
 
         # also plot a line
-#        plt.plot([minDays, maxDays], [obsMean, obsMean], color=obsColor, linewidth=obsLineWidth)
+#        plt.plot([minDays, maxDays], [obsMean, obsMean],
+#                 color=obsColor, linewidth=obsLineWidth)
 
         # plot error bars rather than the "patch" used above
-        symbol = ['o','^','s','D','*']
-        for iObs in range( obsCount ):
-           plt.errorbar( ((maxDays - minDays)/5)*(iObs+1)+minDays, obsMean[iObs], yerr=obsUncertainty[iObs], fmt=symbol[iObs], ecolor='k',
-                       capthick=2, label='{}'.format( obsFileNameDesc[iObs] ) )
+        symbol = ['o', '^', 's', 'D', '*']
+        for iObs in range(obsCount):
+            plt.errorbar(((maxDays - minDays)/5)*(iObs+1)+minDays,
+                         obsMean[iObs], yerr=obsUncertainty[iObs],
+                         fmt=symbol[iObs], ecolor='k',
+                         capthick=2, label='{}'.format(obsFileNameDesc[iObs]))
         # add legend
-        plt.legend( loc='lower right', numpoints=1 )
+        plt.legend(loc='lower right', numpoints=1)
 
         # this will need to be imported from shared.plot.plotting
         plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -1,0 +1,238 @@
+import os
+import xarray
+
+from ..shared.analysis_task import AnalysisTask
+
+from ..shared.constants import constants
+
+from ..shared.plot.plotting import timeseries_analysis_plot
+
+from ..shared.generalized_reader.generalized_reader \
+    import open_multifile_dataset
+
+from ..shared.io.utility import build_config_full_path, make_directories
+
+
+class TimeSeriesAntarcticMelt(AnalysisTask):
+    """
+    Performs analysis of the time-series output of Antarctic sub-ice-shelf
+    melt rates.
+
+    Authors
+    -------
+    Xylar Asay-Davis
+    """
+
+    def __init__(self, config):  # {{{
+        """
+        Construct the analysis task.
+
+        Parameters, Milena Veneziani
+        ----------
+        config :  instance of MpasAnalysisConfigParser
+            Contains configuration options
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        """
+        # first, call the constructor from the base class (AnalysisTask)
+        super(TimeSeriesAntarcticMelt, self).__init__(
+            config=config,
+            taskName='timeSeriesAntarcticMelt',
+            componentName='ocean',
+            tags=['timeSeries', 'melt', 'landIceCavities'])
+
+        # }}}
+
+    def setup_and_check(self):  # {{{
+        """
+        Perform steps to set up the analysis and check for errors in the setup.
+
+        Raises
+        ------
+        IOError
+            If files are not present
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        """
+        # first, call setup_and_check from the base class (AnalysisTask),
+        # which will perform some common setup, including storing:
+        #   self.inDirectory, self.plotsDirectory, self.namelist, self.streams
+        #   self.calendar
+        super(TimeSeriesAntarcticMelt, self).setup_and_check()
+
+        self.check_analysis_enabled(
+            analysisOptionName='config_am_timeseriesstatsmonthly_enable',
+            raiseException=True)
+
+        config = self.config
+
+        landIceFluxMode = self.namelist.get('config_land_ice_flux_mode')
+        if landIceFluxMode not in ['standalone', 'coupled']:
+            raise ValueError('*** timeSeriesAntarcticMelt requires '
+                             'config_land_ice_flux_mode \n'
+                             '    to be standalone or coupled.  Otherwise, no '
+                             'melt rates are available \n'
+                             '    for plotting.')
+
+        mpasMeshName = config.get('input', 'mpasMeshName')
+        regionMaskDirectory = config.get('regions', 'regionMaskDirectory')
+
+        self.regionMaskFileName = '{}/{}_iceShelfMasks.nc'.format(
+                regionMaskDirectory, mpasMeshName)
+
+        if not os.path.exists(self.regionMaskFileName):
+            raise IOError('Regional masking file {} for Antarctica melt-rate '
+                          'calculation does not exist'.format(
+                                  self.regionMaskFileName))
+
+        # Load mesh related variables
+        try:
+            self.restartFileName = self.runStreams.readpath('restart')[0]
+        except ValueError:
+            raise IOError('No MPAS-O restart file found: need at least one '
+                          'restart file for Antarctic melt calculations')
+
+        # get a list of timeSeriesStats output files from the streams file,
+        # reading only those that are between the start and end dates
+        streamName = self.historyStreams.find_stream(
+            self.streamMap['timeSeriesStats'])
+        self.startDate = config.get('timeSeries', 'startDate')
+        self.endDate = config.get('timeSeries', 'endDate')
+        self.inputFiles = \
+            self.historyStreams.readpath(streamName,
+                                         startDate=self.startDate,
+                                         endDate=self.endDate,
+                                         calendar=self.calendar)
+
+        if len(self.inputFiles) == 0:
+            raise IOError('No files were found in stream {} between {} and '
+                          '{}.'.format(streamName, self.startDate,
+                                       self.endDate))
+
+        return  # }}}
+
+    def run(self):  # {{{
+        """
+        Performs analysis of the time-series output of Antarctic sub-ice-shelf
+        melt rates.
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        """
+
+        print "\nPlotting Antarctic melt rate time series..."
+
+        print '  Load melt rate data...'
+
+        config = self.config
+        calendar = self.calendar
+
+        print '\n  Reading files:\n' \
+              '    {} through\n    {}'.format(
+                  os.path.basename(self.inputFiles[0]),
+                  os.path.basename(self.inputFiles[-1]))
+
+        # Load data:
+        variableList = ['timeMonthly_avg_landIceFreshwaterFlux']
+        timeVariableName = ['xtime_startMonthly', 'xtime_endMonthly']
+        ds = open_multifile_dataset(fileNames=self.inputFiles,
+                                    calendar=calendar,
+                                    config=config,
+                                    timeVariableName=timeVariableName,
+                                    variableList=variableList,
+                                    startDate=self.startDate,
+                                    endDate=self.endDate)
+
+        freshwaterFlux = ds.timeMonthly_avg_landIceFreshwaterFlux
+
+        movingAverageMonths = config.getint('timeSeriesAntarcticMelt',
+                                            'movingAverageMonths')
+
+        iceShelvesToPlot = config.getExpression('timeSeriesAntarcticMelt',
+                                                'iceShelvesToPlot')
+
+        dsRestart = xarray.open_dataset(self.restartFileName)
+        areaCell = dsRestart.areaCell
+
+        dsRegionMask = xarray.open_dataset(self.regionMaskFileName)
+        regionNames = list(dsRegionMask.regionNames.values)
+        nRegions = dsRegionMask.dims['nRegions']
+
+        if 'all' in iceShelvesToPlot:
+            iceShelvesToPlot = regionNames
+            regionIndices = [iRegion for iRegion in range(nRegions)]
+        else:
+            regionIndices = []
+            for regionName in iceShelvesToPlot:
+                if regionName not in regionNames:
+                    raise ValueError('Unknown ice shelf name {}'.format(
+                            regionName))
+
+                iRegion = regionNames.index(regionName)
+                regionIndices.append(iRegion)
+
+        # select only those regions we want to plot
+        dsRegionMask = dsRegionMask.isel(nRegions=regionIndices)
+        cellMasks = dsRegionMask.regionCellMasks
+        nRegions = dsRegionMask.dims['nRegions']
+
+        # convert from kg/s to kg/yr
+        totalMeltFlux = constants.sec_per_year * \
+            (cellMasks*areaCell*freshwaterFlux).sum(dim='nCells')
+
+        totalArea = (cellMasks*areaCell).sum(dim='nCells')
+
+        # from kg/m^2/yr to m/yr
+        meltRates = (1./constants.rho_fw) * (totalMeltFlux/totalArea)
+
+        # convert from kg/yr to GT/yr
+        totalMeltFlux /= constants.kg_per_GT
+
+        outputDirectory = build_config_full_path(config, 'output',
+                                                 'timeseriesSubdirectory')
+
+        make_directories(outputDirectory)
+
+        print '  Make plots...'
+        for iRegion in range(nRegions):
+            regionName = iceShelvesToPlot[iRegion]
+
+            title = regionName.replace('_', ' ')
+
+            regionName = regionName.replace(' ', '_')
+
+            xLabel = 'Time (yr)'
+            yLabel = 'Melt Flux (GT/yr)'
+
+            timeSeries = totalMeltFlux.isel(nRegions=iRegion)
+
+            figureName = '{}/melt_flux_{}.png'.format(self.plotsDirectory,
+                                                         regionName)
+
+            timeseries_analysis_plot(config, [timeSeries], movingAverageMonths,
+                                     title, xLabel, yLabel, figureName,
+                                     lineStyles=['b-'], lineWidths=[1.2],
+                                     calendar=calendar)
+
+            xLabel = 'Time (yr)'
+            yLabel = 'Melt Rate (m/yr)'
+
+            timeSeries = meltRates.isel(nRegions=iRegion)
+
+            figureName = '{}/melt_rate_{}.png'.format(self.plotsDirectory,
+                                                         regionName)
+
+            timeseries_analysis_plot(config, [timeSeries], movingAverageMonths,
+                                     title, xLabel, yLabel, figureName,
+                                     lineStyles=['b-'], lineWidths=[1.2],
+                                     calendar=calendar)
+        # }}}
+
+# }}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/constants/constants.py
+++ b/mpas_analysis/shared/constants/constants.py
@@ -61,4 +61,7 @@ eps = 1.E-10
 # density of freshwater (kg/m^3)
 rho_fw = 1000.
 
+# kilograms per gigatonne
+kg_per_GT = 1e12
+
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -33,7 +33,9 @@ from six.moves import configparser
 def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                              fileout, lineStyles, lineWidths, legendText,
                              calendar, maxPoints=None, titleFontSize=None,
-                             figsize=(15, 6), dpi=None, maxXTicks=20):
+                             figsize=(15, 6), dpi=None, maxXTicks=20,
+                             obsMean=None, obsUncertainty=None,
+                             obsLegend=None, legendLocation='lower left'):
 
     """
     Plots the list of time series data sets and stores the result in an image
@@ -87,9 +89,20 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
         This may need to be adjusted depending on the figure size and aspect
         ratio.
 
+    obsMean, obsUncertainty : list of float, optional
+        Mean values and uncertainties for observations to be plotted as error
+        bars. The two lists must have the same number of elements.
+
+    obsLegend : list of str, optional
+        The label in the legend for each element in ``obsMean`` (and
+        ``obsUncertainty``)
+
+    legendLocation : str, optional
+        The location of the legend (see ``pyplot.legend()`` for details)
+
     Authors
     -------
-    Xylar Asay-Davis, Milena Veneziani
+    Xylar Asay-Davis, Milena Veneziani, Stephen Price
     """
 
     if dpi is None:
@@ -117,7 +130,25 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                  lineStyles[dsIndex],
                  linewidth=lineWidths[dsIndex],
                  label=legendText[dsIndex])
-    plt.legend(loc='lower left')
+
+    if obsMean is not None:
+        obsCount = len(obsMean)
+        assert(len(obsUncertainty) == obsCount)
+
+        # space the observations along the time line, leaving gaps at either
+        # end
+        start = np.amin(minDays)
+        end = np.amax(maxDays)
+        obsTimes = np.linspace(start, end, obsCount+2)[1:-1]
+        obsSymbols = ['o', '^', 's', 'D', '*']
+        for iObs in range(obsCount):
+            plt.errorbar(obsTimes[iObs], obsMean[iObs],
+                         yerr=obsUncertainty[iObs],
+                         fmt=obsSymbols[np.mod(iObs, len(obsSymbols))],
+                         ecolor='k',
+                         capthick=2, label=obsLegend[iObs])
+
+    plt.legend(loc=legendLocation)
 
     ax = plt.gca()
 

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -142,11 +142,12 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
         obsTimes = np.linspace(start, end, obsCount+2)[1:-1]
         obsSymbols = ['o', '^', 's', 'D', '*']
         for iObs in range(obsCount):
-            plt.errorbar(obsTimes[iObs], obsMean[iObs],
-                         yerr=obsUncertainty[iObs],
-                         fmt=obsSymbols[np.mod(iObs, len(obsSymbols))],
-                         ecolor='k',
-                         capthick=2, label=obsLegend[iObs])
+            if obsMean[iObs] is not None:
+                plt.errorbar(obsTimes[iObs], obsMean[iObs],
+                             yerr=obsUncertainty[iObs],
+                             fmt=obsSymbols[np.mod(iObs, len(obsSymbols))],
+                             ecolor='k',
+                             capthick=2, label=obsLegend[iObs])
 
     plt.legend(loc=legendLocation)
 
@@ -164,7 +165,7 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
     if yaxLimits[0]*yaxLimits[1] < 0:
         indgood = np.where(np.logical_not(np.isnan(mean)))
         x = mean['Time'][indgood]
-        plt.plot(x, np.zeros(np.size(x)), 'k-', linewidth=1.2)
+        plt.plot(x, np.zeros(np.size(x)), 'k-', linewidth=1.2, zorder=1)
 
     plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)
 

--- a/preprocess_masks/make_ice_shelf_masks.py
+++ b/preprocess_masks/make_ice_shelf_masks.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+
+'''
+Make a mask file for a given mesh from ice-shelf geometric features.
+
+The -m flag is used to specify the name of the ACME mesh to which the
+masks should be applied.
+
+Requires:
+    * a local link to the MPAS mask creator MpasMaskCreator.x
+    * a local link to a mesh file named <mesh_name>_mesh.nc describing the
+      desired mesh
+    * the region file iceShelves.geojson produced by running
+      ./driver_scripts/setup_ice_shelves.py in the geometric_features repo
+
+Produces:
+    * <mesh_name>_iceShelfMasks.nc, the mask file
+
+Author: Xylar Asay-Davis
+'''
+
+import subprocess
+import argparse
+
+
+parser = \
+    argparse.ArgumentParser(description=__doc__,
+                            formatter_class=argparse.RawTextHelpFormatter)
+parser.add_argument('-m', '--mesh_name', dest='mesh_name',
+                    help='The ACME name of the mesh', metavar='MESH_NAME',
+                    required=True)
+args = parser.parse_args()
+
+meshFileName = '{}_mesh.nc'.format(args.mesh_name)
+maskFileName = '{}_iceShelfMasks.nc'.format(args.mesh_name)
+regionFileName = 'iceShelves.geojson'
+
+tempRegionMaskFile = 'tempRegionMasks.nc'
+subprocess.check_call(['./MpasMaskCreator.x', meshFileName, maskFileName,
+                       '-f', regionFileName])

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -77,14 +77,15 @@ def build_analysis_list(config):  # {{{
     analyses.append(ocean.ClimatologyMapMLD(config, oceanClimatolgyTask))
     analyses.append(ocean.ClimatologyMapSST(config, oceanClimatolgyTask))
     analyses.append(ocean.ClimatologyMapSSS(config, oceanClimatolgyTask))
-    analyses.append(ocean.ClimatologyMapAntarcticMelt(config,
-                                                      oceanClimatolgyTask))
     analyses.append(ocean.ClimatologyMapSoseTemperature(config,
                                                         oceanClimatolgyTask))
     analyses.append(ocean.ClimatologyMapSoseSalinity(config,
                                                      oceanClimatolgyTask))
+    analyses.append(ocean.ClimatologyMapAntarcticMelt(config,
+                                                      oceanClimatolgyTask))
 
     analyses.append(oceanTimeSeriesTask)
+    analyses.append(ocean.TimeSeriesAntarcticMelt(config, oceanTimeSeriesTask))
     analyses.append(ocean.TimeSeriesOHC(config, oceanTimeSeriesTask))
     analyses.append(ocean.TimeSeriesSST(config, oceanTimeSeriesTask))
     analyses.append(ocean.MeridionalHeatTransport(config, oceanClimatolgyTask))


### PR DESCRIPTION
This is a continuation of a WIP PR originally submitted by @xylar, for adding the ability to plot time series of submarine melt rates for individual ice shelves. Continued work on this feature is taking place on this fork.