### PR TITLE
Add hemisphere to remapped sea-ice clim. map

### DIFF
--- a/mpas_analysis/sea_ice/climatology_map.py
+++ b/mpas_analysis/sea_ice/climatology_map.py
@@ -94,7 +94,7 @@ class ClimatologyMapSeaIce(SeaIceAnalysisTask):
         self.remapClimatologySubtask = RemapMpasClimatologySubtask(
             mpasClimatologyTask=self.mpasClimatologyTask,
             parentTask=self,
-            climatologyName=self.fieldName,
+            climatologyName='{}{}'.format(self.fieldName, self.hemisphere),
             variableList=[self.mpasFieldName],
             seasons=seasons,
             iselValues=self.iselValues)


### PR DESCRIPTION
This prevents sea-ice thickness tasks from writing to the same file.