### PR TITLE
Switch from subprocess to multiprocessing

### DIFF
--- a/configs/job_script.default.bash
+++ b/configs/job_script.default.bash
@@ -11,6 +11,8 @@ mpas_analysis_dir="."
 # the number of parallel tasks (anything between 1 and the total number
 # of tasks to run)
 parallel_task_count=8
+# ncclimo can run with 1 (serial) or 12 (bck) threads
+ncclimo_mode=bck
 
 if [ ! -f $run_config_file ]; then
     echo "File $run_config_file not found!"
@@ -33,13 +35,14 @@ cat <<EOF > $job_config_file
 # the number of parallel tasks (1 means tasks run in serial, the default)
 parallelTaskCount = $parallel_task_count
 
-# Prefix on the commnd line before a parallel task (e.g. 'srun -n 1 python')
-# Default is no prefix (run_mpas_analysis is executed directly)
-commandPrefix = $command_prefix
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = $ncclimo_mode
 
 EOF
 
-$mpas_analysis_dir/run_mpas_analysis $run_config_file \
+$command_prefix $mpas_analysis_dir/run_mpas_analysis $run_config_file \
     $job_config_file
 
 # commend this out if you want to keep the config file, e.g. for debugging

--- a/configs/olcf/job_script.olcf.bash
+++ b/configs/olcf/job_script.olcf.bash
@@ -6,7 +6,7 @@
 ##PBS -q debug
 # change number of nodes to change the number of parallel tasks
 # (anything between 1 and the total number of tasks to run)
-#PBS -l nodes=10
+#PBS -l nodes=1
 #PBS -l walltime=1:00:00
 #PBS -A cli115
 #PBS -N mpas_analysis
@@ -28,7 +28,9 @@ command_prefix="aprun -b -N 1 -n 1"
 # containing run_mpas_analysis
 mpas_analysis_dir="."
 # one parallel task per node by default
-parallel_task_count=$PBS_NUM_NODES
+parallel_task_count=12
+# ncclimo can run with 1 (serial) or 12 (bck) threads
+ncclimo_mode=bck
 
 if [ ! -f $run_config_file ]; then
     echo "File $run_config_file not found!"
@@ -52,12 +54,13 @@ cat <<EOF > $job_config_file
 # the number of parallel tasks (1 means tasks run in serial, the default)
 parallelTaskCount = $parallel_task_count
 
-# Prefix on the commnd line before a parallel task (e.g. 'srun -n 1 python')
-# Default is no prefix (run_mpas_analysis is executed directly)
-commandPrefix = $command_prefix
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = $ncclimo_mode
 
 EOF
 
-$mpas_analysis_dir/run_mpas_analysis $run_config_file \
+$command_prefix $mpas_analysis_dir/run_mpas_analysis $run_config_file \
     $job_config_file
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -13,9 +13,7 @@ Top-level script: run_mpas_analysis
 
    run_mpas_analysis.update_generate
    run_mpas_analysis.run_parallel_tasks
-   run_mpas_analysis.launch_tasks
    run_mpas_analysis.wait_for_task
-   run_mpas_analysis.is_running
    run_mpas_analysis.build_analysis_list
    run_mpas_analysis.determine_analyses_to_generate
    run_mpas_analysis.run_analysis
@@ -34,6 +32,7 @@ Base Class
 
    AnalysisTask
    AnalysisTask.setup_and_check
+   AnalysisTask.run_analysis
    AnalysisTask.run
    AnalysisTask.check_generate
    AnalysisTask.check_analysis_enabled

--- a/mpas_analysis/analysis_task_template.py
+++ b/mpas_analysis/analysis_task_template.py
@@ -19,7 +19,7 @@ Instructions for creating a new analysis task:
 5. add new analysis task to run_mpas_analysis under build_analysis_list:
       analyses.append(<component>.MyTask(config, myArg='argValue'))
    This will add a new object of the MyTask class to a list of analysis tasks
-   created in build_analysis_list.  Later on in run_analysis, it will first
+   created in build_analysis_list.  Later on in run_task, it will first
    go through the list to make sure each task needs to be generated
    (by calling check_generate, which is defined in AnalysisTask), then, will
    call setup_and_check on each task (to make sure the appropriate AM is on
@@ -220,7 +220,7 @@ class MyTask(AnalysisTask):  # {{{
                                        self.endDate))
 
         # For climatologies, update the start and end year based on the files
-        # that are actually available 
+        # that are actually available
         # If not analyzing climatologies, delete this line
         changed, self.startYear, self.endYear, self.startDate, self.endDate = \
             update_climatology_bounds_from_file_names(self.inputFiles,
@@ -234,19 +234,19 @@ class MyTask(AnalysisTask):  # {{{
         # images should appear on the webpage.
 
         # Note: because of the way parallel tasks are handled in MPAS-Analysis,
-        # we can't be sure that run() will be called (it might be launched
-        # as a completely separate process) so it is not safe to store a list
-        # of xml files from within run(). The recommended procedure is to
-        # create a list of XML files here during setup_and_check() and possibly
-        # use them during run()
+        # we can't be sure that run_task() will be called (it might be
+        # launched as a completely separate process) so it is not safe to store
+        # a list of xml files from within run_task(). The recommended
+        # procedure is to create a list of XML files here during
+        # setup_and_check() and possibly use them during run_task()
 
         self.xmlFileNames = []
-        
+
         # we also show how to store file prefixes for later use in creating
         # plots
         self.filePrefixes = {}
 
-        # plotParameters is a list of parameters, a stand-ins for whatever 
+        # plotParameters is a list of parameters, a stand-ins for whatever
         # you might want to include in each plot name, for example, seasons or
         # types of observation.
         self.plotParameters = self.config.getExpression(self.taskName,
@@ -261,10 +261,9 @@ class MyTask(AnalysisTask):  # {{{
                                                         filePrefix))
             self.filePrefixes[plotParameter] = filePrefix
 
-
         # }}}
 
-    def run(self):  # {{{
+    def run_task(self):  # {{{
         '''
         The main method of the task that performs the analysis task.
 
@@ -275,9 +274,9 @@ class MyTask(AnalysisTask):  # {{{
 
         # Add the main contents of the analysis task below
 
-        # No need to call AnalysisTask.run() because it doesn't do anything,
-        # so we don't call super(MyTask, self).run(), as we do for other
-        # methods above.
+        # No need to call AnalysisTask.run_task() because it doesn't do
+        # anything, so we don't call super(MyTask, self).run_task(), as we
+        # do for other methods above.
 
         # Here is an example of a call to a local helper method (function),
         # one for each of our plotParameters (e.g. seasons)
@@ -296,15 +295,15 @@ class MyTask(AnalysisTask):  # {{{
     def _make_plot(self, plotParameter, optionalArgument=None):  # {{{
         '''
         Make a simple plot
-        
+
         Parameters
         ----------
         plotParameter : str
             The name of a parameter that is specific to this plot
-            
+
         optionalArgument : <type_goes_here>, optional
             An optional argument
-        
+
         <Performs my favorite subtask>
         '''
 
@@ -320,20 +319,20 @@ class MyTask(AnalysisTask):  # {{{
         # get the file name based on the plot parameter
         filePrefix = self.filePrefixes[plotParameter]
         outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
-       
+
         # make the plot
         x = numpy.linspace(0, 1, 1000)
         plt.plot(x, x**2)
         # save the plot to the output file
         plt.savefig(outFileName)
-        
+
         # here's an example of how you would create an XML file for this plot
         # with the appropriate entries.  Some notes:
         # * Gallery groups typically represent all the analysis from a task,
         #   or sometimes from multiple tasks
         # * A gallery might be for just for one set of observations, one
         #   season, etc., depending on what makes sense
-        # * Within each gallery, there is one plot for each value in 
+        # * Within each gallery, there is one plot for each value in
         #   'plotParameters', with a corresponding caption and short thumbnail
         #   description
         caption = 'Plot of x^2 with plotParamter: {}'.format(plotParameter)
@@ -350,8 +349,8 @@ class MyTask(AnalysisTask):  # {{{
             imageDescription=caption,
             imageCaption=caption)
 
-        
-        # 
+
+        #
         # }}}
 
 # }}}

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -17,7 +17,7 @@ from ..shared.timekeeping.utility import get_simulation_start_time
 
 from ..shared.plot.plotting import plot_xtick_format, plot_size_y_axis
 
-from ..shared.analysis_task import AnalysisTask
+from ..shared import AnalysisTask
 from ..shared.html import write_image_xml
 
 
@@ -94,7 +94,7 @@ class IndexNino34(AnalysisTask):  # {{{
 
         # }}}
 
-    def run(self):  # {{{
+    def run_task(self):  # {{{
         '''
         Computes NINO34 index and plots the time series and power spectrum with
         95 and 99% confidence bounds
@@ -104,9 +104,10 @@ class IndexNino34(AnalysisTask):  # {{{
         Luke Van Roekel, Xylar Asay-Davis
         '''
 
-        print "\nPlotting Nino3.4 time series and power spectrum...."
+        self.logger.info("\nPlotting Nino3.4 time series and power "
+                         "spectrum....")
 
-        print '  Load SST data...'
+        self.logger.info('  Load SST data...')
         fieldName = 'nino'
 
         simulationStartTime = get_simulation_start_time(self.runStreams)
@@ -127,10 +128,10 @@ class IndexNino34(AnalysisTask):  # {{{
             dataPath = "{}/ERS_SSTv4_nino34.nc".format(observationsDirectory)
             obsTitle = 'ERS SSTv4'
 
-        print '\n  Reading files:\n' \
-              '    {} through\n    {}'.format(
-                  os.path.basename(self.inputFiles[0]),
-                  os.path.basename(self.inputFiles[-1]))
+        self.logger.info('\n  Reading files:\n'
+                         '    {} through\n    {}'.format(
+                                 os.path.basename(self.inputFiles[0]),
+                                 os.path.basename(self.inputFiles[-1])))
         mainRunName = config.get('runs', 'mainRunName')
 
         # regionIndex should correspond to NINO34 in surface weighted Average
@@ -155,14 +156,14 @@ class IndexNino34(AnalysisTask):  # {{{
         dsObs = xr.open_dataset(dataPath)
         nino34Obs = dsObs.sst
 
-        print '  Compute NINO3.4 index...'
+        self.logger.info('  Compute NINO3.4 index...')
         regionSST = ds[varName].isel(nOceanRegions=regionIndex)
         nino34 = self._compute_nino34_index(regionSST, calendar)
 
         # Compute the observational index over the entire time range
         # nino34Obs = compute_nino34_index(dsObs.sst, calendar)
 
-        print ' Computing NINO3.4 power spectra...'
+        self.logger.info(' Computing NINO3.4 power spectra...')
         f, spectra, conf99, conf95, redNoise = \
             self._compute_nino34_spectra(nino34)
 
@@ -183,7 +184,7 @@ class IndexNino34(AnalysisTask):  # {{{
         fObs = 1.0 / (constants.eps + fObs*constants.sec_per_year)
         f30 = 1.0 / (constants.eps + f30*constants.sec_per_year)
 
-        print ' Plot NINO3.4 index and spectra...'
+        self.logger.info(' Plot NINO3.4 index and spectra...')
 
         figureName = '{}/NINO34_{}.png'.format(self.plotsDirectory,
                                                mainRunName)
@@ -281,7 +282,6 @@ class IndexNino34(AnalysisTask):  # {{{
         pxxSmooth : xarray.DataArray object
             nino34Index power spectra that has been smoothed with a modified
             Daniell window (https://www.ncl.ucar.edu/Document/Functions/Built-in/specx_anal.shtml)
-
 
         f : numpy.array
             array of frequencies corresponding to the center of the spectral
@@ -493,7 +493,7 @@ class IndexNino34(AnalysisTask):  # {{{
         if title is not None:
             fig.suptitle(title, y=0.92, **title_font)
 
-        ax1 = plt.subplot(3, 1, 1)
+        plt.subplot(3, 1, 1)
 
         plt.plot(fObs[2:-3], ninoObs[2:-3], 'k', linewidth=linewidths)
         plt.plot(fObs[2:-3], redNoiseObs[2:-3], 'r', linewidth=linewidths)
@@ -519,7 +519,7 @@ class IndexNino34(AnalysisTask):  # {{{
         if ylabel is not None:
             plt.ylabel(ylabel, **axis_font)
 
-        ax2 = plt.subplot(3, 1, 2)
+        plt.subplot(3, 1, 2)
 
         plt.plot(f30[2:-3], nino30yr[2:-3], 'k', linewidth=linewidths)
         plt.plot(f30[2:-3], redNoise30[2:-3], 'r', linewidth=linewidths)
@@ -539,7 +539,7 @@ class IndexNino34(AnalysisTask):  # {{{
         if ylabel is not None:
             plt.ylabel(ylabel, **axis_font)
 
-        ax3 = plt.subplot(3, 1, 3)
+        plt.subplot(3, 1, 3)
         plt.plot(f[2:-3], ninoSpectra[2:-3], 'k', linewidth=linewidths)
         plt.plot(f[2:-3], redNoiseSpectra[2:-3], 'r', linewidth=linewidths)
         plt.plot(f[2:-3], confidence95[2:-3], 'b', linewidth=linewidths)

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -16,7 +16,7 @@ from ..shared.climatology.climatology \
     compute_climatologies_with_ncclimo, \
     get_ncclimo_season_file_name
 
-from ..shared.analysis_task import AnalysisTask
+from ..shared import AnalysisTask
 from ..shared.html import write_image_xml
 
 
@@ -150,7 +150,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
 
         # }}}
 
-    def run(self):  # {{{
+    def run_task(self):  # {{{
         """
         Process MHT analysis member data if available.
         Plots MHT as:
@@ -161,7 +161,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
         -------
         Mark Petersen, Milena Veneziani, Xylar Asay-Davis
         """
-        print "\nPlotting meridional heat transport (MHT)..."
+        self.logger.info("\nPlotting meridional heat transport (MHT)...")
 
         config = self.config
 
@@ -174,7 +174,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
         # Depth is from refZMid, also in
         # mpaso.hist.am.meridionalHeatTransport.*.nc
 
-        print '  Read in depth and latitude...'
+        self.logger.info('  Read in depth and latitude...')
         ncFile = netCDF4.Dataset(self.mhtFile, mode='r')
         # reference depth [m]
         refZMid = ncFile.variables['refZMid'][:]
@@ -201,19 +201,20 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
         variableList = ['timeMonthly_avg_meridionalHeatTransportLat',
                         'timeMonthly_avg_meridionalHeatTransportLatZ']
 
-        print '\n  Compute and plot global meridional heat transport'
+        self.logger.info('\n  Compute and plot global meridional heat '
+                         'transport')
 
         outputRoot = build_config_full_path(config, 'output',
                                             'mpasClimatologySubdirectory')
 
         outputDirectory = '{}/mht'.format(outputRoot)
 
-        print '\n  List of files for climatologies:\n' \
-              '    {} through\n    {}'.format(
-                  os.path.basename(self.inputFiles[0]),
-                  os.path.basename(self.inputFiles[-1]))
+        self.logger.info('\n  List of files for climatologies:\n'
+                         '    {} through\n    {}'.format(
+                                 os.path.basename(self.inputFiles[0]),
+                                 os.path.basename(self.inputFiles[-1])))
 
-        print '   Load data...'
+        self.logger.info('   Load data...')
 
         climatologyFileName = get_ncclimo_season_file_name(outputDirectory,
                                                            'mpaso', 'ANN',
@@ -233,7 +234,8 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
                     variableList=variableList,
                     modelName='mpaso',
                     seasons=['ANN'],
-                    decemberMode='sdd')
+                    decemberMode='sdd',
+                    logger=self.logger)
 
         annualClimatology = xr.open_dataset(climatologyFileName)
         annualClimatology = annualClimatology.isel(Time=0)
@@ -245,7 +247,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
         depthLimGlobal = config.getExpression(self.sectionName,
                                               'depthLimGlobal')
 
-        print '   Plot global MHT...'
+        self.logger.info('   Plot global MHT...')
         # Plot 1D MHT (zonally averaged, depth integrated)
         x = binBoundaryMerHeatTrans
         y = annualClimatology.timeMonthly_avg_meridionalHeatTransportLat

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -1,6 +1,6 @@
 import os
 
-from ..shared.analysis_task import AnalysisTask
+from ..shared import AnalysisTask
 
 from ..shared.plot.plotting import timeseries_analysis_plot
 
@@ -112,7 +112,7 @@ class TimeSeriesSST(AnalysisTask):
 
         return  # }}}
 
-    def run(self):  # {{{
+    def run_task(self):  # {{{
         """
         Performs analysis of the time-series output of sea-surface temperature
         (SST).
@@ -122,18 +122,18 @@ class TimeSeriesSST(AnalysisTask):
         Xylar Asay-Davis, Milena Veneziani
         """
 
-        print "\nPlotting SST time series..."
+        self.logger.info("\nPlotting SST time series...")
 
-        print '  Load SST data...'
+        self.logger.info('  Load SST data...')
 
         simulationStartTime = get_simulation_start_time(self.runStreams)
         config = self.config
         calendar = self.calendar
 
-        print '\n  Reading files:\n' \
-              '    {} through\n    {}'.format(
-                  os.path.basename(self.inputFiles[0]),
-                  os.path.basename(self.inputFiles[-1]))
+        self.logger.info('\n  Reading files:\n'
+                         '    {} through\n    {}'.format(
+                             os.path.basename(self.inputFiles[0]),
+                             os.path.basename(self.inputFiles[-1])))
 
         mainRunName = config.get('runs', 'mainRunName')
         preprocessedReferenceRunName = \
@@ -179,7 +179,8 @@ class TimeSeriesSST(AnalysisTask):
                                calendar=calendar)
 
         if preprocessedReferenceRunName != 'None':
-            print '  Load in SST for a preprocesses reference run...'
+            self.logger.info('  Load in SST for a preprocesses reference '
+                             'run...')
             inFilesPreprocessed = '{}/SST.{}.year*.nc'.format(
                 preprocessedInputDirectory, preprocessedReferenceRunName)
             dsPreprocessed = open_multifile_dataset(
@@ -194,8 +195,9 @@ class TimeSeriesSST(AnalysisTask):
                 dsPreprocessedTimeSlice = \
                     dsPreprocessed.sel(Time=slice(timeStart, timeEnd))
             else:
-                print '   Warning: Preprocessed time series ends before the ' \
-                    'timeSeries startYear and will not be plotted.'
+                self.logger.warning('Preprocessed time series ends before the '
+                                    'timeSeries startYear and will not be '
+                                    'plotted.')
                 preprocessedReferenceRunName = 'None'
 
         cacheFileName = '{}/sstTimeSeries.nc'.format(outputDirectory)
@@ -206,9 +208,9 @@ class TimeSeriesSST(AnalysisTask):
                                               self._compute_sst_part,
                                               cacheFileName, calendar,
                                               yearsPerCacheUpdate=10,
-                                              printProgress=True)
+                                              logger=self.logger)
 
-        print '  Make plots...'
+        self.logger.info('  Make plots...')
         for regionIndex in regionIndicesToPlot:
             region = regions[regionIndex]
 

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -137,7 +137,7 @@ class TimeSeriesSeaIce(SeaIceAnalysisTask):
             self.xmlFileNames.extend(polarXMLFileNames)
         return  # }}}
 
-    def run(self):  # {{{
+    def run_task(self):  # {{{
         """
         Performs analysis of time series of sea-ice properties.
 
@@ -146,15 +146,15 @@ class TimeSeriesSeaIce(SeaIceAnalysisTask):
         Xylar Asay-Davis, Milena Veneziani
         """
 
-        print "\nPlotting sea-ice area and volume time series..."
+        self.logger.info("\nPlotting sea-ice area and volume time series...")
 
         config = self.config
         calendar = self.calendar
 
-        print '\n  Reading files:\n' \
-              '    {} through\n    {}'.format(
-                  os.path.basename(self.inputFiles[0]),
-                  os.path.basename(self.inputFiles[-1]))
+        self.logger.info('\n  Reading files:\n'
+                         '    {} through\n    {}'.format(
+                                 os.path.basename(self.inputFiles[0]),
+                                 os.path.basename(self.inputFiles[-1])))
 
         plotTitles = {'iceArea': 'Sea-ice area',
                       'iceVolume': 'Sea-ice volume',
@@ -200,7 +200,7 @@ class TimeSeriesSeaIce(SeaIceAnalysisTask):
 
         make_directories(outputDirectory)
 
-        print '  Load sea-ice data...'
+        self.logger.info('  Load sea-ice data...')
         # Load mesh
         self.dsMesh = xr.open_dataset(self.restartFileName)
         self.dsMesh = subset_variables(self.dsMesh,
@@ -240,8 +240,9 @@ class TimeSeriesSeaIce(SeaIceAnalysisTask):
                 dsPreprocessedTimeSlice = \
                     dsPreprocessed.sel(Time=slice(timeStart, timeEnd))
             else:
-                print '   Warning: Preprocessed time series ends before the ' \
-                    'timeSeries startYear and will not be plotted.'
+                self.logger.warning('Preprocessed time series ends before the '
+                                    'timeSeries startYear and will not be '
+                                    'plotted.')
                 preprocessedReferenceRunName = 'None'
 
         norm = {'iceArea': 1e-6,  # m^2 to km^2
@@ -262,7 +263,7 @@ class TimeSeriesSeaIce(SeaIceAnalysisTask):
         plotVars = {}
 
         for hemisphere in ['NH', 'SH']:
-            print '   Caching {} data'.format(hemisphere)
+            self.logger.info('   Caching {} data'.format(hemisphere))
             cacheFileName = '{}/seaIceAreaVolumeTimeSeries_{}.nc'.format(
                 outputDirectory, hemisphere)
 
@@ -271,9 +272,9 @@ class TimeSeriesSeaIce(SeaIceAnalysisTask):
             self.ds = ds
             dsTimeSeries[hemisphere] = cache_time_series(
                 ds.Time.values, self._compute_area_vol_part, cacheFileName,
-                calendar, yearsPerCacheUpdate=10, printProgress=True)
+                calendar, yearsPerCacheUpdate=10, logger=self.logger)
 
-            print '  Make {} plots...'.format(hemisphere)
+            self.logger.info('  Make {} plots...'.format(hemisphere))
 
             for variableName in ['iceArea', 'iceVolume']:
                 key = (hemisphere, variableName)

--- a/mpas_analysis/shared/__init__.py
+++ b/mpas_analysis/shared/__init__.py
@@ -1,0 +1,1 @@
+from analysis_task import AnalysisTask

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -16,7 +16,7 @@ from ..timekeeping.utility import days_to_datetime
 
 def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
                       calendar, yearsPerCacheUpdate=1,
-                      printProgress=False):  # {{{
+                      logger=None):  # {{{
     '''
     Create or update a NetCDF file ``cacheFileName`` containing the given time
     series, calculated with ``timeSeriesCalcFunction`` over the given times,
@@ -52,9 +52,8 @@ def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
         output the file frequently.  If not, there will be needless overhead
         in caching the file too frequently.
 
-    printProgress: bool, optional
-        Whether progress messages should be printed as the climatology is
-        computed
+    logger : ``logging.Logger``, optional
+        A logger to which to write output as the time series is computed
 
     Returns
     -------
@@ -73,8 +72,8 @@ def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
     continueOutput = os.path.exists(cacheFileName)
     cacheDataSetExists = False
     if continueOutput:
-        if printProgress:
-            print '   Read in previously computed time series'
+        if logger is not None:
+            logger.info('   Read in previously computed time series')
         # read in what we have so far
 
         try:
@@ -84,7 +83,10 @@ def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
             # assuming the cache file is corrupt, so deleting it.
             message = 'Deleting cache file {}, which appears to have ' \
                       'been corrupted.'.format(cacheFileName)
-            warnings.warn(message)
+            if logger is None:
+                warnings.warn(message)
+            else:
+                logger.warning(message)
             os.remove(cacheFileName)
 
         if cacheDataSetExists:
@@ -116,13 +118,13 @@ def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
             # no unprocessed time entries in this data range
             continue
 
-        if printProgress:
+        if logger is not None:
             if firstProcessed:
-                print '   Process and save time series'
+                logger.info('   Process and save time series')
             if yearsPerCacheUpdate == 1:
-                print '     {:04d}'.format(years[0])
+                logger.info('     {:04d}'.format(years[0]))
             else:
-                print '     {:04d}-{:04d}'.format(years[0], years[-1])
+                logger.info('     {:04d}-{:04d}'.format(years[0], years[-1]))
 
         ds = timeSeriesCalcFunction(timeIndices, firstProcessed)
         firstProcessed = False

--- a/mpas_analysis/test/test_analysis_task.py
+++ b/mpas_analysis/test/test_analysis_task.py
@@ -1,5 +1,5 @@
 """
-Unit tests for utility functions in run_analysis
+Unit tests for utility functions in run_mpas_analysis
 
 Xylar Asay-Davis
 """
@@ -33,7 +33,7 @@ class TestAnalysisTask(TestCase):
         # a list of analyses to generate.  Valid names are:
         #   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
         #   'climatologyMapSSS', 'climatologyMapMLD', 'timeSeriesSeaIceAreaVol',
-        #   'climatologyMapSeaIceConcNH', 'climatologyMapSeaIceConcSH', 
+        #   'climatologyMapSeaIceConcNH', 'climatologyMapSeaIceConcSH',
         #   'climatologyMapSeaIceThickNH', 'climatologyMapSeaIceThickSH'
         # the following shortcuts exist:
         #   'all' -- all analyses will be run

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -9,15 +9,13 @@ Authors
 Xylar Asay-Davis, Phillip J. Wolfram
 """
 
-import os
 import matplotlib as mpl
 import argparse
 import traceback
 import sys
-import subprocess
-import time
 import pkg_resources
 import shutil
+import os
 
 from mpas_analysis.configuration import MpasAnalysisConfigParser
 
@@ -25,6 +23,8 @@ from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories
 
 from mpas_analysis.shared.html import generate_html
+
+from mpas_analysis.shared import AnalysisTask
 
 
 def update_generate(config, generate):  # {{{
@@ -55,7 +55,7 @@ def update_generate(config, generate):  # {{{
     config.set('output', 'generate', generateString)  # }}}
 
 
-def run_parallel_tasks(config, analyses, configFiles, taskCount):
+def run_parallel_tasks(config, analyses, taskCount):
     # {{{
     """
     Launch new processes for parallel tasks, allowing up to ``taskCount``
@@ -69,9 +69,6 @@ def run_parallel_tasks(config, analyses, configFiles, taskCount):
     analyses : list of ``AnalysisTask`` objects
         A list of analysis tasks to run
 
-    configFiles : list of str
-        A list of config files, passed on to each parallel task
-
     taskCount : int
         The maximum number of tasks that are allowed to run at once
 
@@ -80,33 +77,38 @@ def run_parallel_tasks(config, analyses, configFiles, taskCount):
     Xylar Asay-Davis
     """
 
-    taskNames = [analysisTask.taskName for analysisTask in analyses]
+    taskCount = min(taskCount, len(analyses))
 
-    taskCount = min(taskCount, len(taskNames))
+    runningTasks = {}
+    for analysisTask in analyses[0:taskCount]:
+        print 'Running {}'.format(analysisTask.taskName)
+        analysisTask.start()
+        runningTasks[analysisTask.taskName] = analysisTask
 
-    (processes, logs) = launch_tasks(taskNames[0:taskCount], config,
-                                     configFiles)
-    remainingTasks = taskNames[taskCount:]
+    remainingTasks = analyses[taskCount:]
     tasksWithErrors = []
-    while len(processes) > 0:
-        (taskName, process) = wait_for_task(processes)
-        if process.returncode == 0:
-            print "Task {} has finished successfully.".format(taskName)
-        else:
+    while len(runningTasks.keys()) > 0:
+        analysisTask = wait_for_task(runningTasks)
+        taskName = analysisTask.taskName
+        if analysisTask._runStatus.value == AnalysisTask.SUCCESS:
+            print "   Task {} has finished successfully.".format(taskName)
+        elif analysisTask._runStatus.value == AnalysisTask.FAIL:
             print "ERROR in task {}.  See log file {} for details".format(
-                taskName, logs[taskName].name)
+                taskName, analysisTask._logFileName)
             tasksWithErrors.append(taskName)
-        logs[taskName].close()
+        else:
+            print "Unexpected status from in task {}.  This may be a " \
+                  "bug.".format(taskName)
         # remove the process from the process dictionary (no need to bother)
-        processes.pop(taskName)
+        runningTasks.pop(taskName)
 
         if len(remainingTasks) > 0:
-            (process, log) = launch_tasks(remainingTasks[0:1], config,
-                                          configFiles)
-            # merge the new process and log into these dictionaries
-            processes.update(process)
-            logs.update(log)
+            analysisTask = remainingTasks[0]
             remainingTasks = remainingTasks[1:]
+
+            print 'Running {}'.format(analysisTask.taskName)
+            analysisTask.start()
+            runningTasks[analysisTask.taskName] = analysisTask
 
     # raise the last exception so the process exits with an error
     errorCount = len(tasksWithErrors)
@@ -120,119 +122,33 @@ def run_parallel_tasks(config, analyses, configFiles, taskCount):
     # }}}
 
 
-def launch_tasks(taskNames, config, configFiles):  # {{{
+def wait_for_task(runningTasks, timeout=0.1):  # {{{
     """
-    Launch one or more tasks
+    Build a list of analysis modules based on the 'generate' config option.
+    New tasks should be added here, following the approach used for existing
+    analysis tasks.
 
     Parameters
     ----------
-    taskNames : list of str
-        the names of the tasks to launch
-
-    config : ``MpasAnalysisConfigParser`` object
-        contains config options
-
-    configFiles : list of str
-        A list of config files, passed along when each task is launched
-
-    Authors
-    -------
-    Xylar Asay-Davis
-    """
-    thisFile = os.path.realpath(__file__)
-
-    commandPrefix = config.getWithDefault('execute', 'commandPrefix',
-                                          default='')
-    if commandPrefix == '':
-        commandPrefix = []
-    else:
-        commandPrefix = commandPrefix.split(' ')
-
-    processes = {}
-    logs = {}
-    for taskName in taskNames:
-        args = commandPrefix + \
-            [thisFile, '--subtask', '--generate', taskName] + configFiles
-
-        logFileName = '{}/{}.log'.format(logsDirectory, taskName)
-
-        # write the command to the log file
-        logFile = open(logFileName, 'w')
-        logFile.write('Command: {}\n'.format(' '.join(args)))
-        # make sure the command gets written before the rest of the log
-        logFile.flush()
-        print 'Running {}'.format(taskName)
-        process = subprocess.Popen(args, stdout=logFile,
-                                   stderr=subprocess.STDOUT)
-        processes[taskName] = process
-        logs[taskName] = logFile
-
-    return (processes, logs)  # }}}
-
-
-def wait_for_task(processes):  # {{{
-    """
-    Wait for the next process to finish and check its status.  Returns both the
-    task name and the process that finished.
-
-    Parameters
-    ----------
-    processes : list of ``subprocess.Popen`` objects
-        Processes to wait for
-
+    runningTasks : dict of ``AnalysisTasks``
+        The tasks that are currently running, with task names as keys
 
     Returns
     -------
-    taskName : str
-        The name of the task that finished
-
-    process : ``subprocess.Popen`` object
-        The process that finished
+    analysisTask : ``AnalysisTasks``
+        A task that finished
 
     Authors
     -------
     Xylar Asay-Davis
     """
-
-    # first, check if any process has already finished
-    for taskName, process in processes.iteritems():  # python 2.7!
-        if(not is_running(process)):
-            return (taskName, process)
-
-    # No process has already finished, so wait for the next one
-    (pid, status) = os.waitpid(-1, 0)
-    for taskName, process in processes.iteritems():
-        if pid == process.pid:
-            process.returncode = status
-            # since we used waitpid, this won't happen automatically
-            return (taskName, process)  # }}}
-
-
-def is_running(process):  # {{{
-    """
-    Returns whether a given process is currently running
-
-    Parameters
-    ----------
-    process : ``subprocess.Popen`` object
-        The process to check
-
-    Returns
-    -------
-    isRunning : bool
-        whether the process is running
-
-    Authors
-    -------
-    Xylar Asay-Davis
-    """
-
-    try:
-        os.kill(process.pid, 0)
-    except OSError:
-        return False
-    else:
-        return True  # }}}
+    # necessary to have a timeout so we can kill the whole thing
+    # with a keyboard interrupt
+    while True:
+        for analysisTask in runningTasks.itervalues():
+            analysisTask.join(timeout=timeout)
+            if not analysisTask.is_alive():
+                return analysisTask  # }}}
 
 
 def build_analysis_list(config):  # {{{
@@ -357,36 +273,16 @@ def run_analysis(config, analyses):  # {{{
     tasksWithErrors = []
     lastStacktrace = None
     for analysisTask in analyses:
-        # write out a copy of the configuration to document the run
-        logsDirectory = build_config_full_path(config, 'output',
-                                               'logsSubdirectory')
-        try:
-            startTime = time.clock()
-            analysisTask.run()
-            runDuration = time.clock() - startTime
-            m, s = divmod(runDuration, 60)
-            h, m = divmod(int(m), 60)
-            print 'Execution time: {}:{:02d}:{:05.2f}'.format(h, m, s)
-        except (Exception, BaseException) as e:
-            if isinstance(e, KeyboardInterrupt):
-                raise e
-            lastStacktrace = traceback.format_exc()
-            print "ERROR: analysis task {} failed during run".format(
-                analysisTask.taskName)
-            print lastStacktrace
+        analysisTask.run(writeLogFile=False)
+        if analysisTask._runStatus.value == AnalysisTask.FAIL:
+            lastStacktrace = analysisTask._stackTrace
             tasksWithErrors.append(analysisTask.taskName)
-
-        configFileName = '{}/configs/config.{}'.format(logsDirectory,
-                                                       analysisTask.taskName)
-        configFile = open(configFileName, 'w')
-        config.write(configFile)
-        configFile.close()
 
     if config.getboolean('plot', 'displayToScreen'):
         import matplotlib.pyplot as plt
         plt.show()
 
-    # raise the last exception so the process exits with an error
+    # See if there were errors; exit(1) if so
     errorCount = len(tasksWithErrors)
     if errorCount == 1:
         if len(analyses) > 1:
@@ -408,9 +304,6 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument("--subtask", dest="subtask", action='store_true',
-                        help="If this is a subtask when running parallel "
-                             "tasks")
     parser.add_argument("--setup_only", dest="setup_only", action='store_true',
                         help="If only the setup phase, not the run or HTML "
                         "generation phases, should be executed.")
@@ -479,10 +372,9 @@ if __name__ == "__main__":
         if parallelTaskCount <= 1 or len(analyses) == 1:
             run_analysis(config, analyses)
         else:
-            run_parallel_tasks(config, analyses, configFiles,
-                               parallelTaskCount)
+            run_parallel_tasks(config, analyses, parallelTaskCount)
 
-    if not args.subtask and not args.setup_only:
+    if not args.setup_only:
         generate_html(config, analyses)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
In order to support better data availability between tasks (e.g.
if tasks depend on data from the setup of other tasks), tasks are
now subclasses of `multiprocess.Process`.  This work is needed  to
support subtasks (e.g. for producing climatologies, or for generating 
each plot from a task).

Logging is also altered so that each task has a logger, to which
info, errors and warnings should be logged.  Print statements will
automatically go to the logger as "info" while exceptions and
warnings raised through the `warning` module will be logged as
errors.

Because `multiprocess.Process` already uses a method called `run()`,
the `run()` method of `AnalysisTask` and its derived classes had to
be renamed to `run_analysis()`.