### PR TITLE
Add python 2 and 3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,14 @@ matrix:
   fast_finish: true
   include:
   - python: 2.7
-    env: CONDA_ENV=py27
+  - python: 3.5
+  - python: 3.6
 
 before_install:
   - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
     else
-      wget http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh -O miniconda.sh;
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -24,8 +25,10 @@ before_install:
   - conda info -a
 
 install:
-  - conda env create --file ci/requirements-$CONDA_ENV.yml
+  - conda create -n test_env -c conda-forge python=$TRAVIS_PYTHON_VERSION
+  - conda env update -n test_env -f ci/requirements.yml
   - source activate test_env
+  - conda list
 
 script:
-  - py.test
+  - pytest

--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -1,9 +1,8 @@
-name: test_env
 channels:
   - conda-forge
 dependencies:
-  - python=2.7
   - pytest
+  - six
   - numpy
   - scipy
   - lxml

--- a/mpas_analysis/analysis_task_template.py
+++ b/mpas_analysis/analysis_task_template.py
@@ -33,6 +33,8 @@ Authors
 Xylar Asay-Davis
 '''
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 # import python modules here
 import numpy
 import matplotlib.pyplot as plt

--- a/mpas_analysis/analysis_task_template.py
+++ b/mpas_analysis/analysis_task_template.py
@@ -33,7 +33,8 @@ Authors
 Xylar Asay-Davis
 '''
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 # import python modules here
 import numpy

--- a/mpas_analysis/analysis_task_template.py
+++ b/mpas_analysis/analysis_task_template.py
@@ -351,10 +351,10 @@ class MyTask(AnalysisTask):  # {{{
         # self.myArg is a copy of the argument we passed in to __init__ when we
         # built the task.  It is available in any method after that for us to
         # use as needed.
-        print 'myArg:', self.myArg
-        print 'plotParameter:', plotParameter
+        print('myArg: {}'.format(self.myArg))
+        print('plotParameter: {}'.format(plotParameter))
         if optionalArgument is not None:
-            print 'optionalArgument:', optionalArgument
+            print('optionalArgument: {}'.format(optionalArgument))
 
         # get the file name based on the plot parameter
         filePrefix = self.filePrefixes[plotParameter]

--- a/mpas_analysis/configuration/MpasAnalysisConfigParser.py
+++ b/mpas_analysis/configuration/MpasAnalysisConfigParser.py
@@ -11,9 +11,13 @@ Xylar Asay-Davis, Phillip J. Wolfram
 
 import numbers
 import ast
+import six
 import numpy as np
-from ConfigParser import ConfigParser
 
+from six.moves.configparser import ConfigParser
+
+if six.PY3:
+    xrange = range
 
 npallow = dict(linspace=np.linspace, xrange=xrange, range=range,
                arange=np.arange, pi=np.pi, Pi=np.pi, __builtins__=None)

--- a/mpas_analysis/configuration/MpasAnalysisConfigParser.py
+++ b/mpas_analysis/configuration/MpasAnalysisConfigParser.py
@@ -9,7 +9,8 @@ Authors
 Xylar Asay-Davis, Phillip J. Wolfram
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import numbers
 import ast

--- a/mpas_analysis/configuration/MpasAnalysisConfigParser.py
+++ b/mpas_analysis/configuration/MpasAnalysisConfigParser.py
@@ -9,6 +9,8 @@ Authors
 Xylar Asay-Davis, Phillip J. Wolfram
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numbers
 import ast
 import six

--- a/mpas_analysis/ocean/__init__.py
+++ b/mpas_analysis/ocean/__init__.py
@@ -1,7 +1,7 @@
-from climatology_map import ClimatologyMapSST, ClimatologyMapMLD, \
+from .climatology_map import ClimatologyMapSST, ClimatologyMapMLD, \
     ClimatologyMapSSS
-from time_series_ohc import TimeSeriesOHC
-from time_series_sst import TimeSeriesSST
-from index_nino34 import IndexNino34
-from streamfunction_moc import StreamfunctionMOC
-from meridional_heat_transport import MeridionalHeatTransport
+from .time_series_ohc import TimeSeriesOHC
+from .time_series_sst import TimeSeriesSST
+from .index_nino34 import IndexNino34
+from .streamfunction_moc import StreamfunctionMOC
+from .meridional_heat_transport import MeridionalHeatTransport

--- a/mpas_analysis/ocean/climatology_map.py
+++ b/mpas_analysis/ocean/climatology_map.py
@@ -8,7 +8,8 @@ Authors
 Luke Van Roekel, Xylar Asay-Davis, Milena Veneziani
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import xarray as xr
 import datetime

--- a/mpas_analysis/ocean/climatology_map.py
+++ b/mpas_analysis/ocean/climatology_map.py
@@ -8,6 +8,8 @@ Authors
 Luke Van Roekel, Xylar Asay-Davis, Milena Veneziani
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import xarray as xr
 import datetime
 import numpy as np

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import datetime
 import xarray as xr

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -397,7 +397,7 @@ class IndexNino34(AnalysisTask):  # {{{
         """
 
         nt = len(inputData)
-        sp = (len(wgts) - 1)/2
+        sp = (len(wgts) - 1) // 2
         runningMean = inputData.copy()
         for k in range(sp, nt-(sp+1)):
             runningMean[k] = sum(wgts*inputData[k-sp:k+sp+1].values)

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import datetime
 import xarray as xr
 import pandas as pd

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import xarray as xr
 import numpy as np
 import netCDF4

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import xarray as xr
 import numpy as np

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import xarray as xr
 import numpy as np
 import netCDF4

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import xarray as xr
 import numpy as np

--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import numpy as np
 import netCDF4

--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -216,7 +216,7 @@ class TimeSeriesOHC(AnalysisTask):
                                startDate=self.startDate,
                                endDate=self.endDate)
         # rename the variables to shorter names for convenience
-        renameDict = dict((v, k) for k, v in variables.iteritems())
+        renameDict = dict((v, k) for k, v in variables.items())
         ds.rename(renameDict, inplace=True)
 
         timeStart = string_to_datetime(self.startDate)

--- a/mpas_analysis/ocean/time_series_ohc.py
+++ b/mpas_analysis/ocean/time_series_ohc.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 import netCDF4
 

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 from ..shared import AnalysisTask
 

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from ..shared import AnalysisTask
 
 from ..shared.plot.plotting import timeseries_analysis_plot

--- a/mpas_analysis/sea_ice/__init__.py
+++ b/mpas_analysis/sea_ice/__init__.py
@@ -1,2 +1,2 @@
-from climatology_map import ClimatologyMapSeaIceConc, ClimatologyMapSeaIceThick
-from time_series import TimeSeriesSeaIce
+from .climatology_map import ClimatologyMapSeaIceConc, ClimatologyMapSeaIceThick
+from .time_series import TimeSeriesSeaIce

--- a/mpas_analysis/sea_ice/climatology_map.py
+++ b/mpas_analysis/sea_ice/climatology_map.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import os
 import os.path

--- a/mpas_analysis/sea_ice/climatology_map.py
+++ b/mpas_analysis/sea_ice/climatology_map.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import os.path
 

--- a/mpas_analysis/sea_ice/sea_ice_analysis_task.py
+++ b/mpas_analysis/sea_ice/sea_ice_analysis_task.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from ..shared.analysis_task import AnalysisTask
 
 from ..shared.io import StreamsFile

--- a/mpas_analysis/sea_ice/sea_ice_analysis_task.py
+++ b/mpas_analysis/sea_ice/sea_ice_analysis_task.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 from ..shared.analysis_task import AnalysisTask
 

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -554,9 +554,9 @@ class TimeSeriesSeaIce(SeaIceAnalysisTask):
 
         # clip dsShift to the range of ds
         dsStartTime = dsShift.Time.sel(Time=ds.Time.min(),
-                                       method='nearest').values
+                                       method=str('nearest')).values
         dsEndTime = dsShift.Time.sel(Time=ds.Time.max(),
-                                     method='nearest').values
+                                     method=str('nearest')).values
         dsShift = dsShift.sel(Time=slice(dsStartTime, dsEndTime))
 
         return dsShift  # }}}

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import xarray as xr
 
 from .sea_ice_analysis_task import SeaIceAnalysisTask

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import xarray as xr
 

--- a/mpas_analysis/shared/__init__.py
+++ b/mpas_analysis/shared/__init__.py
@@ -1,1 +1,1 @@
-from analysis_task import AnalysisTask
+from .analysis_task import AnalysisTask

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -7,6 +7,8 @@ Xylar Asay-Davis
 
 '''
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import warnings
 from multiprocessing import Process, Value
 import time

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -509,11 +509,11 @@ class AnalysisFormatter(logging.Formatter):  # {{{
 
     # printing error messages without a prefix because they are sometimes
     # errors and sometimes only warnings sent to stderr
-    err_fmt = "%(msg)s"
     dbg_fmt = "DEBUG: %(module)s: %(lineno)d: %(msg)s"
     info_fmt = "%(msg)s"
+    err_fmt = info_fmt
 
-    def __init__(self, fmt="%(levelno)s: %(msg)s"):
+    def __init__(self, fmt=info_fmt):
         logging.Formatter.__init__(self, fmt)
 
     def format(self, record):
@@ -561,7 +561,7 @@ class StreamToLogger(object):  # {{{
 
     def write(self, buf):
         for line in buf.rstrip().splitlines():
-            self.logger.log(self.log_level, line.rstrip())
+            self.logger.log(self.log_level, str(line.rstrip()))
 
     def flush(self):
         pass

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -7,7 +7,8 @@ Xylar Asay-Davis
 
 '''
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import warnings
 from multiprocessing import Process, Value

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -327,11 +327,11 @@ def add_years_months_days_in_month(ds, calendar=None):  # {{{
             ds.coords['daysInMonth'] = ds.endTime - ds.startTime
         else:
             if calendar == 'gregorian':
-                print 'Warning: The MPAS run used the Gregorian calendar ' \
-                      'but does not appear to have\n' \
-                      'supplied start and end times.  Climatologies ' \
-                      'will be computed with\n' \
-                      'month durations ignoring leap years.'
+                print('Warning: The MPAS run used the Gregorian calendar '
+                      'but does not appear to have\n'
+                      'supplied start and end times.  Climatologies '
+                      'will be computed with\n'
+                      'month durations ignoring leap years.')
 
             daysInMonth = numpy.array([constants.daysInMonth[month-1] for
                                        month in ds.month.values], float)
@@ -527,8 +527,8 @@ def _setup_climatology_caching(ds, startYearClimo, endYearClimo,
                 dsCached = xr.open_dataset(outputFileClimo)
             except IOError:
                 # assuming the cache file is corrupt, so deleting it.
-                print 'Warning: Deleting cache file {}, which appears to ' \
-                      'have been corrupted.'.format(outputFileClimo)
+                print('Warning: Deleting cache file {}, which appears to '
+                      'have been corrupted.'.format(outputFileClimo))
 
                 os.remove(outputFileClimo)
 
@@ -576,7 +576,7 @@ def _cache_individual_climatologies(ds, cacheInfo, printProgress,
         dsYear = ds.where(ds.cacheIndices == cacheIndex, drop=True)
 
         if printProgress:
-            print '     {}'.format(yearString)
+            print('     {}'.format(yearString))
 
         totalDays = dsYear.daysInMonth.sum(dim='Time').values
 
@@ -622,8 +622,8 @@ def _cache_aggregated_climatology(startYearClimo, endYearClimo, cachePrefix,
 
         except IOError:
             # assuming the cache file is corrupt, so deleting it.
-            print 'Warning: Deleting cache file {}, which appears to have ' \
-                  'been corrupted.'.format(outputFileClimo)
+            print('Warning: Deleting cache file {}, which appears to have '
+                  'been corrupted.'.format(outputFileClimo))
             os.remove(outputFileClimo)
 
         if len(cacheInfo) == 1 and outputFileClimo == cacheInfo[0][0]:
@@ -641,8 +641,8 @@ def _cache_aggregated_climatology(startYearClimo, endYearClimo, cachePrefix,
 
     if not done:
         if printProgress:
-            print '   Computing aggregated climatology ' \
-                  '{}...'.format(yearString)
+            print('   Computing aggregated climatology '
+                  '{}...'.format(yearString))
 
         first = True
         for cacheIndex, info in enumerate(cacheInfo):

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -6,6 +6,8 @@ Authors
 Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import xarray as xr
 import os
 import numpy

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -6,7 +6,8 @@ Authors
 Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import xarray as xr
 import os

--- a/mpas_analysis/shared/climatology/comparison_descriptors.py
+++ b/mpas_analysis/shared/climatology/comparison_descriptors.py
@@ -6,6 +6,8 @@ Authors
 Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy
 import pyproj
 

--- a/mpas_analysis/shared/climatology/comparison_descriptors.py
+++ b/mpas_analysis/shared/climatology/comparison_descriptors.py
@@ -6,7 +6,8 @@ Authors
 Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import numpy
 import pyproj

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import xarray
 import os

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -429,8 +429,11 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         stdout, stderr = process.communicate()
 
         if stdout:
-            self.logger.info(stdout)
+            stdout = stdout.decode('utf-8')
+            for line in stdout.split('\n'):
+                self.logger.info(line)
         if stderr:
+            stderr = stderr.decode('utf-8')
             for line in stderr.split('\n'):
                 self.logger.error(line)
 

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import xarray
 import os
 import warnings

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import xarray as xr
 import os

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import xarray as xr
 import os
 

--- a/mpas_analysis/shared/constants/constants.py
+++ b/mpas_analysis/shared/constants/constants.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 """
 Constants that are common to all analysis tasks
 
@@ -11,6 +9,10 @@ Last modified
 -------------
 03/15/2017
 """
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import numpy as np
 
 # set parameters for default climatology comparison grid
 dLongitude = 0.5

--- a/mpas_analysis/shared/constants/constants.py
+++ b/mpas_analysis/shared/constants/constants.py
@@ -10,7 +10,8 @@ Last modified
 03/15/2017
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import numpy as np
 

--- a/mpas_analysis/shared/containers.py
+++ b/mpas_analysis/shared/containers.py
@@ -6,6 +6,8 @@
     10/22/2016
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import collections
 class ReadOnlyDict(collections.Mapping): #{{{
     """ Read only-dictionary

--- a/mpas_analysis/shared/containers.py
+++ b/mpas_analysis/shared/containers.py
@@ -6,7 +6,8 @@
     10/22/2016
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import collections
 class ReadOnlyDict(collections.Mapping): #{{{

--- a/mpas_analysis/shared/generalized_reader/__init__.py
+++ b/mpas_analysis/shared/generalized_reader/__init__.py
@@ -1,1 +1,1 @@
-from generalized_reader import open_multifile_dataset
+from .generalized_reader import open_multifile_dataset

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -13,7 +13,8 @@ Authors
 Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import six
 import xarray

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -151,11 +151,11 @@ def open_multifile_dataset(fileNames, calendar, config,
         if 'autoclose' in str(e):
             if autoclose:
                 # This indicates that xarray version doesn't support autoclose
-                print 'Warning: open_multifile_dataset is trying to use ' \
-                      'autoclose=True but\n' \
-                      'it appears your xarray version doesn\'t support this ' \
-                      'argument. Will\n' \
-                      'try again without autoclose argument.'
+                print('Warning: open_multifile_dataset is trying to use '
+                      'autoclose=True but\n'
+                      'it appears your xarray version doesn\'t support this '
+                      'argument. Will\n'
+                      'try again without autoclose argument.')
 
             ds = xarray.open_mfdataset(fileNames,
                                        preprocess=preprocess_partial,

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -15,6 +15,7 @@ Xylar Asay-Davis
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import six
 import xarray
 from functools import partial
 import resource
@@ -168,10 +169,10 @@ def open_multifile_dataset(fileNames, calendar, config,
     ds = mpas_xarray.remove_repeated_time_index(ds)
 
     if startDate is not None and endDate is not None:
-        if isinstance(startDate, str):
+        if isinstance(startDate, six.string_types):
             startDate = string_to_days_since_date(dateString=startDate,
                                                   calendar=calendar)
-        if isinstance(endDate, str):
+        if isinstance(endDate, six.string_types):
             endDate = string_to_days_since_date(dateString=endDate,
                                                 calendar=calendar)
 

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -13,6 +13,8 @@ Authors
 Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import xarray
 from functools import partial
 import resource

--- a/mpas_analysis/shared/grid/grid.py
+++ b/mpas_analysis/shared/grid/grid.py
@@ -17,6 +17,8 @@ Xylar Asay-Davis
 
 '''
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import netCDF4
 import numpy
 import sys

--- a/mpas_analysis/shared/grid/grid.py
+++ b/mpas_analysis/shared/grid/grid.py
@@ -17,7 +17,8 @@ Xylar Asay-Davis
 
 '''
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import netCDF4
 import numpy

--- a/mpas_analysis/shared/html/image_xml.py
+++ b/mpas_analysis/shared/html/image_xml.py
@@ -164,6 +164,7 @@ def _provenance_command(root, history):  # {{{
     p = subprocess.Popen(['git', 'describe', '--always', '--dirty'],
                          stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout, stderr = p.communicate()
+    stdout = stdout.decode('utf-8')
     if p.returncode == 0:
         githash = stdout.strip('\n')
     else:

--- a/mpas_analysis/shared/html/image_xml.py
+++ b/mpas_analysis/shared/html/image_xml.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import sys
 import shutil

--- a/mpas_analysis/shared/html/image_xml.py
+++ b/mpas_analysis/shared/html/image_xml.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import os
 import sys

--- a/mpas_analysis/shared/html/image_xml.py
+++ b/mpas_analysis/shared/html/image_xml.py
@@ -127,7 +127,7 @@ def write_image_xml(config, filePrefix, componentName, componentSubdirectory,
 
     _provenance_command(root, history)
 
-    for key, value in kwargs.iteritems():
+    for key, value in kwargs.items():
         etree.SubElement(root, key).text = str(value)
 
     tree = etree.ElementTree(root)

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pkg_resources
 from os import makedirs
 from shutil import copyfile

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -408,9 +408,9 @@ class ComponentPage(object):
         Xylar Asay-Davis
         """
         # get the first image name
-        firstGroup = self.groups.values().next()
-        firstGallery = firstGroup['galleries'].values().next()
-        firstImageFileName = firstGallery['images'].keys().next()
+        firstGroup = next(iter(self.groups.values()))
+        firstGallery = next(iter(firstGroup['galleries'].values()))
+        firstImageFileName = next(iter(firstGallery['images']))
         return firstImageFileName
 
     @staticmethod
@@ -493,8 +493,8 @@ class ComponentPage(object):
         content
         """
 
-        firstGallery = groupDict['galleries'].values().next()
-        firstImageFileName = firstGallery['images'].keys().next()
+        firstGallery = next(iter(groupDict['galleries'].values()))
+        firstImageFileName = next(iter(firstGallery['images']))
 
         replacements = {'@analysisGroupName': groupName,
                         '@analysisGroupLink': groupDict['link'],

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pkg_resources
 from os import makedirs

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -185,8 +185,10 @@ class MainPage(object):
 
         outFileName = '{}/index.html'.format(htmlBaseDirectory)
 
-        with open(outFileName, 'w') as mainFile:
-            mainFile.write(pageText.encode('ascii', 'xmlcharrefreplace'))
+        with open(outFileName, mode='w') as mainFile:
+            mainFile.write(
+                    pageText.encode('ascii',
+                                    'xmlcharrefreplace').decode('ascii'))
 
         # copy the css and js files
         fileName = \
@@ -391,8 +393,10 @@ class ComponentPage(object):
 
         outFileName = '{}/index.html'.format(self.directory)
 
-        with open(outFileName, 'w') as componentFile:
-            componentFile.write(pageText.encode('ascii', 'xmlcharrefreplace'))
+        with open(outFileName, mode='w') as componentFile:
+            componentFile.write(
+                    pageText.encode('ascii',
+                                    'xmlcharrefreplace').decode('ascii'))
 
     def get_first_image(self):
         """

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -30,7 +30,7 @@ def generate_html(config, analyses):  # {{{
     if not generateHTML:
         return
 
-    print "Generating webpage for viewing results..."
+    print("Generating webpage for viewing results...")
 
     page = MainPage(config)
 
@@ -46,8 +46,8 @@ def generate_html(config, analyses):  # {{{
                 missingCount += 1
 
     if missingCount > 0:
-        print 'Warning: {} XML files were missing and the analysis website' \
-              ' will be incomplete.'.format(missingCount)
+        print('Warning: {} XML files were missing and the analysis website'
+              ' will be incomplete.'.format(missingCount))
     # generate the page for each component and add the component to the main
     # page
     for componentName, component in components.items():

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -38,7 +38,7 @@ def generate_html(config, analyses):  # {{{
 
     # add images from each analysis task, creating ga dictionary of components
     missingCount = 0
-    for analysisTask in analyses.itervalues():
+    for analysisTask in analyses.values():
         for fileName in analysisTask.xmlFileNames:
             try:
                 ComponentPage.add_image(fileName, config, components)
@@ -405,9 +405,9 @@ class ComponentPage(object):
         Xylar Asay-Davis
         """
         # get the first image name
-        firstGroup = self.groups.itervalues().next()
-        firstGallery = firstGroup['galleries'].itervalues().next()
-        firstImageFileName = firstGallery['images'].iterkeys().next()
+        firstGroup = self.groups.values().next()
+        firstGallery = firstGroup['galleries'].values().next()
+        firstImageFileName = firstGallery['images'].keys().next()
         return firstImageFileName
 
     @staticmethod
@@ -490,8 +490,8 @@ class ComponentPage(object):
         content
         """
 
-        firstGallery = groupDict['galleries'].itervalues().next()
-        firstImageFileName = firstGallery['images'].iterkeys().next()
+        firstGallery = groupDict['galleries'].values().next()
+        firstImageFileName = firstGallery['images'].keys().next()
 
         replacements = {'@analysisGroupName': groupName,
                         '@analysisGroupLink': groupDict['link'],

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -157,7 +157,7 @@ class Remapper(object):
             args.extend(additionalArgs)
 
         if logger is None:
-            print 'running: {}'.format(' '.join(args))
+            print('running: {}'.format(' '.join(args)))
             # make sure any output is flushed before we add output from the
             # subprocess
             sys.stdout.flush()
@@ -299,7 +299,7 @@ class Remapper(object):
         env['NCO_PATH_OVERRIDE'] = 'No'
 
         if logger is None:
-            print 'running: {}'.format(' '.join(args))
+            print('running: {}'.format(' '.join(args)))
             # make sure any output is flushed before we add output from the
             # subprocess
             sys.stdout.flush()

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -319,8 +319,11 @@ class Remapper(object):
             stdout, stderr = process.communicate()
 
             if stdout:
-                logger.info(stdout)
+                stdout = stdout.decode('utf-8')
+                for line in stdout.split('\n'):
+                    logger.info(line)
             if stderr:
+                stderr = stderr.decode('utf-8')
                 for line in stderr.split('\n'):
                     logger.error(line)
 

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -13,6 +13,8 @@ Authors
 Xylar Asay-Davis
 '''
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import subprocess
 import tempfile
 import os

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -13,7 +13,8 @@ Authors
 Xylar Asay-Davis
 '''
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import subprocess
 import tempfile

--- a/mpas_analysis/shared/io/mpas_reader.py
+++ b/mpas_analysis/shared/io/mpas_reader.py
@@ -7,7 +7,8 @@ Authors
 Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import six
 import xarray

--- a/mpas_analysis/shared/io/mpas_reader.py
+++ b/mpas_analysis/shared/io/mpas_reader.py
@@ -7,6 +7,8 @@ Authors
 Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import xarray
 
 from ..timekeeping.utility import string_to_days_since_date, days_to_datetime

--- a/mpas_analysis/shared/io/mpas_reader.py
+++ b/mpas_analysis/shared/io/mpas_reader.py
@@ -239,7 +239,7 @@ def _parse_dataset_time(ds, inTimeVariableName, calendar,
 
         # this is an array of date strings like 'xtime'
         # convert to string
-        timeStrings = [''.join(xtime).strip() for xtime in timeVar.values]
+        timeStrings = [''.join(xtime.astype('U')).strip() for xtime in timeVar.values]
         days = string_to_days_since_date(dateString=timeStrings,
                                          referenceDate=referenceDate,
                                          calendar=calendar)

--- a/mpas_analysis/shared/io/mpas_reader.py
+++ b/mpas_analysis/shared/io/mpas_reader.py
@@ -9,6 +9,7 @@ Xylar Asay-Davis
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import six
 import xarray
 
 from ..timekeeping.utility import string_to_days_since_date, days_to_datetime
@@ -64,10 +65,10 @@ def open_mpas_dataset(fileName, calendar,
     ds = _parse_dataset_time(ds, timeVariableNames, calendar)
 
     if startDate is not None and endDate is not None:
-        if isinstance(startDate, str):
+        if isinstance(startDate, six.string_types):
             startDate = string_to_days_since_date(dateString=startDate,
                                                   calendar=calendar)
-        if isinstance(endDate, str):
+        if isinstance(endDate, six.string_types):
             endDate = string_to_days_since_date(dateString=endDate,
                                                 calendar=calendar)
 

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -10,6 +10,7 @@ Phillip Wolfram, Xylar Asay-Davis
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import six
 from lxml import etree
 import re
 import os.path
@@ -398,12 +399,12 @@ class StreamsFile:
 
         if startDate is not None:
             # read one extra file before the start date to be on the safe side
-            if isinstance(startDate, str):
+            if isinstance(startDate, six.string_types):
                 startDate = string_to_datetime(startDate)
 
         if endDate is not None:
             # read one extra file after the end date to be on the safe side
-            if isinstance(endDate, str):
+            if isinstance(endDate, six.string_types):
                 endDate = string_to_datetime(endDate)
 
         # remove any path that's part of the template

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -8,6 +8,8 @@ Authors
 Phillip Wolfram, Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 from lxml import etree
 import re
 import os.path

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -8,7 +8,8 @@ Authors
 Phillip Wolfram, Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import six
 from lxml import etree

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -4,6 +4,8 @@ IO utility functions
 Phillip J. Wolfram, Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import glob
 import os
 import random

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -4,7 +4,8 @@ IO utility functions
 Phillip J. Wolfram, Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import glob
 import os

--- a/mpas_analysis/shared/io/write_netcdf.py
+++ b/mpas_analysis/shared/io/write_netcdf.py
@@ -12,6 +12,8 @@ Xylar Asay-Davis
 
 '''
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import netCDF4
 import numpy
 

--- a/mpas_analysis/shared/io/write_netcdf.py
+++ b/mpas_analysis/shared/io/write_netcdf.py
@@ -12,7 +12,8 @@ Xylar Asay-Davis
 
 '''
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import netCDF4
 import numpy

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -1,3 +1,7 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+
 import numpy as np
 import xarray
 from functools import partial

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -278,7 +278,7 @@ def remove_repeated_time_index(ds):  # {{{
     """
     # get repeated indices
     times = ds.Time.values
-    indices = range(len(times))
+    indices = list(range(len(times)))
     uniqueTimes = set()
     remove = []
     for timeIndex, time in enumerate(times):

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 
 import numpy as np
+import six
 import xarray
 from functools import partial
 
@@ -342,7 +343,7 @@ def _ensure_list(alist):  # {{{
     Phillip J. Wolfram, Xylar Asay-Davis
     """
 
-    if isinstance(alist, str):
+    if isinstance(alist, six.string_types):
         # print 'Warning, converting %s to a list'%(alist)
         alist = [alist]
 

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -1,6 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
-
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import numpy as np
 import six

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -468,7 +468,7 @@ def _parse_dataset_time(ds, inTimeVariableName, calendar,
         if timeVar.dtype == '|S64':
             # this is an array of date strings like 'xtime'
             # convert to string
-            timeStrings = [''.join(xtime).strip() for xtime in timeVar.values]
+            timeStrings = [''.join(str(xtime.astype('U'))).strip() for xtime in timeVar.values]
             days = string_to_days_since_date(dateString=timeStrings,
                                              referenceDate=referenceDate,
                                              calendar=calendar)

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -10,7 +10,8 @@ Authors
 Xylar Asay-Davis, Milena Veneziani, Luke Van Roekel, Greg Streletz
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import matplotlib.pyplot as plt
 import matplotlib.colors as cols

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -24,7 +24,7 @@ from ..timekeeping.utility import days_to_datetime, date_to_days
 
 from ..constants import constants
 
-import ConfigParser
+from six.moves import configparser
 
 
 def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
@@ -913,7 +913,7 @@ def setup_colormap(config, configSectionName, suffix=''):
         colorbarLevels = config.getExpression(configSectionName,
                                               'colorbarLevels{}'.format(suffix),
                                               usenumpyfunc=True)
-    except(ConfigParser.NoOptionError):
+    except(configparser.NoOptionError):
         colorbarLevels = None
 
     if colorbarLevels is not None:

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -10,6 +10,8 @@ Authors
 Xylar Asay-Davis, Milena Veneziani, Luke Van Roekel, Greg Streletz
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import matplotlib.pyplot as plt
 import matplotlib.colors as cols
 import xarray as xr

--- a/mpas_analysis/shared/time_series/__init__.py
+++ b/mpas_analysis/shared/time_series/__init__.py
@@ -1,2 +1,2 @@
 from .time_series import cache_time_series
-from mpas_time_series_task import MpasTimeSeriesTask
+from .mpas_time_series_task import MpasTimeSeriesTask

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import warnings
 import subprocess

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -317,8 +317,11 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         stdout, stderr = process.communicate()
 
         if stdout:
-            self.logger.info(stdout)
+            stdout = stdout.decode('utf-8')
+            for line in stdout.split('\n'):
+                self.logger.info(line)
         if stderr:
+            stderr = stderr.decode('utf-8')
             for line in stderr.split('\n'):
                 self.logger.error(line)
 

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import os
 import warnings

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -6,6 +6,8 @@ Authors
 Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import xarray as xr
 import numpy
 import os

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -6,7 +6,8 @@ Authors
 Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import xarray as xr
 import numpy

--- a/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
+++ b/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
@@ -1,3 +1,6 @@
+
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import datetime
 from dateutil.relativedelta import relativedelta
 from calendar import monthrange, isleap

--- a/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
+++ b/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
@@ -1,5 +1,6 @@
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import datetime
 from dateutil.relativedelta import relativedelta

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -6,6 +6,8 @@ Authors
 Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import datetime
 import netCDF4
 import numpy

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -420,7 +420,7 @@ def _parse_date_string(dateString, isInterval=False):  # {{{
         offset = 1
 
     # change underscores to spaces so both can be supported
-    dateString = dateString.replace('_', ' ')
+    dateString = dateString.replace('_', ' ').strip()
     if ' ' in dateString:
         ymd, hms = dateString.split(' ')
     else:

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -52,7 +52,7 @@ def get_simulation_start_time(streams):
     ncFile = netCDF4.Dataset(restartFile, mode='r')
     simulationStartTime = ncFile.variables['simulationStartTime'][:]
     # convert from character array to str
-    simulationStartTime = ''.join(simulationStartTime).strip()
+    simulationStartTime = ''.join(simulationStartTime.astype('U')).strip()
     # replace underscores so it works as a CF-compliant reference date
     simulationStartTime = simulationStartTime.replace('_', ' ')
     ncFile.close()

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 import netCDF4
 import numpy
+import six
 
 from .MpasRelativeDelta import MpasRelativeDelta
 
@@ -207,7 +208,7 @@ def string_to_days_since_date(dateString, calendar='gregorian',
     Xylar Asay-Davis
     """
 
-    isSingleString = isinstance(dateString, str)
+    isSingleString = isinstance(dateString, six.string_types)
 
     if isSingleString:
         dateString = [dateString]

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -6,7 +6,8 @@ Authors
 Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import datetime
 import netCDF4

--- a/mpas_analysis/test/__init__.py
+++ b/mpas_analysis/test/__init__.py
@@ -55,7 +55,7 @@ def loaddatadir(request, tmpdir):
     test_dir, _ = os.path.splitext(filename)
 
     if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, bytes(tmpdir))
+        dir_util.copy_tree(test_dir, str(tmpdir))
 
     request.cls.datadir = tmpdir
 

--- a/mpas_analysis/test/__init__.py
+++ b/mpas_analysis/test/__init__.py
@@ -5,6 +5,8 @@ Phillip J. Wolfram, Xylar Asay-Davis
 04/06/2017
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import warnings
 from contextlib import contextmanager
 

--- a/mpas_analysis/test/__init__.py
+++ b/mpas_analysis/test/__init__.py
@@ -5,7 +5,8 @@ Phillip J. Wolfram, Xylar Asay-Davis
 04/06/2017
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import warnings
 from contextlib import contextmanager

--- a/mpas_analysis/test/test_analysis_task.py
+++ b/mpas_analysis/test/test_analysis_task.py
@@ -4,6 +4,8 @@ Unit tests for utility functions in run_mpas_analysis
 Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 from mpas_analysis.test import TestCase
 from mpas_analysis.shared.analysis_task import AnalysisTask

--- a/mpas_analysis/test/test_analysis_task.py
+++ b/mpas_analysis/test/test_analysis_task.py
@@ -4,7 +4,8 @@ Unit tests for utility functions in run_mpas_analysis
 Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pytest
 from mpas_analysis.test import TestCase

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -5,7 +5,8 @@ Xylar Asay-Davis
 04/11/2017
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pytest
 import tempfile

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -5,6 +5,8 @@ Xylar Asay-Davis
 04/11/2017
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 import tempfile
 import shutil

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -235,7 +235,7 @@ class TestClimatology(TestCase):
 
         assert('Time' not in dsClimatology.dims.keys())
 
-        self.assertEqual(dsClimatology.data_vars.keys(), ['mld'])
+        self.assertEqual(list(dsClimatology.data_vars.keys()), ['mld'])
 
         climFileName = '{}/refSeasonalClim.nc'.format(self.datadir)
         refClimatology = xarray.open_dataset(climFileName)
@@ -263,7 +263,7 @@ class TestClimatology(TestCase):
 
         assert(len(monthlyClimatology.month) == 3)
 
-        self.assertEqual(monthlyClimatology.data_vars.keys(), ['mld'])
+        self.assertEqual(list(monthlyClimatology.data_vars.keys()), ['mld'])
 
         climFileName = '{}/refMonthlyClim.nc'.format(self.datadir)
         refClimatology = xarray.open_dataset(climFileName)

--- a/mpas_analysis/test/test_generalized_reader.py
+++ b/mpas_analysis/test/test_generalized_reader.py
@@ -5,7 +5,8 @@ Xylar Asay-Davis
 02/16/2017
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir

--- a/mpas_analysis/test/test_generalized_reader.py
+++ b/mpas_analysis/test/test_generalized_reader.py
@@ -80,7 +80,7 @@ class TestGeneralizedReader(TestCase):
                 config=config,
                 timeVariableName=timestr,
                 variableList=variableList)
-            self.assertEqual(ds.data_vars.keys(), variableList)
+            self.assertEqual(list(ds.data_vars.keys()), variableList)
 
     def test_start_end(self):
         fileName = str(self.datadir.join('example_jan_feb.nc'))

--- a/mpas_analysis/test/test_generalized_reader.py
+++ b/mpas_analysis/test/test_generalized_reader.py
@@ -5,6 +5,8 @@ Xylar Asay-Davis
 02/16/2017
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.generalized_reader.generalized_reader \

--- a/mpas_analysis/test/test_interpolate.py
+++ b/mpas_analysis/test/test_interpolate.py
@@ -5,7 +5,8 @@ Xylar Asay-Davis
 04/06/2017
 '''
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pytest
 import shutil

--- a/mpas_analysis/test/test_interpolate.py
+++ b/mpas_analysis/test/test_interpolate.py
@@ -5,6 +5,8 @@ Xylar Asay-Davis
 04/06/2017
 '''
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 import shutil
 import os

--- a/mpas_analysis/test/test_io_utility.py
+++ b/mpas_analysis/test/test_io_utility.py
@@ -5,6 +5,8 @@ Phillip J. Wolfram
 10/07/2016
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir

--- a/mpas_analysis/test/test_io_utility.py
+++ b/mpas_analysis/test/test_io_utility.py
@@ -5,7 +5,8 @@ Phillip J. Wolfram
 10/07/2016
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import os
 import pytest

--- a/mpas_analysis/test/test_io_utility.py
+++ b/mpas_analysis/test/test_io_utility.py
@@ -16,7 +16,7 @@ from mpas_analysis.shared.io import paths
 @pytest.mark.usefixtures("loaddatadir")
 class TestPaths(TestCase):
     def test_paths(self):
-        os.chdir(bytes(self.datadir))
+        os.chdir(str(self.datadir))
         self.assertEquals(paths('[0-9]*', '[a-z]*'),
                           ['0.txt', '1.txt', '2.txt', 'a.txt', 'b.txt',
                            'c.txt'])

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -4,7 +4,8 @@ Unit test infrastructure for MpasClimatologyTask.
 Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pytest
 import tempfile

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -4,6 +4,8 @@ Unit test infrastructure for MpasClimatologyTask.
 Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 import tempfile
 import shutil

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -5,7 +5,8 @@ Xylar Asay-Davis, Phillip J. Wolfram
 01/31/2017
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pytest
 import six

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -80,7 +80,7 @@ class TestMPASAnalysisConfigParser(TestCase):
         with self.assertRaisesRegexp(
                 configparser.NoOptionError,
                 "No option 'doesntexist' in section: 'Test'"):
-            self.config.getExpression('Test', 'doesntexist')
+            self.config.getExpression(str('Test'), str('doesntexist'))
 
     @requires_numpy
     def test_read_config_numpy(self):
@@ -118,18 +118,13 @@ class TestMPASAnalysisConfigParser(TestCase):
             assert isinstance(var, dtype)
             self.assertEqual(var, value)
 
-        if six.PY3:
-            integer_types = (int,)
-        else:
-            integer_types = (int, long,)
-
         # test several types with getWithDefault
         check_get_with_default(name='aBool', value=True, dtype=bool)
-        check_get_with_default(name='anInt', value=1, dtype=integer_types)
+        check_get_with_default(name='anInt', value=1, dtype=six.integer_types)
         check_get_with_default(name='aFloat', value=1.0, dtype=float)
         check_get_with_default(name='aList', value=[1, 2, 3], dtype=list)
         check_get_with_default(name='aTuple', value=(1, 2, 3), dtype=tuple)
         check_get_with_default(name='aDict', value={'blah': 1}, dtype=dict)
-        check_get_with_default(name='aStr', value='blah', dtype=str)
+        check_get_with_default(name='aStr', value='blah', dtype=six.string_types)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -6,7 +6,7 @@ Xylar Asay-Davis, Phillip J. Wolfram
 """
 
 import pytest
-import ConfigParser
+from six.moves import configparser
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.configuration.MpasAnalysisConfigParser \
     import MpasAnalysisConfigParser
@@ -75,7 +75,7 @@ class TestMPASAnalysisConfigParser(TestCase):
                                     'key3': False})
 
         with self.assertRaisesRegexp(
-                ConfigParser.NoOptionError,
+                configparser.NoOptionError,
                 "No option 'doesntexist' in section: 'Test'"):
             self.config.getExpression('Test', 'doesntexist')
 

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -118,9 +118,14 @@ class TestMPASAnalysisConfigParser(TestCase):
             assert isinstance(var, dtype)
             self.assertEqual(var, value)
 
+        if six.PY3:
+            integer_types = (int,)
+        else:
+            integer_types = (int, long,)
+
         # test several types with getWithDefault
         check_get_with_default(name='aBool', value=True, dtype=bool)
-        check_get_with_default(name='anInt', value=1, dtype=(int, long))
+        check_get_with_default(name='anInt', value=1, dtype=integer_types)
         check_get_with_default(name='aFloat', value=1.0, dtype=float)
         check_get_with_default(name='aList', value=[1, 2, 3], dtype=list)
         check_get_with_default(name='aTuple', value=(1, 2, 3), dtype=tuple)

--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -5,7 +5,10 @@ Xylar Asay-Davis, Phillip J. Wolfram
 01/31/2017
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
+import six
 from six.moves import configparser
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.configuration.MpasAnalysisConfigParser \

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -5,6 +5,8 @@ Xylar Asay-Davis, Phillip J. Wolfram
 02/15/2017
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.mpas_xarray import mpas_xarray

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -40,7 +40,7 @@ class TestMpasXarray(TestCase):
                                                 calendar=calendar,
                                                 timeVariableName=timestr,
                                                 variableList=variableList)
-        self.assertEqual(ds.data_vars.keys(), variableList)
+        self.assertEqual(list(ds.data_vars.keys()), variableList)
 
         with self.assertRaisesRegexp(ValueError,
                                      'Empty dataset is returned.'):
@@ -149,7 +149,7 @@ class TestMpasXarray(TestCase):
                 variableList=variableList,
                 selValues=selvals)
 
-            self.assertEqual(ds.data_vars.keys(), variableList)
+            self.assertEqual(list(ds.data_vars.keys()), variableList)
             self.assertEqual(ds[variableList[0]].shape, (1, 7))
             self.assertEqual(ds['refBottomDepth'],
                              dsRef['refBottomDepth'][vertIndex])

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -5,7 +5,8 @@ Xylar Asay-Davis, Phillip J. Wolfram
 02/15/2017
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir

--- a/mpas_analysis/test/test_namelist_streams_interface.py
+++ b/mpas_analysis/test/test_namelist_streams_interface.py
@@ -17,11 +17,11 @@ from mpas_analysis.shared.io import NameList, StreamsFile
 class TestNamelist(TestCase):
     def setup_namelist(self):
         nlpath = self.datadir.join('namelist.ocean')
-        self.nl = NameList(bytes(nlpath))
+        self.nl = NameList(str(nlpath))
 
     def setup_streams(self):
         sfpath = self.datadir.join('streams.ocean')
-        self.sf = StreamsFile(bytes(sfpath))
+        self.sf = StreamsFile(str(sfpath))
 
     def test_open_files(self):
         self.setup_namelist()

--- a/mpas_analysis/test/test_namelist_streams_interface.py
+++ b/mpas_analysis/test/test_namelist_streams_interface.py
@@ -6,7 +6,8 @@ Phillip J. Wolfram, Xylar Asay-Davis
 10/26/2016
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir

--- a/mpas_analysis/test/test_namelist_streams_interface.py
+++ b/mpas_analysis/test/test_namelist_streams_interface.py
@@ -6,6 +6,8 @@ Phillip J. Wolfram, Xylar Asay-Davis
 10/26/2016
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.io import NameList, StreamsFile

--- a/mpas_analysis/test/test_open_mpas_dataset.py
+++ b/mpas_analysis/test/test_open_mpas_dataset.py
@@ -27,7 +27,7 @@ class TestOpenMpasDataset(TestCase):
                 calendar=calendar,
                 timeVariableNames=timestr,
                 variableList=variableList)
-            self.assertEqual(ds.data_vars.keys(), variableList)
+            self.assertEqual(list(ds.data_vars.keys()), variableList)
 
     def test_start_end(self):
         fileName = str(self.datadir.join('example_jan_feb.nc'))

--- a/mpas_analysis/test/test_open_mpas_dataset.py
+++ b/mpas_analysis/test/test_open_mpas_dataset.py
@@ -5,7 +5,8 @@ Xylar Asay-Davis
 02/16/2017
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir

--- a/mpas_analysis/test/test_open_mpas_dataset.py
+++ b/mpas_analysis/test/test_open_mpas_dataset.py
@@ -5,6 +5,8 @@ Xylar Asay-Davis
 02/16/2017
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.io import open_mpas_dataset

--- a/mpas_analysis/test/test_timekeeping.py
+++ b/mpas_analysis/test/test_timekeeping.py
@@ -6,6 +6,8 @@ Authors
 Xylar Asay-Davis
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import pytest
 import datetime
 from mpas_analysis.shared.timekeeping.MpasRelativeDelta \

--- a/mpas_analysis/test/test_timekeeping.py
+++ b/mpas_analysis/test/test_timekeeping.py
@@ -6,7 +6,8 @@ Authors
 Xylar Asay-Davis
 """
 
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
 
 import pytest
 import datetime

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -9,6 +9,8 @@ Authors
 Xylar Asay-Davis, Phillip J. Wolfram
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import matplotlib as mpl
 import argparse
 import traceback

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -184,12 +184,12 @@ def add_task_and_subtasks(analysisTask, analysesToGenerate,
         add_task_and_subtasks(prereq, analysesToGenerate,
                               callCheckGenerate=False)
         if prereq._setupStatus != 'success':
-            print prereq._setupStatus
+            print(prereq._setupStatus)
             # a prereq failed setup_and_check
-            print "ERROR: prerequisite task {} of analysis task {}" \
-                  " failed during check,\n" \
+            print("ERROR: prerequisite task {} of analysis task {}"
+                  " failed during check,\n"
                   "       so this task will not be run".format(
-                          prereq.printTaskName, taskTitle)
+                prereq.printTaskName, taskTitle))
             analysisTask._setupStatus = 'fail'
             return
 
@@ -199,8 +199,8 @@ def add_task_and_subtasks(analysisTask, analysesToGenerate,
         analysisTask.setup_and_check()
     except (Exception, BaseException):
         traceback.print_exc(file=sys.stdout)
-        print "ERROR: analysis task {} failed during check and " \
-            "will not be run".format(taskTitle)
+        print("ERROR: analysis task {} failed during check and "
+              "will not be run".format(taskTitle))
         analysisTask._setupStatus = 'fail'
         return
 
@@ -212,9 +212,9 @@ def add_task_and_subtasks(analysisTask, analysesToGenerate,
                               callCheckGenerate=False)
         if subtask._setupStatus != 'success':
             # a subtask failed setup_and_check
-            print "ERROR: a subtask of analysis task {}" \
-                  " failed during check,\n" \
-                  "       so this task will not be run".format(taskTitle)
+            print("ERROR: a subtask of analysis task {}"
+                  " failed during check,\n"
+                  "       so this task will not be run".format(taskTitle))
             analysisTask._setupStatus = 'fail'
             return
 
@@ -313,7 +313,7 @@ def run_analysis(config, analyses):  # {{{
         for key, analysisTask in analyses.items():
             if analysisTask._runStatus.value == AnalysisTask.READY:
                 if isParallel:
-                    print 'Running {}'.format(analysisTask.printTaskName)
+                    print('Running {}'.format(analysisTask.printTaskName))
                     analysisTask._runStatus.value = AnalysisTask.RUNNING
                     analysisTask.start()
                     runningTasks[key] = analysisTask
@@ -331,14 +331,14 @@ def run_analysis(config, analyses):  # {{{
             taskTitle = analysisTask.printTaskName
 
             if analysisTask._runStatus.value == AnalysisTask.SUCCESS:
-                print "   Task {} has finished successfully.".format(taskTitle)
+                print("   Task {} has finished successfully.".format(taskTitle))
             elif analysisTask._runStatus.value == AnalysisTask.FAIL:
-                print "ERROR in task {}.  See log file {} for details".format(
-                    taskTitle, analysisTask._logFileName)
+                print("ERROR in task {}.  See log file {} for details".format(
+                    taskTitle, analysisTask._logFileName))
                 tasksWithErrors.append(taskTitle)
             else:
-                print "Unexpected status from in task {}.  This may be a " \
-                      "bug.".format(taskTitle)
+                print("Unexpected status from in task {}.  This may be a "
+                      "bug.".format(taskTitle))
 
     if not isParallel and config.getboolean('plot', 'displayToScreen'):
         import matplotlib.pyplot as plt
@@ -347,11 +347,11 @@ def run_analysis(config, analyses):  # {{{
     # raise the last exception so the process exits with an error
     errorCount = len(tasksWithErrors)
     if errorCount == 1:
-        print "There were errors in task {}".format(tasksWithErrors[0])
+        print("There were errors in task {}".format(tasksWithErrors[0]))
         sys.exit(1)
     elif errorCount > 0:
-        print "There were errors in {} tasks: {}".format(
-                errorCount, ', '.join(tasksWithErrors))
+        print("There were errors in {} tasks: {}".format(
+            errorCount, ', '.join(tasksWithErrors)))
         sys.exit(1)
     # }}}
 
@@ -415,9 +415,9 @@ if __name__ == "__main__":
                                                         'config.default')
         configFiles = [defaultConfig] + args.configFiles
     else:
-        print 'WARNING: Did not find config.default.  Assuming other config ' \
-              'file(s) contain a\n' \
-              'full set of configuration options.'
+        print('WARNING: Did not find config.default.  Assuming other config '
+              'file(s) contain a\n'
+              'full set of configuration options.')
         configFiles = args.configFiles
 
     config = MpasAnalysisConfigParser()
@@ -426,17 +426,17 @@ if __name__ == "__main__":
     if args.list:
         analyses = build_analysis_list(config)
         for analysisTask in analyses:
-            print '{}\n    tags: {}'.format(analysisTask.taskName,
-                                            ', '.join(analysisTask.tags))
+            print('{}\n    tags: {}'.format(analysisTask.taskName,
+                                            ', '.join(analysisTask.tags)))
         sys.exit(0)
 
     if args.purge:
         outputDirectory = config.get('output', 'baseDirectory')
         if not os.path.exists(outputDirectory):
-            print 'Output directory {} does not exist.\n' \
-                  'No purge necessary.'.format(outputDirectory)
+            print('Output directory {} does not exist.\n'
+                  'No purge necessary.'.format(outputDirectory))
         else:
-            print 'Deleting contents of {}'.format(outputDirectory)
+            print('Deleting contents of {}'.format(outputDirectory))
             shutil.rmtree(outputDirectory)
 
     if args.generate:

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -274,7 +274,7 @@ def run_analysis(config, analyses):  # {{{
 
     isParallel = taskCount > 1 and len(analyses) > 1
 
-    for analysisTask in analyses.itervalues():
+    for analysisTask in analyses.values():
         if not analysisTask.runAfterTasks and not analysisTask.subtasks:
             analysisTask._runStatus.value = AnalysisTask.READY
         else:
@@ -286,7 +286,7 @@ def run_analysis(config, analyses):  # {{{
     # run each analysis task
     while True:
         # we still have tasks to run
-        for analysisTask in analyses.itervalues():
+        for analysisTask in analyses.values():
             if analysisTask._runStatus.value == AnalysisTask.BLOCKED:
                 prereqs = analysisTask.runAfterTasks + analysisTask.subtasks
                 prereqStatus = [prereq._runStatus.value for prereq in prereqs]
@@ -300,7 +300,7 @@ def run_analysis(config, analyses):  # {{{
                     analysisTask._runStatus.value = AnalysisTask.READY
 
         unfinishedCount = 0
-        for analysisTask in analyses.itervalues():
+        for analysisTask in analyses.values():
             if analysisTask._runStatus.value not in [AnalysisTask.SUCCESS,
                                                      AnalysisTask.FAIL]:
                 unfinishedCount += 1
@@ -379,7 +379,7 @@ def wait_for_task(runningTasks, timeout=0.1):  # {{{
     # necessary to have a timeout so we can kill the whole thing
     # with a keyboard interrupt
     while True:
-        for analysisTask in runningTasks.itervalues():
+        for analysisTask in runningTasks.values():
             analysisTask.join(timeout=timeout)
             if not analysisTask.is_alive():
                 return analysisTask  # }}}


### PR DESCRIPTION
This PR adds python 2 and 3 support using the module `six` as little as possible. 

I've tried to commit like-changes in small chunks so you can easily see what was needed to change the code. *Note: that means that all commits from 57dbcb9 to cb5e801 are broken. This could all be squashed for merging into master.*

Status:
-------

All tests pass in both python 2.7 and 3.5, *but* there are likely issues lurking in the python 2 code now with unicode vs byte strings. 

Left to do:
-----------

- [x] configure ci for tox (see #40 and #42)

- [x] check all usages of `str` for cross compatibility

----

fixes #43