### PR TITLE
Fix bug in defining filePrefix for time_series_sst

### DIFF
--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -327,7 +327,7 @@ class TimeSeriesOHC(AnalysisTask):
             z = ds.avgLayerTemperatureAnomaly.isel(nOceanRegionsTmp=regionIndex)
             z = z.transpose()
 
-            colorbarLabel = '[$^\circ$ C]'
+            colorbarLabel = '[$^\circ$C]'
             xLabel = 'Time [years]'
             yLabel = 'Depth [m]'
 

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -105,7 +105,7 @@ class TimeSeriesSST(AnalysisTask):
         regions = [regions[index] for index in regionIndicesToPlot]
 
         for region in regions:
-            filePrefix = 'sst_{}_{}.png'.format(region, mainRunName)
+            filePrefix = 'sst_{}_{}'.format(region, mainRunName)
             self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
                                                         filePrefix))
             self.filePrefixes[region] = filePrefix
@@ -215,7 +215,7 @@ class TimeSeriesSST(AnalysisTask):
             title = plotTitles[regionIndex]
             title = 'SST, %s \n %s (black)' % (title, mainRunName)
             xLabel = 'Time [years]'
-            yLabel = '[$^\circ$ C]'
+            yLabel = '[$^\circ$C]'
 
             SST = dsSST[varName].isel(nOceanRegions=regionIndex)
 


### PR DESCRIPTION
In `time_series_sst`, `filePrefix` was defined with the `.png` extension in it, making all filenames have the extra `.png` in them.
This may have been introduced by mistake in one of our latest commits.