### PR TITLE
Add Anvil support

### DIFF
--- a/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+++ b/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
@@ -1,0 +1,147 @@
+[runs]
+## options related to the run to be analyzed and reference runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = 20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+# preprocessedReferenceRunName is the name of a reference run that has been
+# preprocessed to compare against (or None to turn off comparison).  Reference
+# runs of this type would have preprocessed results because they were not
+# performed with MPAS components (so they cannot be easily ingested by
+# MPAS-Analysis)
+preprocessedReferenceRunName = B1850C5_ne30_v0.4
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /lcrc/group/acme/jwolfe/acme_scratch/20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil/run
+
+# names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
+mpasMeshName = oEC60to30v3
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+baseDirectory = /dir/to/analysis/output
+
+# Anvil doesn't have direct access to a web portal, so output will need
+# to be copied elsewhere (e.g. NERSC web portal)
+htmlSubdirectory = html
+
+# a list of analyses to generate.  Valid names are:
+#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
+#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
+#   'indexNino34', 'meridionalHeatTransport',
+#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH', 
+#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH', 
+#   'climatologyMapSeaIceThickSH'
+# the following shortcuts exist:
+#   'all' -- all analyses will be run
+#   'all_timeSeries' -- all time-series analyses will be run
+#   'all_climatology' -- all analyses involving climatologies
+#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
+#   'all_ocean' -- all ocean analyses will be run
+#   'all_seaIce' -- all sea-ice analyses will be run
+#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
+#                             other analyses).
+#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
+#                                            given category of analysis
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    ./run_mpas_analysis config.analysis --generate \
+#         all,no_ocean,all_timeSeries
+generate = ['all']
+
+# alternative examples that would perform all analysis except
+#   'timeSeriesOHC'
+#generate = ['all', 'no_timeSeriesOHC']
+# Each subsequent list entry can be used to alter previous list entries. For
+# example, the following would run all tasks that aren't ocean analyses,
+# except that it would also run ocean time series tasks:
+#generate = ['all', 'no_ocean', 'all_timeSeries']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 11
+# the last year over which to average climatalogies
+endYear = 20
+
+# The names of the mapping file used for interpolation.  If a mapping file has
+# already been generated, supplying the absolute path can save the time of
+# generating a new one.  If nothing is supplied, the file name is automatically
+# generated based on the MPAS mesh name, the comparison grid resolution, and
+# the interpolation method
+mpasMappingFile = /lcrc/group/acme/lvanroe/APrime_Files/mapping/maps/map_oEC60to30v3_TO_0.5x0.5degree_blin.nc
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+startYear = 1
+endYear = 22
+
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
+[oceanObservations]
+## options related to ocean observations with which the results will be compared
+
+# directory where ocean observations are stored
+baseDirectory = /lcrc/group/acme/lvanroe/APrime_Files/observations/Ocean
+sstSubdirectory = SST
+sssSubdirectory = SSS
+mldSubdirectory = MLD
+ninoSubdirectory = Nino
+mhtSubdirectory = MHT
+
+
+[oceanPreprocessedReference]
+## options related to preprocessed ocean reference run with which the results
+## will be compared (e.g. a POP, CESM or ACME v0 run)
+
+# directory where ocean reference simulation results are stored
+baseDirectory = /lcrc/group/acme/lvanroe/APrime_Files/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+
+[seaIceObservations]
+## options related to sea ice observations with which the results will be
+## compared
+
+# directory where sea ice observations are stored
+baseDirectory = /lcrc/group/acme/lvanroe/APrime_Files/observations/SeaIce
+
+[seaIcePreprocessedReference]
+## options related to preprocessed sea ice reference run with which the results
+## will be compared (e.g. a CICE, CESM or ACME v0 run)
+
+# directory where ocean reference simulation results are stored
+baseDirectory = /lcrc/group/acme/lvanroe/APrime_Files/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
+
+[timeSeriesSeaIceAreaVol]
+## options related to plotting time series of sea ice area and volume
+
+# plot on polar plot
+polarPlot = False
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning
+## circulation (MOC)
+maxChunkSize = 1000
+
+# Mask file for ocean basin regional computation
+regionMaskFiles = /lcrc/group/acme/lvanroe/APrime_Files/mpas_analysis/region_masks/oEC60to30v3_Atlantic_region_and_southern_transect.nc

--- a/configs/anvil/job_script.anvil.bash
+++ b/configs/anvil/job_script.anvil.bash
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# comment out if using debug queue
+#PBS -q acme
+#PBS -A ACME
+#PBS -l nodes=1
+#PBS -l walltime=1:00:00
+#PBS -N mpas_analysis
+#PBS -o mpas_analysis.o$PBS_JOBID
+#PBS -e mpas_analysis.e$PBS_JOBID
+
+cd $PBS_O_WORKDIR
+
+# needed to prevent interference with acme-unified
+unset LD_LIBRARY_PATH
+soft add +acme-unified-1.1.1-nox
+
+# MPAS/ACME job to be analyzed, including paths to simulation data and
+# observations. Change this name and path as needed
+run_config_file="config.run_name_here"
+# change this if not submitting this script from the directory
+# containing run_mpas_analysis
+mpas_analysis_dir="."
+# one parallel task per node by default
+parallel_task_count=6
+# ncclimo can run with 1 (serial) or 12 (bck) threads
+ncclimo_mode=bck
+
+if [ ! -f $run_config_file ]; then
+    echo "File $run_config_file not found!"
+    exit 1
+fi
+if [ ! -f $mpas_analysis_dir/run_mpas_analysis ]; then
+    echo "run_mpas_analysis not found in $mpas_analysis_dir!"
+    exit 1
+fi
+
+
+job_config_file=config.output.$PBS_JOBID
+
+# write out the config file specific to this job
+cat <<EOF > $job_config_file
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = $parallel_task_count
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = $ncclimo_mode
+
+EOF
+
+# first, perform setup only without mpirun to create the mapping files
+$mpas_analysis_dir/run_mpas_analysis --purge --setup_only $run_config_file \
+    $job_config_file
+# next, do the full run now tht we have mapping files, but this time launching
+# with mpirun
+mpirun -n 1 $mpas_analysis_dir/run_mpas_analysis $run_config_file \
+    $job_config_file
+

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -411,6 +411,12 @@ if __name__ == "__main__":
     parser.add_argument("--subtask", dest="subtask", action='store_true',
                         help="If this is a subtask when running parallel "
                              "tasks")
+    parser.add_argument("--setup_only", dest="setup_only", action='store_true',
+                        help="If only the setup phase, not the run or HTML "
+                        "generation phases, should be executed.")
+    parser.add_argument("--html_only", dest="html_only", action='store_true',
+                        help="If only the setup and HTML generation phases, "
+                        "not the run phase, should be executed.")
     parser.add_argument("-g", "--generate", dest="generate",
                         help="A list of analysis modules to generate "
                         "(nearly identical generate option in config file).",
@@ -469,12 +475,14 @@ if __name__ == "__main__":
     parallelTaskCount = config.getWithDefault('execute', 'parallelTaskCount',
                                               default=1)
 
-    if parallelTaskCount <= 1 or len(analyses) == 1:
-        run_analysis(config, analyses)
-    else:
-        run_parallel_tasks(config, analyses, configFiles, parallelTaskCount)
+    if not args.setup_only and not args.html_only:
+        if parallelTaskCount <= 1 or len(analyses) == 1:
+            run_analysis(config, analyses)
+        else:
+            run_parallel_tasks(config, analyses, configFiles,
+                               parallelTaskCount)
 
-    if not args.subtask:
+    if not args.subtask and not args.setup_only:
         generate_html(config, analyses)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
In order to support Anvil, we need to move mapping file generation to the `setup_and_check()` phase (so it runs in serial).   We also need to run setup on its own without the mpirun command so that ESMF_RegridWeightGen (which is an mpi program) can run properly.

This merge also adds a job script and config file for analyzing a run on Anvil.