### PR TITLE
Fix exit status when errors occur in tasks in serial mode

### DIFF
--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -341,6 +341,9 @@ def run_analysis(config, analyses):  # {{{
             else:
                 print("Unexpected status from in task {}.  This may be a "
                       "bug.".format(taskTitle))
+        else:
+            if analysisTask._runStatus.value == AnalysisTask.FAIL:
+                sys.exit(1)
 
     if not isParallel and config.getboolean('plot', 'displayToScreen'):
         import matplotlib.pyplot as plt


### PR DESCRIPTION
Previously, the code was not exiting with status 1 when a task failed.