### PR TITLE
Update the range for diff in sea ice conc. and thick

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -121,8 +121,8 @@ htmlSubdirectory = html
 #   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
 #   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
 #   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH', 
-#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH', 
+#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH',
+#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH',
 #   'climatologyMapSeaIceThickSH'
 # the following shortcuts exist:
 #   'all' -- all analyses will be run
@@ -305,7 +305,7 @@ plotOriginalFields = False
 compareWithObservations = False
 # list of region indices to plot from the region list in [regions] below
 regionIndicesToPlot = [6]
-# Number of points over which to compute moving average for time series (e.g., 
+# Number of points over which to compute moving average for time series (e.g.,
 #for monthly output, movingAveragePoints=12 corresponds to a 12-month moving
 # average window)
 movingAveragePointsTimeSeries = 12
@@ -583,9 +583,9 @@ colorbarLevelsResult = [0.15, 0.3, 0.5, 0.7, 0.8, 0.85, 0.9, 0.95, 1]
 # colormap for differences
 colormapNameDifference = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 40, 80, 127, 127, 170, 210, 255]
+colormapIndicesDifference = [0, 32, 64, 96, 128, 128, 160, 192, 224, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = [-0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8]
+colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8, 1.]
 
 # Times for comparison times (These should be left unchanged, since
 # observations are only available for these seasons)
@@ -619,9 +619,9 @@ colorbarLevelsResult = [0.15, 0.3, 0.5, 0.7, 0.8, 0.85, 0.9, 0.95, 1]
 # colormap for differences
 colormapNameDifference = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 40, 80, 127, 127, 170, 210, 255]
+colormapIndicesDifference = [0, 32, 64, 96, 128, 128, 160, 192, 224, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = [-0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8]
+colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8, 1.]
 
 # Times for comparison times (These should be left unchanged, since
 # observations are only available for these seasons)
@@ -655,9 +655,9 @@ colorbarLevelsResult = [0, 0.25, 0.5, 1, 1.5, 2, 2.5, 3, 3.5]
 # colormap for differences
 colormapNameDifference = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 40, 80, 127, 127, 170, 210, 255]
+colormapIndicesDifference = [0, 32, 64, 96, 128, 128, 160, 192, 224, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = [-2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5]
+colorbarLevelsDifference = [-3., -2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5, 3.]
 
 # Times for comparison times (These should be left unchanged, since
 # observations are only available for these seasons)
@@ -691,9 +691,9 @@ colorbarLevelsResult = [0, 0.2, 0.4, 0.6, 0.8, 1, 1.5, 2, 2.5]
 # colormap for differences
 colormapNameDifference = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 40, 80, 127, 127, 170, 210, 255]
+colormapIndicesDifference = [0, 32, 64, 96, 128, 128, 160, 192, 224, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = [-2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5]
+colorbarLevelsDifference = [-3., -2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5, 3.]
 
 # Times for comparison times (These should be left unchanged, since
 # observations are only available for these seasons)


### PR DESCRIPTION
The range for sea ice concentration used to go only to +/- 0.8. Now it goes to +/- 1.0.  Sea-ice thickness now goes to +/- 3.0. I have added 2 color levels to each difference plot, so the colors
of each level have changed slightly.