### PR TITLE
Fix future warning from xarray

### DIFF
--- a/mpas_analysis/shared/io/write_netcdf.py
+++ b/mpas_analysis/shared/io/write_netcdf.py
@@ -42,7 +42,8 @@ def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals):  # {{{
 
     '''
     encodingDict = {}
-    for variableName in ds:
+    variableNames = list(ds.data_vars.keys()) + list(ds.coords.keys())
+    for variableName in variableNames:
         dtype = ds[variableName].dtype
         for fillType in fillValues:
             if dtype == numpy.dtype(fillType):


### PR DESCRIPTION
Iterating over data sets will no longer iterate over coordinates in addition to data variables.  We want both when we write out NetCDF files, so we switch to doing so explicitly.