### PR TITLE
Add --list and --purge command-line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,19 @@ conda install numpy scipy matplotlib netCDF4 xarray dask bottleneck basemap \
     lxml nco pyproj pillow
 ```
 
+## List Analysis
+
+To list the available analysis tasks, run:
+
+```
+./run_mpas_analysis --list
+```
+This lists all tasks and their tags.  These can be used in the `generate`
+command-line option or config option.  See `mpas_analysis/config.default`
+for more details.
+
 ## Running the analysis
+
   1. Create and empty config file (say `config.myrun`) or copy one of the
      example files in the `configs` directory.
   2. Copy and modify any config options you want to change from
@@ -71,8 +83,19 @@ conda install numpy scipy matplotlib netCDF4 xarray dask bottleneck basemap \
      `--generate` flag on the command line.  See the comments in
      `mpas_analysis/config.default` for more details on this option.
 
+## Purge Old Analysis
+
+To purge old analysis (delete the whole output directory) before running run
+the analysis, add the `--purge` flag:
+
+```
+./run_mpas_analysis --purge <config.file>
+````
+The directory to delete is the `baseDirectory` option in the `output`
+section.
 
 ## Running in parallel
+
   1. Copy the appropriate job script file from `configs/<machine_name>` to
      the same directory as `run_mpas_analysis` (or another directory if
      preferred). The default script, `configs/job_script.default.bash`, is

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,7 @@ Top-level script: run_mpas_analysis
    run_mpas_analysis.wait_for_task
    run_mpas_analysis.is_running
    run_mpas_analysis.build_analysis_list
+   run_mpas_analysis.determine_analyses_to_generate
    run_mpas_analysis.run_analysis
 
 

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -17,6 +17,7 @@ import sys
 import subprocess
 import time
 import pkg_resources
+import shutil
 
 from mpas_analysis.configuration import MpasAnalysisConfigParser
 
@@ -236,9 +237,8 @@ def is_running(process):  # {{{
 
 def build_analysis_list(config):  # {{{
     """
-    Build a list of analysis modules based on the 'generate' config option.
-    New tasks should be added here, following the approach used for existing
-    analysis tasks.
+    Build a list of analysis tasks. New tasks should be added here, following
+    the approach used for existing analysis tasks.
 
     Parameters
     ----------
@@ -247,8 +247,8 @@ def build_analysis_list(config):  # {{{
 
     Returns
     -------
-    analysesToGenerate : list of ``AnalysisTask`` objects
-        A list of analysis tasks to run
+    analyses : list of ``AnalysisTask`` objects
+        A list of all analysis tasks
 
     Authors
     -------
@@ -284,6 +284,31 @@ def build_analysis_list(config):  # {{{
     analyses.append(sea_ice.ClimatologyMapSeaIceConc(config, hemisphere='SH'))
     analyses.append(sea_ice.ClimatologyMapSeaIceThick(config, hemisphere='SH'))
     analyses.append(sea_ice.TimeSeriesSeaIce(config))
+
+    return analyses  # }}}
+
+
+def determine_analyses_to_generate(analyses):  # {{{
+    """
+    Build a list of analysis tasks to run based on the 'generate' config
+    option (or command-line flag) and prerequisites and subtasks of each
+    requested task.  Each task's ``setup_and_check`` method is called in the
+    process.
+
+    Parameters
+    ----------
+    analyses : list of ``AnalysisTask`` objects
+        A list of all analysis tasks
+
+    Returns
+    -------
+    analysesToGenerate : list of ``AnalysisTask`` objects
+        A list of analysis tasks to run
+
+    Authors
+    -------
+    Xylar Asay-Davis
+    """
 
     # check which analysis we actually want to generate and only keep those
     analysesToGenerate = []
@@ -390,8 +415,13 @@ if __name__ == "__main__":
                         help="A list of analysis modules to generate "
                         "(nearly identical generate option in config file).",
                         metavar="ANALYSIS1[,ANALYSIS2,ANALYSIS3,...]")
+    parser.add_argument("-l", "--list", dest="list", action='store_true',
+                        help="List the available analysis tasks")
+    parser.add_argument("-p", "--purge", dest="purge", action='store_true',
+                        help="Purge the analysis by deleting the output"
+                        "directory before running")
     parser.add_argument('configFiles', metavar='CONFIG',
-                        type=str, nargs='+', help='config file')
+                        type=str, nargs='*', help='config file')
     args = parser.parse_args()
 
     # add config.default to cover default not included in the config files
@@ -409,6 +439,22 @@ if __name__ == "__main__":
     config = MpasAnalysisConfigParser()
     config.read(configFiles)
 
+    if args.list:
+        analyses = build_analysis_list(config)
+        for analysisTask in analyses:
+            print '{}\n    tags: {}'.format(analysisTask.taskName,
+                                            ', '.join(analysisTask.tags))
+        sys.exit(0)
+
+    if args.purge:
+        outputDirectory = config.get('output', 'baseDirectory')
+        if not os.path.exists(outputDirectory):
+            print 'Output directory {} does not exist.\n' \
+                  'No purge necessary.'.format(outputDirectory)
+        else:
+            print 'Deleting contents of {}'.format(outputDirectory)
+            shutil.rmtree(outputDirectory)
+
     if args.generate:
         update_generate(config, args.generate)
 
@@ -418,6 +464,7 @@ if __name__ == "__main__":
     make_directories('{}/configs/'.format(logsDirectory))
 
     analyses = build_analysis_list(config)
+    analyses = determine_analyses_to_generate(analyses)
 
     parallelTaskCount = config.getWithDefault('execute', 'parallelTaskCount',
                                               default=1)


### PR DESCRIPTION
`--list` will list all available analysis tasks (useful for deciding
what to include in the `--generate` flag).  No config file should be
needed. The tags associated with each task are also printed.

`--purge` will delete the base output directory so the analysis can
be run cleanly at that location.  A config file must be supplied
with section [output] and option baseDirectory giving the location
to be deleted.  The user is told whether the location was deleted.