### PR TITLE
fix CI test test_analysis_task

### DIFF
--- a/mpas_analysis/test/test_analysis_task.py
+++ b/mpas_analysis/test/test_analysis_task.py
@@ -75,8 +75,14 @@ class TestAnalysisTask(TestCase):
                 'climatologyMapMLD': ['climatology', 'horizontalMap', 'mld'],
                 'climatologyMapSSS': ['climatology', 'horizontalMap', 'sss'],
                 'timeSeriesSeaIceAreaVol': ['timeSeries'],
-                'climatologyMapSeaIceConcThick': ['climatology',
-                                                  'horizontalMap']}
+                'climatologyMapSeaIceConcNH': ['climatology',
+                                               'horizontalMap'],
+                'climatologyMapSeaIceConcSH': ['climatology',
+                                               'horizontalMap'],
+                'climatologyMapSeaIceThickNH': ['climatology',
+                                                'horizontalMap'],
+                'climatologyMapSeaIceThickSH': ['climatology',
+                                                'horizontalMap']}
 
         # test 'all'
         expectedResults = {}


### PR DESCRIPTION
I accidentally pushed a broken CI test and it got merged before we noticed.  This merge fixes the error (where names of sea-ice tasks were changed in some places but not others in the test).