### PR TITLE
Add a config file and job script for theta

### DIFF
--- a/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -1,0 +1,179 @@
+[runs]
+## options related to the run to be analyzed and reference runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = 20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+# preprocessedReferenceRunName is the name of a reference run that has been
+# preprocessed to compare against (or None to turn off comparison).  Reference
+# runs of this type would have preprocessed results because they were not
+# performed with MPAS components (so they cannot be easily ingested by
+# MPAS-Analysis)
+preprocessedReferenceRunName = None
+
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+#parallelTaskCount = 24
+parallelTaskCount = 1
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+#ncclimoParallelMode = bck
+ncclimoParallelMode = serial
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /projects/OceanClimate/mpeterse/20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta/run
+
+# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+mpasMeshName = oEC60to30v3wLI
+
+# Directory for mapping files (if they have been generated already). If mapping
+# files needed by the analysis are not found here, they will be generated and
+# placed in the output mappingSubdirectory
+mappingDirectory = /projects/OceanClimate/mpas-analysis_data/mpas_analysis/mapping
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+baseDirectory = /dir/to/analysis/output
+
+# a list of analyses to generate.  Valid names are:
+#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
+#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
+#   'indexNino34', 'meridionalHeatTransport',
+#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcThick'
+# the following shortcuts exist:
+#   'all' -- all analyses will be run
+#   'all_timeSeries' -- all time-series analyses will be run
+#   'all_climatology' -- all analyses involving climatologies
+#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
+#   'all_ocean' -- all ocean analyses will be run
+#   'all_seaIce' -- all sea-ice analyses will be run
+#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
+#                             other analyses).
+#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
+#                                            given category of analysis
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    ./run_analysis.py config.analysis --generate \
+#         all,no_ocean,all_timeSeries
+generate = ['all']
+
+# alternative examples that would perform all analysis except
+#   'timeSeriesOHC'
+#generate = ['all', 'no_timeSeriesOHC']
+# Each subsequent list entry can be used to alter previous list entries. For
+# example, the following would run all tasks that aren't ocean analyses,
+# except that it would also run ocean time series tasks:
+#generate = ['all', 'no_ocean', 'all_timeSeries']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 5
+# the last year over which to average climatalogies
+endYear = 10
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+startYear = 1
+endYear = 9999
+
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
+[oceanObservations]
+## options related to ocean observations with which the results will be compared
+
+# directory where ocean observations are stored
+baseDirectory = /projects/OceanClimate/mpas-analysis_data/observations/Ocean/
+sstSubdirectory = SST
+sssSubdirectory = SSS
+mldSubdirectory = MLD
+ninoSubdirectory = Nino
+mhtSubdirectory = MHT
+meltSubdirectory = Melt
+soseSubdirectory = SOSE
+
+[oceanPreprocessedReference]
+## options related to preprocessed ocean reference run with which the results
+## will be compared (e.g. a POP, CESM or ACME v0 run)
+
+# directory where ocean reference simulation results are stored
+baseDirectory = /projects/OceanClimate/mpas-analysis_data/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+
+[seaIceObservations]
+## options related to sea ice observations with which the results will be
+## compared
+
+# directory where sea ice observations are stored
+baseDirectory = /projects/OceanClimate/mpas-analysis_data/observations/SeaIce
+
+[seaIcePreprocessedReference]
+## options related to preprocessed sea ice reference run with which the results
+## will be compared (e.g. a CICE, CESM or ACME v0 run)
+
+# directory where ocean reference simulation results are stored
+baseDirectory =  /projects/OceanClimate/mpas-analysis_data/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
+
+[timeSeriesSeaIceAreaVol]
+## options related to plotting time series of sea ice area and volume
+
+# plot on polar plot
+polarPlot = False
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning 
+## circulation (MOC)
+maxChunkSize = 1000
+
+# Mask file for ocean basin regional computation
+regionMaskFiles = /projects/OceanClimate/mpas-analysis_data/mpas_analysis/region_masks/oEC60to30v3wLI_Atlantic_region_masks_and_southern_transect.nc
+
+[regions]
+# Directory containing mask files for ocean basins and ice shelves
+regionMaskDirectory = /projects/OceanClimate/mpas-analysis_data/mpas_analysis/region_masks/
+
+[climatologyMapSoseTemperature]
+# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['JFM', 'JAS', 'ANN']
+
+# list of depths in meters (positive up) at which to analyze, 'bot' for the
+# bottom of the ocean
+depths = ['top', -200, -400, -600, -800, 'bot']
+
+[climatologyMapSoseSalinity]
+# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['JFM', 'JAS', 'ANN']
+
+# list of depths in meters (positive up) at which to analyze, 'bot' for the
+# bottom of the ocean
+depths = ['top', -200, -400, -600, -800, 'bot']
+
+[timeSeriesAntarcticMelt]
+# a list of ice shelves to plot
+iceShelvesToPlot = ['Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Larsen_D', 'Ronne', 'Filchner', 'Brunt_Stancomb', 'Fimbul', 'Riiser-Larsen', 'Baudouin', 'Amery', 'West', 'Shackleton', 'Totten', 'Mertz', 'Ross_East', 'Ross_West', 'Getz', 'Dotson', 'Crosson', 'Thwaites', 'Pine_Island', 'Abbot', 'Stange', 'George_VI', 'Wilkins']

--- a/configs/theta/job_script.theta.bash
+++ b/configs/theta/job_script.theta.bash
@@ -1,0 +1,71 @@
+#!/bin/bash
+#COBALT -t 1:00:00
+#COBALT -n 1
+#COBALT -A OceanClimate
+#COBALT -q debug-flat-quad
+
+export OMP_NUM_THREADS=1
+
+module unload python
+module use /projects/OceanClimate/modulefiles/all
+module load python/anaconda-2.7-acme
+
+# MPAS/ACME job to be analyzed, including paths to simulation data and
+# observations. Change this name and path as needed
+run_config_file="config.run_name_here"
+# prefix to run a serial job on a single node on edison
+command_prefix="aprun -N 1 -n 1"
+# change this if not submitting this script from the directory
+# containing run_mpas_analysis
+mpas_analysis_dir="."
+# one parallel task per node by default
+parallel_task_count=12
+# ncclimo can run with 1 (serial) or 12 (bck) threads
+ncclimo_mode=bck
+
+if [ ! -f $run_config_file ]; then
+    echo "File $run_config_file not found!"
+    exit 1
+fi
+if [ ! -f $mpas_analysis_dir/run_mpas_analysis ]; then
+    echo "run_mpas_analysis not found in $mpas_analysis_dir!"
+    exit 1
+fi
+
+
+# This is a config file generated just for this job with the output directory,
+# command prefix and parallel task count from above.
+job_config_file=config.output.$COBALT_JOBID
+
+# write out the config file specific to this job
+cat <<EOF > $job_config_file
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = $parallel_task_count
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = $ncclimo_mode
+
+EOF
+
+# write a batch script to prevent issues with cobalt or aprun trying to
+# symlink run_mpas_analysis
+cat <<EOF > run_mpas_analysis.bash
+#!/bin/bash
+
+module unload python
+module use /projects/OceanClimate/modulefiles/all
+module load python/anaconda-2.7-acme
+
+$mpas_analysis_dir/run_mpas_analysis --purge \
+    $run_config_file $job_config_file
+EOF
+
+chmod u+x run_mpas_analysis.bash
+
+$command_prefix ./run_mpas_analysis.bash
+


### PR DESCRIPTION
The theta job script needs an extra step of creating a bash wrapper around `run_mpas_analysis`.  This is because, without the wrapper, the job scheduler creates a symlink to `run_mpas_analysis`, meaning python no longer finds the `mpas_analysis` package.