### PR TITLE
Adding code for the creation of vertical trends plots for S, T, and O…

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -308,7 +308,7 @@ regionIndicesToPlot = [6]
 # Number of points over which to compute moving average for time series (e.g., 
 #for monthly output, movingAveragePoints=12 corresponds to a 12-month moving
 # average window)
-movingAveragePoints = 12
+movingAveragePointsTimeSeries = 12
 # Number of points over which to compute moving average for Hovmoller plots
 movingAveragePointsHovmoller = 12
 
@@ -345,7 +345,7 @@ colormapNameTemperatureAnomaly = RdBu_r
 colormapIndicesTemperatureAnomaly = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
 colorbarLevelsTemperatureAnomaly = [-1, -0.5, -0.2, -0.05, 0, 0.05, 0.2, 0.5, 1]
-#contour line levels
+# contour line levels
 contourLevelsTemperatureAnomaly = np.arange(-1.0, 1.26, 0.25)
 
 # colormap for salinity
@@ -363,9 +363,8 @@ colormapNameSalinityAnomaly = RdBu_r
 colormapIndicesSalinityAnomaly = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
 colorbarLevelsSalinityAnomaly = [-0.1, -0.02, -0.003, -0.001, 0, 0.001, 0.003, 0.02, 0.1]
-#contour line levels
+# contour line levels
 contourLevelsSalinityAnomaly = np.arange(-0.1, 0.11, 0.02)
-
 
 [timeSeriesSST]
 ## options related to plotting time series of sea surface temperature (SST)

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -310,7 +310,7 @@ regionIndicesToPlot = [6]
 # average window)
 movingAveragePoints = 12
 # Number of points over which to compute moving average for Hovmoller plots
-movingAveragePointsHovmoller = 1
+movingAveragePointsHovmoller = 12
 
 # colormap for OHC
 colormapNameOHC = RdYlBu_r

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -328,7 +328,7 @@ colormapIndicesOHCAnomaly = [0, 40, 80, 110, 140, 170, 200, 230, 255]
 # colorbar levels/values for contour boundaries
 colorbarLevelsOHCAnomaly = [-2.4, -0.8, -0.4, -0.2, 0.2, 0.4, 0.8, 2.4]
 # contour line levels
-contourLevelsOHCAnomaly = np.arange(-2.5, 2.5, 0.25)
+contourLevelsOHCAnomaly = np.arange(-2.5, 2.6, 0.5)
 
 # colormap for temperature
 colormapNameTemperature = RdYlBu_r
@@ -346,7 +346,7 @@ colormapIndicesTemperatureAnomaly = [0, 40, 80, 110, 140, 170, 200, 230, 255]
 # colormap levels/values for contour boundaries
 colorbarLevelsTemperatureAnomaly = [-1.0, -0.20, -0.07, -0.02, 0.02, 0.07, 0.20, 1.0]
 #contour line levels
-contourLevelsTemperatureAnomaly = np.arange(-1.0, 1.1, 0.1)
+contourLevelsTemperatureAnomaly = np.arange(-1.0, 1.26, 0.25)
 
 # colormap for salinity
 colormapNameSalinity = RdYlBu_r

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -299,14 +299,73 @@ baseDirectory = /dir/to/seaice/reference
 [timeSeriesOHC]
 ## options related to plotting time series of ocean heat content (OHC)
 
+# plot S, T, and OHC fields themselves, in addition to their anomalies?
+plotOriginalFields = False
 # compare to observations?
 compareWithObservations = False
 # list of region indices to plot from the region list in [regions] below
 regionIndicesToPlot = [6]
-# Number of points over which to compute moving average (e.g., for monthly
-# output, movingAveragePoints=12 corresponds to a 12-month moving average
-# window)
+# Number of points over which to compute moving average for time series (e.g., 
+#for monthly output, movingAveragePoints=12 corresponds to a 12-month moving
+# average window)
 movingAveragePoints = 12
+# Number of points over which to compute moving average for Hovmoller plots
+movingAveragePointsHovmoller = 1
+
+# colormap for OHC
+colormapNameOHC = RdYlBu_r
+# colormap indices for contour color
+colormapIndicesOHC = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+# colorbar levels/values for contour boundaries
+colorbarLevelsOHC = [0, 5, 10, 15, 20, 25, 30, 35, 40]
+# contour line levels
+contourLevelsOHC = np.arange(0, 41, 4)
+
+# colormap for OHC anomaly
+colormapNameOHCAnomaly = RdBu_r
+# colormap indices for contour color
+colormapIndicesOHCAnomaly = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+# colorbar levels/values for contour boundaries
+colorbarLevelsOHCAnomaly = [-2.4, -0.8, -0.4, -0.2, 0.2, 0.4, 0.8, 2.4]
+# contour line levels
+contourLevelsOHCAnomaly = np.arange(-2.5, 2.5, 0.25)
+
+# colormap for temperature
+colormapNameTemperature = RdYlBu_r
+# color indices into colormapName for filled contours
+colormapIndicesTemperature = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsTemperature = [0, 0.6, 1.2, 2, 4, 6, 8, 10, 20]
+# contour line levels
+contourLevelsTemperature = np.arange(1, 21, 2)
+
+# colormap for temperature anomaly
+colormapNameTemperatureAnomaly = RdBu_r
+# color indices into colormapName for filled contours
+colormapIndicesTemperatureAnomaly = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsTemperatureAnomaly = [-1.0, -0.20, -0.07, -0.02, 0.02, 0.07, 0.20, 1.0]
+#contour line levels
+contourLevelsTemperatureAnomaly = np.arange(-1.0, 1.1, 0.1)
+
+# colormap for salinity
+colormapNameSalinity = RdYlBu_r
+# color indices into colormapName for filled contours
+colormapIndicesSalinity = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsSalinity = [34.5, 34.6, 34.65, 34.7, 34.72, 34.74, 34.76, 34.78, 34.8]
+# contour line levels
+contourLevelsSalinity = np.arange(34.51, 34.82, 0.02)
+
+# colormap for salinity anomaly
+colormapNameSalinityAnomaly = RdBu_r
+# color indices into colormapName for filled contours
+colormapIndicesSalinityAnomaly = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsSalinityAnomaly = [-0.1, -0.02, -0.003, -0.001, 0.001, 0.003, 0.02, 0.1]
+#contour line levels
+contourLevelsSalinityAnomaly = np.arange(-0.1, 0.11, 0.02)
+
 
 [timeSeriesSST]
 ## options related to plotting time series of sea surface temperature (SST)
@@ -366,6 +425,10 @@ compareWithObservations = True
 # plot the vertical section of MHT?
 plotVerticalSection = False
 
+# Number of points over which to compute moving average (with respect to latitude)
+# for MHT vertical section plots
+movingAveragePoints = 1
+
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning
 ## circulation (MOC)
@@ -418,6 +481,10 @@ compareWithObservations = True
 # MOC timeseries (e.g., for monthly output, movingAveragePoints=12
 # corresponds to a 12-month moving average window)
 movingAveragePoints = 12
+
+# Number of points over which to compute moving average (with respect to
+# latitude) for climatological MOC plots
+movingAveragePointsClimatological = 1
 
 [timeSeriesSeaIceAreaVol]
 ## options related to plotting time series of sea ice area and volume

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -324,9 +324,9 @@ contourLevelsOHC = np.arange(0, 41, 4)
 # colormap for OHC anomaly
 colormapNameOHCAnomaly = RdBu_r
 # colormap indices for contour color
-colormapIndicesOHCAnomaly = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+colormapIndicesOHCAnomaly = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colorbar levels/values for contour boundaries
-colorbarLevelsOHCAnomaly = [-2.4, -0.8, -0.4, -0.2, 0.2, 0.4, 0.8, 2.4]
+colorbarLevelsOHCAnomaly = [-2.4, -0.8, -0.4, -0.2, 0, 0.2, 0.4, 0.8, 2.4]
 # contour line levels
 contourLevelsOHCAnomaly = np.arange(-2.5, 2.6, 0.5)
 
@@ -342,9 +342,9 @@ contourLevelsTemperature = np.arange(1, 21, 2)
 # colormap for temperature anomaly
 colormapNameTemperatureAnomaly = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesTemperatureAnomaly = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+colormapIndicesTemperatureAnomaly = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsTemperatureAnomaly = [-1.0, -0.20, -0.07, -0.02, 0.02, 0.07, 0.20, 1.0]
+colorbarLevelsTemperatureAnomaly = [-1, -0.5, -0.2, -0.05, 0, 0.05, 0.2, 0.5, 1]
 #contour line levels
 contourLevelsTemperatureAnomaly = np.arange(-1.0, 1.26, 0.25)
 
@@ -360,9 +360,9 @@ contourLevelsSalinity = np.arange(34.51, 34.82, 0.02)
 # colormap for salinity anomaly
 colormapNameSalinityAnomaly = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesSalinityAnomaly = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+colormapIndicesSalinityAnomaly = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsSalinityAnomaly = [-0.1, -0.02, -0.003, -0.001, 0.001, 0.003, 0.02, 0.1]
+colorbarLevelsSalinityAnomaly = [-0.1, -0.02, -0.003, -0.001, 0, 0.001, 0.003, 0.02, 0.1]
 #contour line levels
 contourLevelsSalinityAnomaly = np.arange(-0.1, 0.11, 0.02)
 

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -165,6 +165,9 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
 
         config = self.config
 
+        movingAveragePoints = config.getint('meridionalHeatTransport',
+                                            'movingAveragePoints')
+
         # Read in depth and MHT latitude points
         # Latitude is from binBoundaryMerHeatTrans written in
         #  mpaso.hist.am.meridionalHeatTransport.*.nc
@@ -312,7 +315,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
                                   contourLevels, colorbarLabel,
                                   title, xLabel, yLabel, figureName,
                                   xLim=xLimGlobal, yLim=depthLimGlobal,
-                                  invertYAxis=False)
+                                  invertYAxis=False, N=movingAveragePoints)
 
             self._write_xml(filePrefix)
 

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -212,6 +212,9 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
         mainRunName = config.get('runs', 'mainRunName')
         movingAveragePoints = config.getint(self.sectionName,
                                             'movingAveragePoints')
+        movingAveragePointsClimatological = \
+                        config.getint(self.sectionName,
+                                      'movingAveragePointsClimatological')
         colorbarLabel = '[Sv]'
         xLabel = 'latitude [deg]'
         yLabel = 'depth [m]'
@@ -237,7 +240,8 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
             z = self.moc[region]
             plot_vertical_section(config, x, y, z, colormapName,
                                   colorbarLevels, contourLevels, colorbarLabel,
-                                  title, xLabel, yLabel, figureName)
+                                  title, xLabel, yLabel, figureName,
+                                  N=movingAveragePointsClimatological)
 
             caption = '{} Meridional Overturning Streamfunction'.format(region)
             write_image_xml(

--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -107,7 +107,11 @@ class TimeSeriesOHC(AnalysisTask):
         regions = [regions[index] for index in regionIndicesToPlot]
 
         for region in regions:
-            for plotType in ['TZ', 'TAnomalyZ', 'SZ', 'SAnomalyZ', 'OHCZ', 'OHCAnomalyZ', 'OHC', 'OHCAnomaly']:
+            if plotOriginalFields:
+                plotType = ['TZ', 'TAnomalyZ', 'SZ', 'SAnomalyZ', 'OHCZ', 'OHCAnomalyZ', 'OHC', 'OHCAnomaly']
+            else:
+                plotTypes = ['TAnomalyZ', 'SAnomalyZ', 'OHCAnomalyZ', 'OHCAnomaly']
+            for plotType in plotTypes:
                 filePrefix = '{}_{}_{}'.format(plotType, region, mainRunName)
                 self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory, filePrefix))
                 self.filePrefixes[plotType, region] = filePrefix

--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -107,25 +107,11 @@ class TimeSeriesOHC(AnalysisTask):
         regions = [regions[index] for index in regionIndicesToPlot]
 
         for region in regions:
-            filePrefix = 'TAnomalyZ_{}_{}'.format(region, mainRunName)
-            self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
-                                                            filePrefix))
-            self.filePrefixes[0, region] = filePrefix
+            for plotType in ['TZ', 'TAnomalyZ', 'SZ', 'SAnomalyZ', 'OHCZ', 'OHCAnomalyZ', 'OHC', 'OHCAnomaly']:
+                filePrefix = '{}_{}_{}'.format(plotType, region, mainRunName)
+                self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory, filePrefix))
+                self.filePrefixes[plotType, region] = filePrefix
 
-            filePrefix = 'SAnomalyZ_{}_{}'.format(region, mainRunName)
-            self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
-                                                            filePrefix))
-            self.filePrefixes[1, region] = filePrefix
-
-            filePrefix = 'OHCAnomalyZ_{}_{}'.format(region, mainRunName)
-            self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
-                                                            filePrefix))
-            self.filePrefixes[2, region] = filePrefix
-
-            filePrefix = 'OHCAnomaly_{}_{}'.format(region, mainRunName)
-            self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
-                                                        filePrefix))
-            self.filePrefixes[3, region] = filePrefix
         return  # }}}
 
     def run(self):  # {{{
@@ -158,8 +144,8 @@ class TimeSeriesOHC(AnalysisTask):
         compareWithObservations = config.getboolean(configSectionName,
                                                     'compareWithObservations')
 
-        movingAveragePoints = config.getint(configSectionName,
-                                            'movingAveragePoints')
+        movingAveragePointsTimeSeries = config.getint(configSectionName,
+                                                      'movingAveragePointsTimeSeries')
 
         movingAveragePointsHovmoller = config.getint(configSectionName,
                                                      'movingAveragePointsHovmoller')
@@ -250,7 +236,6 @@ class TimeSeriesOHC(AnalysisTask):
                 variableList=[avgTemperatureVarName, avgSalinityVarName],
                 startDate=startDateFirstYear,
                 endDate=endDateFirstYear)
-
             firstYearAvgLayerTemperature = dsFirstYear[avgTemperatureVarName]
             firstYearAvgLayerSalinity = dsFirstYear[avgSalinityVarName]
         else:
@@ -339,9 +324,7 @@ class TimeSeriesOHC(AnalysisTask):
 
             title = 'Temperature Anomaly, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
 
-            figureName = '{}/TAnomalyZ_{}_{}.png'.format(self.plotsDirectory,
-                                                         region,
-                                                         mainRunName)
+            figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['TAnomalyZ', region])
 
             (colormapName, colorbarLevels) = setup_colormap(config,
                                                             configSectionName,
@@ -358,11 +341,10 @@ class TimeSeriesOHC(AnalysisTask):
                                   figureName, linewidths=1, xArrayIsTime=True,
                                   N=movingAveragePointsHovmoller, calendar=calendar)
 
-            filePrefix = self.filePrefixes[0, region]
             caption = 'Trend of {} Temperature Anomaly vs depth from Year 0001'.format(region)
             write_image_xml(
                 config=config,
-                filePrefix=filePrefix,
+                filePrefix=self.filePrefixes['TAnomalyZ', region],
                 componentName='Ocean',
                 componentSubdirectory='ocean',
                 galleryGroup='Trends vs Depth',
@@ -377,9 +359,7 @@ class TimeSeriesOHC(AnalysisTask):
 
                 title = 'Temperature, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
 
-                figureName = '{}/TZ_{}_{}.png'.format(self.plotsDirectory,
-                                                      region,
-                                                      mainRunName)
+                figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['TZ', region])
 
                 (colormap, colorbarLevels) = setup_colormap(config,
                                                             configSectionName,
@@ -403,9 +383,7 @@ class TimeSeriesOHC(AnalysisTask):
 
             colorbarLabel = '[PSU]'
 
-            figureName = '{}/SAnomalyZ_{}_{}.png'.format(self.plotsDirectory,
-                                                         region,
-                                                         mainRunName)
+            figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['SAnomalyZ', region])
 
             (colormapName, colorbarLevels) = setup_colormap(config,
                                                             configSectionName,
@@ -422,11 +400,10 @@ class TimeSeriesOHC(AnalysisTask):
                                   figureName, linewidths=1, xArrayIsTime=True,
                                   N=movingAveragePointsHovmoller, calendar=calendar)
 
-            filePrefix = self.filePrefixes[1, region]
             caption = 'Trend of {} Salinity Anomaly vs depth from Year 0001'.format(region)
             write_image_xml(
                 config=config,
-                filePrefix=filePrefix,
+                filePrefix=self.filePrefixes['SAnomalyZ', region],
                 componentName='Ocean',
                 componentSubdirectory='ocean',
                 galleryGroup='Trends vs Depth',
@@ -441,9 +418,7 @@ class TimeSeriesOHC(AnalysisTask):
 
                 title = 'Salinity, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
 
-                figureName = '{}/SZ_{}_{}.png'.format(self.plotsDirectory,
-                                                      region,
-                                                      mainRunName)
+                figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['SZ', region])
 
                 (colormapName, colorbarLevels) = setup_colormap(config,
                                                                 configSectionName,
@@ -468,9 +443,7 @@ class TimeSeriesOHC(AnalysisTask):
 
             colorbarLabel = '[x$10^{22}$ J]'
 
-            figureName = '{}/OHCAnomalyZ_{}_{}.png'.format(self.plotsDirectory,
-                                                   region,
-                                                   mainRunName)
+            figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['OHCAnomalyZ', region])
             
             (colormap, colorbarLevels) = setup_colormap(config,
                                                         configSectionName,
@@ -487,11 +460,10 @@ class TimeSeriesOHC(AnalysisTask):
                                   figureName, linewidths=1, xArrayIsTime=True,
                                   N=movingAveragePointsHovmoller, calendar=calendar)
 
-            filePrefix = self.filePrefixes[2, region]
             caption = 'Trend of {} OHC Anomaly vs depth from Year 0001'.format(region)
             write_image_xml(
                 config=config,
-                filePrefix=filePrefix,
+                filePrefix=self.filePrefixes['OHCAnomalyZ', region],
                 componentName='Ocean',
                 componentSubdirectory='ocean',
                 galleryGroup='Trends vs Depth',
@@ -507,9 +479,7 @@ class TimeSeriesOHC(AnalysisTask):
 
                 title = 'OHC, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
 
-                figureName = '{}/OHCZ_{}_{}.png'.format(self.plotsDirectory,
-                                                        region,
-                                                        mainRunName)
+                figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['OHCZ', region])
             
                 (colormap, colorbarLevels) = setup_colormap(config,
                                                             configSectionName,
@@ -524,6 +494,7 @@ class TimeSeriesOHC(AnalysisTask):
                                       colorbarLabel, title, xLabel, yLabel,
                                       figureName, linewidths=1, xArrayIsTime=True,
                                       N=movingAveragePointsHovmoller, calendar=calendar)
+
 
             # Now plot OHC timeseries
 
@@ -548,9 +519,7 @@ class TimeSeriesOHC(AnalysisTask):
                     ' 2000m-bottom (-.) \n {}'.format(plotTitles[regionIndex],
                                                       mainRunName)
 
-            figureName = '{}/OHCAnomaly_{}_{}.png'.format(self.plotsDirectory,
-                                                   region,
-                                                   mainRunName)
+            figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['OHCAnomaly', region])
 
             if preprocessedReferenceRunName != 'None':
                 # these preprocessed data are OHC *anomalies*
@@ -566,7 +535,7 @@ class TimeSeriesOHC(AnalysisTask):
                                                   ohcPreprocessed700m,
                                                   ohcPreprocessed2000m,
                                                   ohcPreprocessedBottom],
-                                         movingAveragePoints, title,
+                                         movingAveragePointsTimeSeries, title,
                                          xLabel, yLabel, figureName,
                                          lineStyles=['r-', 'r-', 'r--', 'r-.',
                                                      'b-', 'b-', 'b--', 'b-.'],
@@ -578,18 +547,17 @@ class TimeSeriesOHC(AnalysisTask):
                     preprocessedReferenceRunName == 'None'):
                 timeseries_analysis_plot(config, [ohcAnomalyTotal, ohcAnomaly700m, ohcAnomaly2000m,
                                                   ohcAnomalyBottom],
-                                         movingAveragePoints, title,
+                                         movingAveragePointsTimeSeries, title,
                                          xLabel, yLabel, figureName,
                                          lineStyles=['r-', 'r-', 'r--', 'r-.'],
                                          lineWidths=[2, 1, 1.5, 1.5],
                                          calendar=calendar)
 
-            filePrefix = self.filePrefixes[3, region]
             caption = 'Running Mean of the Anomaly in {} Ocean Heat Content ' \
                       'from Year 0001'.format(region)
             write_image_xml(
                 config=config,
-                filePrefix=filePrefix,
+                filePrefix=self.filePrefixes['OHCAnomaly', region],
                 componentName='Ocean',
                 componentSubdirectory='ocean',
                 galleryGroup='Time Series',
@@ -610,13 +578,11 @@ class TimeSeriesOHC(AnalysisTask):
                         ' 2000m-bottom (-.) \n {}'.format(plotTitles[regionIndex],
                                                           mainRunName)
                         
-                figureName = '{}/OHC_{}_{}.png'.format(self.plotsDirectory,
-                                                       region,
-                                                       mainRunName)
+                figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['OHC', region])
 
                 timeseries_analysis_plot(config, [ohcTotal, ohc700m, ohc2000m,
                                                   ohcBottom],
-                                         movingAveragePoints, title,
+                                         movingAveragePointsTimeSeries, title,
                                          xLabel, yLabel, figureName,
                                          lineStyles=['r-', 'r-', 'r--', 'r-.'],
                                          lineWidths=[2, 1, 1.5, 1.5],

--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -310,108 +310,20 @@ class TimeSeriesOHC(AnalysisTask):
         for regionIndex in regionIndicesToPlot:
             region = regions[regionIndex]
 
-            # Plot OHC, temperature, and salinity (and their anomalies) as
-            # heatmaps on time/depth plots
+            # Plot temperature, salinity and OHC anomalies (and full fields)
+            # trends with depth
 
+            #  First T vs depth/time
             x = ds.Time.values
             y = depth
-
-            if plotOriginalFields:
-                #ohc = dsOHC.ohc.isel(nOceanRegionsTmp=0)  #.isel(nOceanRegionsTmp=regionIndex)
-                ohc = dsOHC.ohc.isel(nOceanRegionsTmp=regionIndex)
-                ohcScaled = unitsScalefactor*ohc
-
-                title = 'OHC, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
-
-                colorbarLabel = '[x$10^{22}$ J]'
-                xLabel = 'Time [years]'
-                yLabel = 'Depth [m]'
-
-                figureName = '{}/OHCZ_{}_{}.png'.format(self.plotsDirectory,
-                                                        region,
-                                                        mainRunName)
-            
-                (colormap, colorbarLevels) = setup_colormap(config,
-                                                            configSectionName,
-                                                            suffix='OHC')
-
-                contourLevels = config.getExpression(configSectionName,
-                                                     'contourLevels{}'.format('OHC'),
-                                                     usenumpyfunc=True)
-
-                z = ohcScaled.transpose()
-
-                plot_vertical_section(config, x, y, z,
-                                      colormap, colorbarLevels, contourLevels,
-                                      colorbarLabel, title, xLabel, yLabel,
-                                      figureName, linewidths=1, xArrayIsTime=True,
-                                      N=movingAveragePointsHovmoller, calendar=calendar)
-
-            #ohcAnomaly = dsOHC.ohcAnomaly.isel(nOceanRegionsTmp=0)  #.isel(nOceanRegionsTmp=regionIndex)
-            ohcAnomaly = dsOHC.ohcAnomaly.isel(nOceanRegionsTmp=regionIndex)
-            ohcAnomalyScaled = unitsScalefactor*ohcAnomaly            
-
-            title = 'OHC Anomaly, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
-
-            colorbarLabel = '[x$10^{22}$ J]'
-            xLabel = 'Time [years]'
-            yLabel = 'Depth [m]'
-
-            figureName = '{}/OHCAnomalyZ_{}_{}.png'.format(self.plotsDirectory,
-                                                   region,
-                                                   mainRunName)
-            
-            (colormap, colorbarLevels) = setup_colormap(config,
-                                                        configSectionName,
-                                                        suffix='OHCAnomaly')
-
-            contourLevels = \
-                config.getExpression(configSectionName,
-                                     'contourLevels{}'.format('OHCAnomaly'),
-                                     usenumpyfunc=True)
-
-            z = ohcAnomalyScaled.transpose()
-
-            plot_vertical_section(config, x, y, z,
-                                  colormap, colorbarLevels, contourLevels,
-                                  colorbarLabel, title, xLabel, yLabel,
-                                  figureName, linewidths=1, xArrayIsTime=True,
-                                  N=movingAveragePointsHovmoller, calendar=calendar)
-
-            if plotOriginalFields:
-                title = 'Average Layer Temperature, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
-
-                colorbarLabel = '[$^\circ$ C]'
-                xLabel = 'Time [years]'
-                yLabel = 'Depth [m]'
-
-                figureName = '{}/TZ_{}_{}.png'.format(self.plotsDirectory,
-                                                      region,
-                                                      mainRunName)
-
-                (colormap, colorbarLevels) = setup_colormap(config,
-                                                            configSectionName,
-                                                            suffix='Temperature')
-
-                contourLevels = config.getExpression(configSectionName,
-                                                     'contourLevels{}'.format('Temperature'),
-                                                     usenumpyfunc=True)
-
-                #z = ds[avgTemperatureVarName].isel(nOceanRegionsTmp=0)  #.isel(nOceanRegionsTmp=regionIndex)
-                z = ds[avgTemperatureVarName].isel(nOceanRegionsTmp=regionIndex)
-                z = z.transpose()
-
-                plot_vertical_section(config, x, y, z,
-                                      colormap, colorbarLevels, contourLevels,
-                                      colorbarLabel, title, xLabel, yLabel,
-                                      figureName, linewidths=1, xArrayIsTime=True,
-                                      N=movingAveragePointsHovmoller, calendar=calendar)
-            
-            title = 'Average Layer Temperature Anomaly, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
+            z = ds.avgLayerTemperatureAnomaly.isel(nOceanRegionsTmp=regionIndex)
+            z = z.transpose()
 
             colorbarLabel = '[$^\circ$ C]'
             xLabel = 'Time [years]'
             yLabel = 'Depth [m]'
+
+            title = 'Temperature Anomaly, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
 
             figureName = '{}/TAnomalyZ_{}_{}.png'.format(self.plotsDirectory,
                                                          region,
@@ -426,10 +338,6 @@ class TimeSeriesOHC(AnalysisTask):
                                      'contourLevels{}'.format('TemperatureAnomaly'),
                                      usenumpyfunc=True)
    
-            #z = ds.avgLayerTemperatureAnomaly.isel(nOceanRegionsTmp=0)  #.isel(nOceanRegionsTmp=regionIndex)
-            z = ds.avgLayerTemperatureAnomaly.isel(nOceanRegionsTmp=regionIndex)
-            z = z.transpose()
-
             plot_vertical_section(config, x, y, z,
                                   colormapName, colorbarLevels, contourLevels,
                                   colorbarLabel, title, xLabel, yLabel,
@@ -437,40 +345,36 @@ class TimeSeriesOHC(AnalysisTask):
                                   N=movingAveragePointsHovmoller, calendar=calendar)
              
             if plotOriginalFields:
-                title = 'Average Layer Salinity, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
+                z = ds[avgTemperatureVarName].isel(nOceanRegionsTmp=regionIndex)
+                z = z.transpose()
 
-                colorbarLabel = '[PSU]'
-                xLabel = 'Time [years]'
-                yLabel = 'Depth [m]'
+                title = 'Temperature, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
 
-                figureName = '{}/SZ_{}_{}.png'.format(self.plotsDirectory,
+                figureName = '{}/TZ_{}_{}.png'.format(self.plotsDirectory,
                                                       region,
                                                       mainRunName)
 
-                (colormapName, colorbarLevels) = setup_colormap(config,
-                                                                configSectionName,
-                                                                suffix='Salinity')
-  
+                (colormap, colorbarLevels) = setup_colormap(config,
+                                                            configSectionName,
+                                                            suffix='Temperature')
+
                 contourLevels = config.getExpression(configSectionName,
-                                                     'contourLevels{}'.format('Salinity'),
+                                                     'contourLevels{}'.format('Temperature'),
                                                      usenumpyfunc=True)
 
-                #z = ds[avgSalinityVarName].isel(nOceanRegionsTmp=0)  #.isel(nOceanRegionsTmp=regionIndex)
-                z = ds[avgSalinityVarName].isel(nOceanRegionsTmp=regionIndex)
-                z = z.transpose()
-
                 plot_vertical_section(config, x, y, z,
-                                      colormapName, colorbarLevels, contourLevels,
+                                      colormap, colorbarLevels, contourLevels,
                                       colorbarLabel, title, xLabel, yLabel,
                                       figureName, linewidths=1, xArrayIsTime=True,
                                       N=movingAveragePointsHovmoller, calendar=calendar)
             
+            #  Second S vs depth/time
+            z = ds.avgLayerSalinityAnomaly.isel(nOceanRegionsTmp=regionIndex)
+            z = z.transpose()
 
-            title = 'Average Layer Salinity Anomaly, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
+            title = 'Salinity Anomaly, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
 
             colorbarLabel = '[PSU]'
-            xLabel = 'Time [years]'
-            yLabel = 'Depth [m]'
 
             figureName = '{}/SAnomalyZ_{}_{}.png'.format(self.plotsDirectory,
                                                          region,
@@ -485,58 +389,106 @@ class TimeSeriesOHC(AnalysisTask):
                                      'contourLevels{}'.format('SalinityAnomaly'),
                                      usenumpyfunc=True)
 
-            #z = ds.avgLayerSalinityAnomaly.isel(nOceanRegionsTmp=0)  #.isel(nOceanRegionsTmp=regionIndex)
-            z = ds.avgLayerSalinityAnomaly.isel(nOceanRegionsTmp=regionIndex)
-            z = z.transpose()
-
             plot_vertical_section(config, x, y, z,
                                   colormapName, colorbarLevels, contourLevels,
                                   colorbarLabel, title, xLabel, yLabel,
                                   figureName, linewidths=1, xArrayIsTime=True,
                                   N=movingAveragePointsHovmoller, calendar=calendar)
 
+            if plotOriginalFields:
+                z = ds[avgSalinityVarName].isel(nOceanRegionsTmp=regionIndex)
+                z = z.transpose()
+
+                title = 'Salinity, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
+
+                figureName = '{}/SZ_{}_{}.png'.format(self.plotsDirectory,
+                                                      region,
+                                                      mainRunName)
+
+                (colormapName, colorbarLevels) = setup_colormap(config,
+                                                                configSectionName,
+                                                                suffix='Salinity')
+  
+                contourLevels = config.getExpression(configSectionName,
+                                                     'contourLevels{}'.format('Salinity'),
+                                                     usenumpyfunc=True)
+
+                plot_vertical_section(config, x, y, z,
+                                      colormapName, colorbarLevels, contourLevels,
+                                      colorbarLabel, title, xLabel, yLabel,
+                                      figureName, linewidths=1, xArrayIsTime=True,
+                                      N=movingAveragePointsHovmoller, calendar=calendar)
+
+            #  Third OHC vs depth/time
+            ohcAnomaly = dsOHC.ohcAnomaly.isel(nOceanRegionsTmp=regionIndex)
+            ohcAnomalyScaled = unitsScalefactor*ohcAnomaly            
+            z = ohcAnomalyScaled.transpose()
+
+            title = 'OHC Anomaly, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
+
+            colorbarLabel = '[x$10^{22}$ J]'
+
+            figureName = '{}/OHCAnomalyZ_{}_{}.png'.format(self.plotsDirectory,
+                                                   region,
+                                                   mainRunName)
+            
+            (colormap, colorbarLevels) = setup_colormap(config,
+                                                        configSectionName,
+                                                        suffix='OHCAnomaly')
+
+            contourLevels = \
+                config.getExpression(configSectionName,
+                                     'contourLevels{}'.format('OHCAnomaly'),
+                                     usenumpyfunc=True)
+
+            plot_vertical_section(config, x, y, z,
+                                  colormap, colorbarLevels, contourLevels,
+                                  colorbarLabel, title, xLabel, yLabel,
+                                  figureName, linewidths=1, xArrayIsTime=True,
+                                  N=movingAveragePointsHovmoller, calendar=calendar)
+
+            if plotOriginalFields:
+                ohc = dsOHC.ohc.isel(nOceanRegionsTmp=regionIndex)
+                ohcScaled = unitsScalefactor*ohc
+                z = ohcScaled.transpose()
+
+                title = 'OHC, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
+
+                figureName = '{}/OHCZ_{}_{}.png'.format(self.plotsDirectory,
+                                                        region,
+                                                        mainRunName)
+            
+                (colormap, colorbarLevels) = setup_colormap(config,
+                                                            configSectionName,
+                                                            suffix='OHC')
+
+                contourLevels = config.getExpression(configSectionName,
+                                                     'contourLevels{}'.format('OHC'),
+                                                     usenumpyfunc=True)
+
+                plot_vertical_section(config, x, y, z,
+                                      colormap, colorbarLevels, contourLevels,
+                                      colorbarLabel, title, xLabel, yLabel,
+                                      figureName, linewidths=1, xArrayIsTime=True,
+                                      N=movingAveragePointsHovmoller, calendar=calendar)
+
             # Now plot OHC timeseries
 
             # OHC over 0-bottom depth range:
-            ohcTotal = unitsScalefactor*ohc.sum('nVertLevels')
             ohcAnomalyTotal = unitsScalefactor*ohcAnomaly.sum('nVertLevels')
 
             # OHC over 0-700m depth range:
-            ohc700m = unitsScalefactor*ohc[:, 0:k700m].sum('nVertLevels')
             ohcAnomaly700m = unitsScalefactor*ohcAnomaly[:, 0:k700m].sum('nVertLevels')
 
             # OHC over 700m-2000m depth range:
-            ohc2000m = \
-                unitsScalefactor*ohc[:, k700m+1:k2000m].sum('nVertLevels')
             ohcAnomaly2000m = \
                 unitsScalefactor*ohcAnomaly[:, k700m+1:k2000m].sum('nVertLevels')
 
             # OHC over 2000m-bottom depth range:
-            ohcBottom = unitsScalefactor*ohc[:, k2000m+1:kbtm].sum('nVertLevels')
             ohcAnomalyBottom = unitsScalefactor*ohcAnomaly[:, k2000m+1:kbtm].sum('nVertLevels')
 
             xLabel = 'Time [years]'
             yLabel = '[x$10^{22}$ J]'
-
-            if plotOriginalFields:
-
-                title = 'OHC, {}, 0-bottom (thick-),' \
-                        ' 0-700m (thin-), 700-2000m (--),' \
-                        ' 2000m-bottom (-.) \n {}'.format(plotTitles[regionIndex],
-                                                          mainRunName)
-                        
-                figureName = '{}/OHC_{}_{}.png'.format(self.plotsDirectory,
-                                                       region,
-                                                       mainRunName)
-
-                timeseries_analysis_plot(config, [ohcTotal, ohc700m, ohc2000m,
-                                                  ohcBottom],
-                                         movingAveragePoints, title,
-                                         xLabel, yLabel, figureName,
-                                         lineStyles=['r-', 'r-', 'r--', 'r-.'],
-                                         lineWidths=[2, 1, 1.5, 1.5],
-                                         calendar=calendar)
-
 
             title = 'OHC Anomaly, {}, 0-bottom (thick-),' \
                     ' 0-700m (thin-), 700-2000m (--),' \
@@ -592,6 +544,30 @@ class TimeSeriesOHC(AnalysisTask):
                 thumbnailDescription=u'{} ΔOHC'.format(region),
                 imageDescription=caption,
                 imageCaption=caption)
+
+            if plotOriginalFields:
+                ohcTotal = unitsScalefactor*ohc.sum('nVertLevels')
+                ohc700m = unitsScalefactor*ohc[:, 0:k700m].sum('nVertLevels')
+                ohc2000m = \
+                    unitsScalefactor*ohc[:, k700m+1:k2000m].sum('nVertLevels')
+                ohcBottom = unitsScalefactor*ohc[:, k2000m+1:kbtm].sum('nVertLevels')
+
+                title = 'OHC, {}, 0-bottom (thick-),' \
+                        ' 0-700m (thin-), 700-2000m (--),' \
+                        ' 2000m-bottom (-.) \n {}'.format(plotTitles[regionIndex],
+                                                          mainRunName)
+                        
+                figureName = '{}/OHC_{}_{}.png'.format(self.plotsDirectory,
+                                                       region,
+                                                       mainRunName)
+
+                timeseries_analysis_plot(config, [ohcTotal, ohc700m, ohc2000m,
+                                                  ohcBottom],
+                                         movingAveragePoints, title,
+                                         xLabel, yLabel, figureName,
+                                         lineStyles=['r-', 'r-', 'r--', 'r-.'],
+                                         lineWidths=[2, 1, 1.5, 1.5],
+                                         calendar=calendar)
         # }}}
 
 

--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -343,14 +343,15 @@ class TimeSeriesOHC(AnalysisTask):
                 config.getExpression(configSectionName,
                                      'contourLevels{}'.format('TemperatureAnomaly'),
                                      usenumpyfunc=True)
-   
+
             plot_vertical_section(config, x, y, z,
                                   colormapName, colorbarLevels, contourLevels,
                                   colorbarLabel, title, xLabel, yLabel,
                                   figureName, linewidths=1, xArrayIsTime=True,
                                   N=movingAveragePointsHovmoller, calendar=calendar)
 
-            caption = 'Trend of {} Temperature Anomaly vs depth from Year 0001'.format(region)
+            caption = 'Trend of {} Temperature Anomaly vs depth from Year ' \
+                      '{}'.format(region, simulationStartTime[0:4])
             write_image_xml(
                 config=config,
                 filePrefix=self.filePrefixes['TAnomalyZ', region],
@@ -361,7 +362,7 @@ class TimeSeriesOHC(AnalysisTask):
                 thumbnailDescription=u'{} ΔT'.format(region),
                 imageDescription=caption,
                 imageCaption=caption)
-             
+
             if plotOriginalFields:
                 z = ds[avgTemperatureVarName].isel(nOceanRegionsTmp=regionIndex)
                 z = z.transpose()
@@ -392,11 +393,11 @@ class TimeSeriesOHC(AnalysisTask):
                     componentSubdirectory='ocean',
                     galleryGroup='Trends vs Depth',
                     groupLink='trendsvsdepth',
-                    thumbnailDescription=u'{} ΔT'.format(region),
+                    thumbnailDescription=u'{} T'.format(region),
                     imageDescription=caption,
                     imageCaption=caption)
 
-            
+
             #  Second S vs depth/time
             z = ds.avgLayerSalinityAnomaly.isel(nOceanRegionsTmp=regionIndex)
             z = z.transpose()
@@ -410,7 +411,7 @@ class TimeSeriesOHC(AnalysisTask):
             (colormapName, colorbarLevels) = setup_colormap(config,
                                                             configSectionName,
                                                             suffix='SalinityAnomaly')
-   
+
             contourLevels = \
                 config.getExpression(configSectionName,
                                      'contourLevels{}'.format('SalinityAnomaly'),
@@ -422,7 +423,8 @@ class TimeSeriesOHC(AnalysisTask):
                                   figureName, linewidths=1, xArrayIsTime=True,
                                   N=movingAveragePointsHovmoller, calendar=calendar)
 
-            caption = 'Trend of {} Salinity Anomaly vs depth from Year 0001'.format(region)
+            caption = 'Trend of {} Salinity Anomaly vs depth from Year ' \
+                      '{}'.format(region, simulationStartTime[0:4])
             write_image_xml(
                 config=config,
                 filePrefix=self.filePrefixes['SAnomalyZ', region],
@@ -445,7 +447,7 @@ class TimeSeriesOHC(AnalysisTask):
                 (colormapName, colorbarLevels) = setup_colormap(config,
                                                                 configSectionName,
                                                                 suffix='Salinity')
-  
+
                 contourLevels = config.getExpression(configSectionName,
                                                      'contourLevels{}'.format('Salinity'),
                                                      usenumpyfunc=True)
@@ -464,14 +466,14 @@ class TimeSeriesOHC(AnalysisTask):
                     componentSubdirectory='ocean',
                     galleryGroup='Trends vs Depth',
                     groupLink='trendsvsdepth',
-                    thumbnailDescription=u'{} ΔS'.format(region),
+                    thumbnailDescription=u'{} S'.format(region),
                     imageDescription=caption,
                     imageCaption=caption)
 
 
             #  Third OHC vs depth/time
             ohcAnomaly = dsOHC.ohcAnomaly.isel(nOceanRegionsTmp=regionIndex)
-            ohcAnomalyScaled = unitsScalefactor*ohcAnomaly            
+            ohcAnomalyScaled = unitsScalefactor*ohcAnomaly
             z = ohcAnomalyScaled.transpose()
 
             title = 'OHC Anomaly, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
@@ -479,7 +481,7 @@ class TimeSeriesOHC(AnalysisTask):
             colorbarLabel = '[x$10^{22}$ J]'
 
             figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['OHCAnomalyZ', region])
-            
+
             (colormap, colorbarLevels) = setup_colormap(config,
                                                         configSectionName,
                                                         suffix='OHCAnomaly')
@@ -495,7 +497,8 @@ class TimeSeriesOHC(AnalysisTask):
                                   figureName, linewidths=1, xArrayIsTime=True,
                                   N=movingAveragePointsHovmoller, calendar=calendar)
 
-            caption = 'Trend of {} OHC Anomaly vs depth from Year 0001'.format(region)
+            caption = 'Trend of {} OHC Anomaly vs depth from Year ' \
+                      '{}'.format(region, simulationStartTime[0:4])
             write_image_xml(
                 config=config,
                 filePrefix=self.filePrefixes['OHCAnomalyZ', region],
@@ -515,7 +518,7 @@ class TimeSeriesOHC(AnalysisTask):
                 title = 'OHC, {} \n {}'.format(plotTitles[regionIndex], mainRunName)
 
                 figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['OHCZ', region])
-            
+
                 (colormap, colorbarLevels) = setup_colormap(config,
                                                             configSectionName,
                                                             suffix='OHC')
@@ -538,7 +541,7 @@ class TimeSeriesOHC(AnalysisTask):
                     componentSubdirectory='ocean',
                     galleryGroup='Trends vs Depth',
                     groupLink='trendsvsdepth',
-                    thumbnailDescription=u'{} ΔOHC'.format(region),
+                    thumbnailDescription=u'{} OHC'.format(region),
                     imageDescription=caption,
                     imageCaption=caption)
 
@@ -601,7 +604,7 @@ class TimeSeriesOHC(AnalysisTask):
                                          calendar=calendar)
 
             caption = 'Running Mean of the Anomaly in {} Ocean Heat Content ' \
-                      'from Year 0001'.format(region)
+                      'from Year {}'.format(region, simulationStartTime[0:4])
             write_image_xml(
                 config=config,
                 filePrefix=self.filePrefixes['OHCAnomaly', region],
@@ -624,7 +627,7 @@ class TimeSeriesOHC(AnalysisTask):
                         ' 0-700m (thin-), 700-2000m (--),' \
                         ' 2000m-bottom (-.) \n {}'.format(plotTitles[regionIndex],
                                                           mainRunName)
-                        
+
                 figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefixes['OHC', region])
 
                 timeseries_analysis_plot(config, [ohcTotal, ohc700m, ohc2000m,
@@ -643,7 +646,7 @@ class TimeSeriesOHC(AnalysisTask):
                     componentSubdirectory='ocean',
                     galleryGroup='Time Series',
                     groupLink='timeseries',
-                    thumbnailDescription=u'{} ΔOHC'.format(region),
+                    thumbnailDescription=u'{} OHC'.format(region),
                     imageDescription=caption,
                     imageCaption=caption)
 

--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -106,11 +106,16 @@ class TimeSeriesOHC(AnalysisTask):
 
         regions = [regions[index] for index in regionIndicesToPlot]
 
+        configSectionName = 'timeSeriesOHC'
+        plotOriginalFields = config.getboolean(configSectionName,
+                                               'plotOriginalFields')
+
+        if plotOriginalFields:
+            plotTypes = ['TZ', 'TAnomalyZ', 'SZ', 'SAnomalyZ', 'OHCZ', 'OHCAnomalyZ', 'OHC', 'OHCAnomaly']
+        else:
+            plotTypes = ['TAnomalyZ', 'SAnomalyZ', 'OHCAnomalyZ', 'OHCAnomaly']
+
         for region in regions:
-            if plotOriginalFields:
-                plotType = ['TZ', 'TAnomalyZ', 'SZ', 'SAnomalyZ', 'OHCZ', 'OHCAnomalyZ', 'OHC', 'OHCAnomaly']
-            else:
-                plotTypes = ['TAnomalyZ', 'SAnomalyZ', 'OHCAnomalyZ', 'OHCAnomaly']
             for plotType in plotTypes:
                 filePrefix = '{}_{}_{}'.format(plotType, region, mainRunName)
                 self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory, filePrefix))
@@ -378,6 +383,19 @@ class TimeSeriesOHC(AnalysisTask):
                                       colorbarLabel, title, xLabel, yLabel,
                                       figureName, linewidths=1, xArrayIsTime=True,
                                       N=movingAveragePointsHovmoller, calendar=calendar)
+
+                caption = 'Trend of {} Temperature vs depth'.format(region)
+                write_image_xml(
+                    config=config,
+                    filePrefix=self.filePrefixes['TZ', region],
+                    componentName='Ocean',
+                    componentSubdirectory='ocean',
+                    galleryGroup='Trends vs Depth',
+                    groupLink='trendsvsdepth',
+                    thumbnailDescription=u'{} ΔT'.format(region),
+                    imageDescription=caption,
+                    imageCaption=caption)
+
             
             #  Second S vs depth/time
             z = ds.avgLayerSalinityAnomaly.isel(nOceanRegionsTmp=regionIndex)
@@ -437,6 +455,19 @@ class TimeSeriesOHC(AnalysisTask):
                                       colorbarLabel, title, xLabel, yLabel,
                                       figureName, linewidths=1, xArrayIsTime=True,
                                       N=movingAveragePointsHovmoller, calendar=calendar)
+
+                caption = 'Trend of {} Salinity vs depth'.format(region)
+                write_image_xml(
+                    config=config,
+                    filePrefix=self.filePrefixes['SZ', region],
+                    componentName='Ocean',
+                    componentSubdirectory='ocean',
+                    galleryGroup='Trends vs Depth',
+                    groupLink='trendsvsdepth',
+                    thumbnailDescription=u'{} ΔS'.format(region),
+                    imageDescription=caption,
+                    imageCaption=caption)
+
 
             #  Third OHC vs depth/time
             ohcAnomaly = dsOHC.ohcAnomaly.isel(nOceanRegionsTmp=regionIndex)
@@ -498,6 +529,18 @@ class TimeSeriesOHC(AnalysisTask):
                                       colorbarLabel, title, xLabel, yLabel,
                                       figureName, linewidths=1, xArrayIsTime=True,
                                       N=movingAveragePointsHovmoller, calendar=calendar)
+
+                caption = 'Trend of {} OHC vs depth'.format(region)
+                write_image_xml(
+                    config=config,
+                    filePrefix=self.filePrefixes['OHCZ', region],
+                    componentName='Ocean',
+                    componentSubdirectory='ocean',
+                    galleryGroup='Trends vs Depth',
+                    groupLink='trendsvsdepth',
+                    thumbnailDescription=u'{} ΔOHC'.format(region),
+                    imageDescription=caption,
+                    imageCaption=caption)
 
 
             # Now plot OHC timeseries
@@ -591,6 +634,20 @@ class TimeSeriesOHC(AnalysisTask):
                                          lineStyles=['r-', 'r-', 'r--', 'r-.'],
                                          lineWidths=[2, 1, 1.5, 1.5],
                                          calendar=calendar)
+
+                caption = 'Running Mean of {} Ocean Heat Content'.format(region)
+                write_image_xml(
+                    config=config,
+                    filePrefix=self.filePrefixes['OHC', region],
+                    componentName='Ocean',
+                    componentSubdirectory='ocean',
+                    galleryGroup='Time Series',
+                    groupLink='timeseries',
+                    thumbnailDescription=u'{} ΔOHC'.format(region),
+                    imageDescription=caption,
+                    imageCaption=caption)
+
+
         # }}}
 
 

--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -107,11 +107,25 @@ class TimeSeriesOHC(AnalysisTask):
         regions = [regions[index] for index in regionIndicesToPlot]
 
         for region in regions:
+            filePrefix = 'TAnomalyZ_{}_{}'.format(region, mainRunName)
+            self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
+                                                            filePrefix))
+            self.filePrefixes[0, region] = filePrefix
+
+            filePrefix = 'SAnomalyZ_{}_{}'.format(region, mainRunName)
+            self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
+                                                            filePrefix))
+            self.filePrefixes[1, region] = filePrefix
+
+            filePrefix = 'OHCAnomalyZ_{}_{}'.format(region, mainRunName)
+            self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
+                                                            filePrefix))
+            self.filePrefixes[2, region] = filePrefix
+
             filePrefix = 'OHCAnomaly_{}_{}'.format(region, mainRunName)
             self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
                                                         filePrefix))
-            self.filePrefixes[region] = filePrefix
-
+            self.filePrefixes[3, region] = filePrefix
         return  # }}}
 
     def run(self):  # {{{
@@ -343,6 +357,19 @@ class TimeSeriesOHC(AnalysisTask):
                                   colorbarLabel, title, xLabel, yLabel,
                                   figureName, linewidths=1, xArrayIsTime=True,
                                   N=movingAveragePointsHovmoller, calendar=calendar)
+
+            filePrefix = self.filePrefixes[0, region]
+            caption = 'Trend of {} Temperature Anomaly vs depth from Year 0001'.format(region)
+            write_image_xml(
+                config=config,
+                filePrefix=filePrefix,
+                componentName='Ocean',
+                componentSubdirectory='ocean',
+                galleryGroup='Trends vs Depth',
+                groupLink='trendsvsdepth',
+                thumbnailDescription=u'{} ΔT'.format(region),
+                imageDescription=caption,
+                imageCaption=caption)
              
             if plotOriginalFields:
                 z = ds[avgTemperatureVarName].isel(nOceanRegionsTmp=regionIndex)
@@ -395,6 +422,19 @@ class TimeSeriesOHC(AnalysisTask):
                                   figureName, linewidths=1, xArrayIsTime=True,
                                   N=movingAveragePointsHovmoller, calendar=calendar)
 
+            filePrefix = self.filePrefixes[1, region]
+            caption = 'Trend of {} Salinity Anomaly vs depth from Year 0001'.format(region)
+            write_image_xml(
+                config=config,
+                filePrefix=filePrefix,
+                componentName='Ocean',
+                componentSubdirectory='ocean',
+                galleryGroup='Trends vs Depth',
+                groupLink='trendsvsdepth',
+                thumbnailDescription=u'{} ΔS'.format(region),
+                imageDescription=caption,
+                imageCaption=caption)
+
             if plotOriginalFields:
                 z = ds[avgSalinityVarName].isel(nOceanRegionsTmp=regionIndex)
                 z = z.transpose()
@@ -446,6 +486,19 @@ class TimeSeriesOHC(AnalysisTask):
                                   colorbarLabel, title, xLabel, yLabel,
                                   figureName, linewidths=1, xArrayIsTime=True,
                                   N=movingAveragePointsHovmoller, calendar=calendar)
+
+            filePrefix = self.filePrefixes[2, region]
+            caption = 'Trend of {} OHC Anomaly vs depth from Year 0001'.format(region)
+            write_image_xml(
+                config=config,
+                filePrefix=filePrefix,
+                componentName='Ocean',
+                componentSubdirectory='ocean',
+                galleryGroup='Trends vs Depth',
+                groupLink='trendsvsdepth',
+                thumbnailDescription=u'{} ΔOHC'.format(region),
+                imageDescription=caption,
+                imageCaption=caption)
 
             if plotOriginalFields:
                 ohc = dsOHC.ohc.isel(nOceanRegionsTmp=regionIndex)
@@ -531,7 +584,7 @@ class TimeSeriesOHC(AnalysisTask):
                                          lineWidths=[2, 1, 1.5, 1.5],
                                          calendar=calendar)
 
-            filePrefix = self.filePrefixes[region]
+            filePrefix = self.filePrefixes[3, region]
             caption = 'Running Mean of the Anomaly in {} Ocean Heat Content ' \
                       'from Year 0001'.format(region)
             write_image_xml(

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -24,6 +24,8 @@ from ..timekeeping.utility import days_to_datetime, date_to_days
 
 from ..constants import constants
 
+import ConfigParser
+
 
 def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                              fileout, lineStyles, lineWidths, calendar,
@@ -897,9 +899,12 @@ def setup_colormap(config, configSectionName, suffix=''):
                                    'colormapIndices{}'.format(suffix),
                                    usenumpyfunc=True)
 
-    colorbarLevels = config.getExpression(configSectionName,
-                                          'colorbarLevels{}'.format(suffix),
-                                          usenumpyfunc=True)
+    try:
+        colorbarLevels = config.getExpression(configSectionName,
+                                              'colorbarLevels{}'.format(suffix),
+                                              usenumpyfunc=True)
+    except(ConfigParser.NoOptionError):
+        colorbarLevels = None
 
     if colorbarLevels is not None:
         # set under/over values based on the first/last indices in the colormap


### PR DESCRIPTION
…HC (both the original fields and their anomalies).

Added the ability to create vertical trends plots (Hovmoller diagrams with depth as the spatial coordinate) of S, T, and OHC anomalies.  Also added the ability to create these plots for S, T, and OHC themselves (and added the ability to create an OHC time series plot in addition to the pre-existing time series plot of the OHC anomaly).  Because the plots of the original fields are of less interest than the anomalies (as they don't have much structure), these plots are optional, with the default being to not create them (set the plotOriginalFields config parameter to True to enable such plots).

NOTE:  there currently is an issue with this code and recent changes to Develop that seem to have broken regional analysis.  As the comment in time_series_ohc.py mentions, there should be a selection by nOceanRegions in order to select the desired region(s), but this currently does not work, since the data object now retrieved has an nOceanRegions dimension of size 1, instead of size 6 as before (nOceanRegions=6 is the Global case, for which I have run all of my tests).

The plots that follow are the ones that I generated from using the code in my original branch for this task;  because of the region analysis issue above (presumably), the corresponding plots created using the T_S_vertical_trends branch do *not* look like these (but should be made to be so before this branch is merged):

![sz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720660-b1d6e4de-9ee5-11e7-8b34-657401b4f2fb.png)

![sanomalyz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720687-ca139740-9ee5-11e7-98e0-31fae15004f7.png)

![tz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720694-d522fbee-9ee5-11e7-8c07-e1bf3a943fdd.png)

![tanomalyz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720697-d7704596-9ee5-11e7-99de-ecb5befcfbc0.png)

![ohcz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720704-e0869086-9ee5-11e7-84ad-15cb27194ac6.png)

![ohcanomalyz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720708-e33c4db6-9ee5-11e7-88af-0c2f2a52bca0.png)

![ohc_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720714-e92a0a74-9ee5-11e7-803f-5f8326455f0b.png)

![ohcanomaly_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720719-ed70b970-9ee5-11e7-9935-5fc9ca9f1404.png)


In order to support moving averaging of the time axis on Hovmoller plots (mainly to remove seasonal variations, as is currently done in time series plots), a moving average option (and various associated config parameters) were added to plot_vertical_sections in plotting.py.  This option is intended mainly for the Hovmoller plots (the S, T, and OHC vertical trends), but it will work for other vertical section plots as well.

The moving averaged versions (over 12 month windows) of the above Hovmoller plots are as follows:

![sz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720833-6123c31c-9ee6-11e7-82d7-ad8989f37b96.png)

![sanomalyz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720835-63d7d6b6-9ee6-11e7-8db0-35cca54afa63.png)

![tz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720841-68cf3416-9ee6-11e7-80b9-d2b9794ad28e.png)

![tanomalyz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720845-6d9d6ddc-9ee6-11e7-8779-09f842d6194e.png)

![ohcz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720864-7dcaa8a0-9ee6-11e7-82a3-d0b8f98012d8.png)

![ohcanomalyz_global_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison](https://user-images.githubusercontent.com/29957141/30720866-7ee54128-9ee6-11e7-9bc8-8a04e4615113.png)


The original Global MOC vertical section plot and the corresponding plot with moving averaging using 11 points are as follows:

![mocglobal_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison_years0001-0050](https://user-images.githubusercontent.com/29957141/30720928-cd6722f8-9ee6-11e7-8213-a0188a259f67.png)

![mocglobal_20170502 beta1_05 a_wcycl1850s ne30_oecv3_icg edison_years0001-0050](https://user-images.githubusercontent.com/29957141/30720933-d5e29d0e-9ee6-11e7-96c0-b57a9d65849a.png)


In addition to the problems with regional analysis mentioned above, there are some things that need to be done to fully integrate the new plots here with the new XML-generation code in the Develop branch.

Also, the name "time_series_ohc" is now a bit of a misnomer, as this task now computes not only time series (for OHC and the OHC anomaly), but also the Hovmoller diagrams.  The name could be changed to something more representative, but I have not made this change as of yet.

Similarly, the name "plot_vertical_sections" is somewhat of a misnomer, as it is now used not only to compute vertical sections, but but also to compute vertical Hovmoller diagrams (and could potentially be used to compute horizontal Hovmoller diagrams, if desired).  Also, the MOC and MHT "vertical sections" computed using this function are not really sections (as in vertical slices of the ocean) but rather averages mapped onto lat/depth planes.  But again, I decided not to change the name of this function as of yet.
