### PR TITLE
Add NCO_PATH_OVERRIDE='No' before NCO calls

### DIFF
--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -353,7 +353,12 @@ def compute_climatologies_with_ncclimo(config, inDirectory, outDirectory,
     sys.stdout.flush()
     sys.stderr.flush()
 
-    subprocess.check_call(args)  # }}}
+    # set an environment variable to make sure we're not using czender's
+    # local version of NCO instead of one we have intentionally loaded
+    env = os.environ.copy()
+    env['NCO_PATH_OVERRIDE'] = 'No'
+
+    subprocess.check_call(args, env=env)  # }}}
 
 
 def get_observation_climatology_file_names(config, fieldName, monthNames,

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -161,6 +161,7 @@ class Remapper(object):
         # throw out the standard output from ESMF_RegridWeightGen, as it's
         # rather verbose but keep stderr
         DEVNULL = open(os.devnull, 'wb')
+
         subprocess.check_call(args, stdout=DEVNULL)
 
         # remove the temporary SCRIP files
@@ -272,7 +273,12 @@ class Remapper(object):
         sys.stdout.flush()
         sys.stderr.flush()
 
-        subprocess.check_call(args)  # }}}
+        # set an environment variable to make sure we're not using czender's
+        # local version of NCO instead of one we have intentionally loaded
+        env = os.environ.copy()
+        env['NCO_PATH_OVERRIDE'] = 'No'
+
+        subprocess.check_call(args, env=env)  # }}}
 
     def remap(self, ds, renormalizationThreshold=None):  # {{{
         '''


### PR DESCRIPTION
This prevents NCO from using @czender's local version of NCO instead of our own NCO version on DOE LCF machines.