### PR TITLE
Fix bug in OHC time series

### DIFF
--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -226,9 +226,6 @@ class TimeSeriesOHC(AnalysisTask):
                 startDate=startDateFirstYear,
                 endDate=endDateFirstYear)
 
-            dsFirstYear = \
-                dsFirstYear.isel(nOceanRegionsTmp=regionIndicesToPlot)
-
             firstYearAvgLayerTemperature = dsFirstYear[avgTempVarName]
         else:
             firstYearAvgLayerTemperature = ds[avgTempVarName]


### PR DESCRIPTION
In cases where the first simulation year was not part of the
time series, the first year was being computed only for the regions
to plot, whereas the time series was being computed for all regions.
This led to a problem when trying to combine the two.