### PR TITLE
Add task for plotting climatology maps for Antarctic melt rates

### DIFF
--- a/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+++ b/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
@@ -36,37 +36,28 @@ baseDirectory = /dir/to/analysis/output
 # to be copied elsewhere (e.g. NERSC web portal)
 htmlSubdirectory = html
 
-# a list of analyses to generate.  Valid names are:
-#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
-#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
-#   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH',
-#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH',
-#   'climatologyMapSeaIceThickSH'
-# the following shortcuts exist:
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
 #   'all' -- all analyses will be run
-#   'all_timeSeries' -- all time-series analyses will be run
-#   'all_climatology' -- all analyses involving climatologies
-#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
-#   'all_ocean' -- all ocean analyses will be run
-#   'all_seaIce' -- all sea-ice analyses will be run
-#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
-#                             other analyses).
-#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
-#                                            given category of analysis
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
-
-# alternative examples that would perform all analysis except
-#   'timeSeriesOHC'
-#generate = ['all', 'no_timeSeriesOHC']
-# Each subsequent list entry can be used to alter previous list entries. For
-# example, the following would run all tasks that aren't ocean analyses,
-# except that it would also run ocean time series tasks:
-#generate = ['all', 'no_ocean', 'all_timeSeries']
+# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# include ice-shelf cavities.`
+generate = ['all', 'no_climatologyMapAntarcticMelt']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/edison/config.20170807.beta1.G_oQU240.edison
+++ b/configs/edison/config.20170807.beta1.G_oQU240.edison
@@ -37,37 +37,28 @@ baseDirectory = /dir/to/analysis/output
 # htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
-# a list of analyses to generate.  Valid names are:
-#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
-#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
-#   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH',
-#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH',
-#   'climatologyMapSeaIceThickSH'
-# the following shortcuts exist:
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
 #   'all' -- all analyses will be run
-#   'all_timeSeries' -- all time-series analyses will be run
-#   'all_climatology' -- all analyses involving climatologies
-#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
-#   'all_ocean' -- all ocean analyses will be run
-#   'all_seaIce' -- all sea-ice analyses will be run
-#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
-#                             other analyses).
-#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
-#                                            given category of analysis
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
-
-# alternative examples that would perform all analysis except
-#   'timeSeriesOHC'
-#generate = ['all', 'no_timeSeriesOHC']
-# Each subsequent list entry can be used to alter previous list entries. For
-# example, the following would run all tasks that aren't ocean analyses,
-# except that it would also run ocean time series tasks:
-#generate = ['all', 'no_ocean', 'all_timeSeries']
+# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# include ice-shelf cavities.`
+generate = ['all', 'no_climatologyMapAntarcticMelt']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/edison/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -52,37 +52,28 @@ baseDirectory = /dir/to/analysis/output
 # htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
-# a list of analyses to generate.  Valid names are:
-#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
-#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
-#   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH',
-#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH',
-#   'climatologyMapSeaIceThickSH'
-# the following shortcuts exist:
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
 #   'all' -- all analyses will be run
-#   'all_timeSeries' -- all time-series analyses will be run
-#   'all_climatology' -- all analyses involving climatologies
-#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
-#   'all_ocean' -- all ocean analyses will be run
-#   'all_seaIce' -- all sea-ice analyses will be run
-#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
-#                             other analyses).
-#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
-#                                            given category of analysis
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
-
-# alternative examples that would perform all analysis except
-#   'timeSeriesOHC'
-#generate = ['all', 'no_timeSeriesOHC']
-# Each subsequent list entry can be used to alter previous list entries. For
-# example, the following would run all tasks that aren't ocean analyses,
-# except that it would also run ocean time series tasks:
-#generate = ['all', 'no_ocean', 'all_timeSeries']
+# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# include ice-shelf cavities.`
+generate = ['all', 'no_climatologyMapAntarcticMelt']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/edison/config.20171102.beta3rc02_1850.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20171102.beta3rc02_1850.ne30_oECv3_ICG.edison
@@ -38,37 +38,28 @@ baseDirectory = /dir/to/analysis/output
 # htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
-# a list of analyses to generate.  Valid names are:
-#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
-#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
-#   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH',
-#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH',
-#   'climatologyMapSeaIceThickSH'
-# the following shortcuts exist:
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
 #   'all' -- all analyses will be run
-#   'all_timeSeries' -- all time-series analyses will be run
-#   'all_climatology' -- all analyses involving climatologies
-#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
-#   'all_ocean' -- all ocean analyses will be run
-#   'all_seaIce' -- all sea-ice analyses will be run
-#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
-#                             other analyses).
-#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
-#                                            given category of analysis
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
-
-# alternative examples that would perform all analysis except
-#   'timeSeriesOHC'
-#generate = ['all', 'no_timeSeriesOHC']
-# Each subsequent list entry can be used to alter previous list entries. For
-# example, the following would run all tasks that aren't ocean analyses,
-# except that it would also run ocean time series tasks:
-#generate = ['all', 'no_ocean', 'all_timeSeries']
+# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# include ice-shelf cavities.`
+generate = ['all', 'no_climatologyMapAntarcticMelt']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -3,7 +3,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = MPAS-SeaIce.QU60km_polar
+mainRunName = B_low_res_ice_shelves_1696_JWolfe_layout_Edison
 # preprocessedReferenceRunName is the name of a reference run that has been
 # preprocessed to compare against (or None to turn off comparison).  Reference
 # runs of this type would have preprocessed results because they were not
@@ -11,19 +11,30 @@ mainRunName = MPAS-SeaIce.QU60km_polar
 # MPAS-Analysis)
 preprocessedReferenceRunName = B1850C5_ne30_v0.4
 
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 1
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = serial
+
 [input]
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /net/scratch2/akt/MPAS/rundirs/rundir_QU60km_polar
+baseDirectory = /global/cscratch1/sd/fyke/ACME_simulations/B_low_res_ice_shelves_1696_JWolfe_layout_Edison/run
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
-mpasMeshName = QU60
+# names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
+mpasMeshName = oEC60to30v3wLI
 
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-# mappingDirectory = /dir/for/mapping/files
+mappingDirectory = /global/project/projectdirs/acme/mpas_analysis/mapping
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
@@ -44,21 +55,23 @@ baseDirectory = /dir/to/analysis/output
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with
-#                                   the given tag
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all_seaIce']
+generate = ['all']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against
 ## observations and previous runs
 
 # the first year over which to average climatalogies
-startYear = 1960
+startYear = 91
 # the last year over which to average climatalogies
-endYear = 1961
+endYear = 100
 
 [timeSeries]
 ## options related to producing time series plots, often to compare against
@@ -67,8 +80,8 @@ endYear = 1961
 # start and end years for timeseries analysis. Using out-of-bounds values
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
-startYear = 1960
-endYear = 1961
+startYear = 1
+endYear = 10
 
 [index]
 ## options related to producing nino index.
@@ -84,31 +97,47 @@ endYear = 9999
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/observations
+baseDirectory = /global/project/projectdirs/acme/observations/Ocean/
+sstSubdirectory = SST
+sssSubdirectory = SSS
+mldSubdirectory = MLD
+ninoSubdirectory = Nino
+mhtSubdirectory = MHT
+meltSubdirectory = Melt
+soseSubdirectory = SOSE
 
 [oceanPreprocessedReference]
 ## options related to preprocessed ocean reference run with which the results
 ## will be compared (e.g. a POP, CESM or ACME v0 run)
 
 # directory where ocean reference simulation results are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/observations/SeaIce
+baseDirectory = /global/project/projectdirs/acme/observations/SeaIce
 
 [seaIcePreprocessedReference]
 ## options related to preprocessed sea ice reference run with which the results
 ## will be compared (e.g. a CICE, CESM or ACME v0 run)
 
 # directory where ocean reference simulation results are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
+baseDirectory =  /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
 
 [timeSeriesSeaIceAreaVol]
 ## options related to plotting time series of sea ice area and volume
 
 # plot on polar plot
 polarPlot = False
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning 
+## circulation (MOC)
+maxChunkSize = 1000
+
+# Mask file for ocean basin regional computation
+regionMaskFiles = /global/project/projectdirs/acme/mpas_analysis/region_masks/oEC60to30v3wLI_SingleRegionAtlanticWTransportTransects_masks.nc
+

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -32,37 +32,28 @@ mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/
 # directory where analysis should be written
 baseDirectory = /dir/to/analysis/output
 
-# a list of analyses to generate.  Valid names are:
-#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
-#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
-#   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH',
-#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH',
-#   'climatologyMapSeaIceThickSH'
-# the following shortcuts exist:
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
 #   'all' -- all analyses will be run
-#   'all_timeSeries' -- all time-series analyses will be run
-#   'all_climatology' -- all analyses involving climatologies
-#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
-#   'all_ocean' -- all ocean analyses will be run
-#   'all_seaIce' -- all sea-ice analyses will be run
-#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
-#                             other analyses).
-#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
-#                                            given category of analysis
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
-
-# alternative examples that would perform all analysis except
-#   'timeSeriesOHC'
-#generate = ['all', 'no_timeSeriesOHC']
-# Each subsequent list entry can be used to alter previous list entries. For
-# example, the following would run all tasks that aren't ocean analyses,
-# except that it would also run ocean time series tasks:
-#generate = ['all', 'no_ocean', 'all_timeSeries']
+# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# include ice-shelf cavities.`
+generate = ['all', 'no_climatologyMapAntarcticMelt']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -32,37 +32,28 @@ mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mapping/
 # directory where analysis should be written
 baseDirectory = /dir/to/analysis/output
 
-# a list of analyses to generate.  Valid names are:
-#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
-#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
-#   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH',
-#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH',
-#   'climatologyMapSeaIceThickSH'
-# the following shortcuts exist:
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
 #   'all' -- all analyses will be run
-#   'all_timeSeries' -- all time-series analyses will be run
-#   'all_climatology' -- all analyses involving climatologies
-#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
-#   'all_ocean' -- all ocean analyses will be run
-#   'all_seaIce' -- all sea-ice analyses will be run
-#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
-#                             other analyses).
-#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
-#                                            given category of analysis
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
-
-# alternative examples that would perform all analysis except
-#   'timeSeriesOHC'
-#generate = ['all', 'no_timeSeriesOHC']
-# Each subsequent list entry can be used to alter previous list entries. For
-# example, the following would run all tasks that aren't ocean analyses,
-# except that it would also run ocean time series tasks:
-#generate = ['all', 'no_ocean', 'all_timeSeries']
+# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# include ice-shelf cavities.`
+generate = ['all', 'no_climatologyMapAntarcticMelt']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -51,37 +51,26 @@ mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mapping/
 # directory where analysis should be written
 baseDirectory = /dir/to/analysis/output
 
-# a list of analyses to generate.  Valid names are:
-#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
-#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
-#   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH',
-#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH',
-#   'climatologyMapSeaIceThickSH'
-# the following shortcuts exist:
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
 #   'all' -- all analyses will be run
-#   'all_timeSeries' -- all time-series analyses will be run
-#   'all_climatology' -- all analyses involving climatologies
-#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
-#   'all_ocean' -- all ocean analyses will be run
-#   'all_seaIce' -- all sea-ice analyses will be run
-#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
-#                             other analyses).
-#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
-#                                            given category of analysis
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
-
-# alternative examples that would perform all analysis except
-#   'timeSeriesOHC'
-#generate = ['all', 'no_timeSeriesOHC']
-# Each subsequent list entry can be used to alter previous list entries. For
-# example, the following would run all tasks that aren't ocean analyses,
-# except that it would also run ocean time series tasks:
-#generate = ['all', 'no_ocean', 'all_timeSeries']
+generate = ['all', 'no_climatologyMapAntarcticMelt']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -34,37 +34,28 @@ baseDirectory = /lustre/atlas1/cli115/scratch/vanroek/GMPAS-IAF_oRRS18to6v3/run
 # NOTE: This directory path must be specific to each test case.
 baseDirectory = /dir/to/analysis/output
 
-# a list of analyses to generate.  Valid names are:
-#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
-#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
-#   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH',
-#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH',
-#   'climatologyMapSeaIceThickSH'
-# the following shortcuts exist:
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
 #   'all' -- all analyses will be run
-#   'all_timeSeries' -- all time-series analyses will be run
-#   'all_climatology' -- all analyses involving climatologies
-#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
-#   'all_ocean' -- all ocean analyses will be run
-#   'all_seaIce' -- all sea-ice analyses will be run
-#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
-#                             other analyses).
-#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
-#                                            given category of analysis
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
-
-# alternative examples that would perform all analysis except
-#   'timeSeriesOHC'
-#generate = ['all', 'no_timeSeriesOHC']
-# Each subsequent list entry can be used to alter previous list entries. For
-# example, the following would run all tasks that aren't ocean analyses,
-# except that it would also run ocean time series tasks:
-#generate = ['all', 'no_ocean', 'all_timeSeries']
+# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# include ice-shelf cavities.`
+generate = ['all', 'no_climatologyMapAntarcticMelt']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -45,35 +45,26 @@ mappingDirectory = /projects/OceanClimate/mpas-analysis_data/mpas_analysis/mappi
 # directory where analysis should be written
 baseDirectory = /dir/to/analysis/output
 
-# a list of analyses to generate.  Valid names are:
-#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
-#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
-#   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcThick'
-# the following shortcuts exist:
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
 #   'all' -- all analyses will be run
-#   'all_timeSeries' -- all time-series analyses will be run
-#   'all_climatology' -- all analyses involving climatologies
-#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
-#   'all_ocean' -- all ocean analyses will be run
-#   'all_seaIce' -- all sea-ice analyses will be run
-#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
-#                             other analyses).
-#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
-#                                            given category of analysis
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
-#    ./run_analysis.py config.analysis --generate \
+#    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
 generate = ['all']
-
-# alternative examples that would perform all analysis except
-#   'timeSeriesOHC'
-#generate = ['all', 'no_timeSeriesOHC']
-# Each subsequent list entry can be used to alter previous list entries. For
-# example, the following would run all tasks that aren't ocean analyses,
-# except that it would also run ocean time series tasks:
-#generate = ['all', 'no_ocean', 'all_timeSeries']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against
@@ -145,7 +136,7 @@ baseDirectory =  /projects/OceanClimate/mpas-analysis_data/ACMEv0_lowres/B1850C5
 polarPlot = False
 
 [streamfunctionMOC]
-## options related to plotting the streamfunction of the meridional overturning 
+## options related to plotting the streamfunction of the meridional overturning
 ## circulation (MOC)
 maxChunkSize = 1000
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -51,6 +51,7 @@ Ocean tasks
    ClimatologyMapSST
    ClimatologyMapSSS
    ClimatologyMapMLD
+   ClimatologyMapAntarcticMelt
    IndexNino34
    MeridionalHeatTransport
    StreamfunctionMOC

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -129,10 +129,12 @@ htmlSubdirectory = html
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with
-#                                   the given tag
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
 # an equivalent syntax can be used on the command line to override this
 # option:
-#    ./run_analysis.py config.analysis --generate \
+#    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
 generate = ['all']
 

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -117,37 +117,24 @@ timeCacheSubdirectory = timecache
 # portal)
 htmlSubdirectory = html
 
-# a list of analyses to generate.  Valid names are:
-#   'timeSeriesOHC', 'timeSeriesSST', 'climatologyMapSST',
-#   'climatologyMapSSS', 'climatologyMapMLD', 'streamfunctionMOC',
-#   'indexNino34', 'meridionalHeatTransport',
-#   'timeSeriesSeaIceAreaVol', 'climatologyMapSeaIceConcNH',
-#   'climatologyMapSeaIceConcSH', 'climatologyMapSeaIceThickNH',
-#   'climatologyMapSeaIceThickSH'
-# the following shortcuts exist:
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
 #   'all' -- all analyses will be run
-#   'all_timeSeries' -- all time-series analyses will be run
-#   'all_climatology' -- all analyses involving climatologies
-#   'all_horizontalMap' -- all analyses involving horizontal climatology maps
-#   'all_ocean' -- all ocean analyses will be run
-#   'all_seaIce' -- all sea-ice analyses will be run
-#   'no_timeSeriesOHC' -- skip 'timeSeriesOHC' (and similarly with the
-#                             other analyses).
-#   'no_ocean', 'no_timeSeries', etc. -- in analogy to 'all_*', skip the
-#                                            given category of analysis
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag
 # an equivalent syntax can be used on the command line to override this
 # option:
-#    ./run_mpas_analysis config.analysis --generate \
+#    ./run_analysis.py config.analysis --generate \
 #         all,no_ocean,all_timeSeries
 generate = ['all']
-
-# alternative examples that would perform all analysis except
-#   'timeSeriesOHC'
-#generate = ['all', 'no_timeSeriesOHC']
-# Each subsequent list entry can be used to alter previous list entries. For
-# example, the following would run all tasks that aren't ocean analyses,
-# except that it would also run ocean time series tasks:
-#generate = ['all', 'no_ocean', 'all_timeSeries']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against
@@ -213,6 +200,7 @@ sssSubdirectory = SSS
 mldSubdirectory = MLD
 ninoSubdirectory = Nino
 mhtSubdirectory = MHT
+meltSubdirectory = Melt
 
 # first and last year of SST observational climatology (preferably one of the
 # two ranges given below)
@@ -580,6 +568,38 @@ seasons =  ['JFM', 'JAS', 'ANN']
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
 comparisonGrids = ['latlon']
+
+[climatologyMapAntarcticMelt]
+## options related to plotting horizontally regridded maps of Antarctic
+## sub-ice-shelf melt rates against reference model results and observations
+
+# comparison grid(s)
+# only the Antarctic really makes sense but lat-lon could technically work.
+comparisonGrids = ['antarctic']
+
+# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['JFM', 'JAS', 'ANN']
+
+# colormap for model/observations
+colormapNameResult = erdc_iceFire_H
+# the type of norm used in the colormap
+normTypeResult = symLog
+# A dictionary with keywords for the SemiLogNorm
+normArgsResult = {'linthresh': 1., 'linscale': 0.5, 'vmin': -100.,
+                  'vmax': 100.}
+colorbarTicksResult = [-100., -50., -20., -10., -5., -2., -1., 0., 1., 2., 5.,
+                       10., 20., 50., 100.]
+
+# colormap for differences
+colormapNameDifference = RdBu_r
+# the type of norm used in the colormap
+normTypeDifference = symLog
+# A dictionary with keywords for the SemiLogNorm
+normArgsDifference = {'linthresh': 1., 'linscale': 0.5, 'vmin': -100.,
+                      'vmax': 100.}
+colorbarTicksDifference = [-100., -50., -20., -10., -5., -2., -1., 0., 1., 2.,
+                           5., 10., 20., 50., 100.]
 
 [climatologyMapSeaIceConcNH]
 ## options related to plotting horizontally remapped climatologies of

--- a/mpas_analysis/ocean/__init__.py
+++ b/mpas_analysis/ocean/__init__.py
@@ -1,6 +1,7 @@
 from .climatology_map_sst import ClimatologyMapSST
 from .climatology_map_mld import ClimatologyMapMLD
 from .climatology_map_sss import ClimatologyMapSSS
+from .climatology_map_antarctic_melt import ClimatologyMapAntarcticMelt
 
 from .time_series_ohc import TimeSeriesOHC
 from .time_series_sst import TimeSeriesSST

--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -1,0 +1,284 @@
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+import xarray as xr
+
+from ..shared import AnalysisTask
+
+from ..shared.io.utility import build_config_full_path
+
+from ..shared.climatology import RemapMpasClimatologySubtask, \
+    RemapObservedClimatologySubtask, get_antarctic_stereographic_projection
+
+from .plot_climatology_map_subtask import PlotClimatologyMapSubtask
+
+from ..shared.mpas_xarray import mpas_xarray
+
+from ..shared.constants import constants
+
+from ..shared.grid import ProjectionGridDescriptor
+
+
+class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
+    """
+    An analysis task for comparison of Antarctic melt rates against
+    observations
+
+    Authors
+    -------
+    Xylar Asay-Davis
+    """
+    def __init__(self, config, mpasClimatologyTask):  # {{{
+        """
+        Construct the analysis task.
+
+        Parameters
+        ----------
+        config :  instance of MpasAnalysisConfigParser
+            Contains configuration options
+
+        mpasClimatologyTask : ``MpasClimatologyTask``
+            The task that produced the climatology to be remapped and plotted
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        """
+        fieldName = 'meltRate'
+        # call the constructor from the base class (AnalysisTask)
+        super(ClimatologyMapAntarcticMelt, self).__init__(
+                config=config, taskName='climatologyMapAntarcticMelt',
+                componentName='ocean',
+                tags=['climatology', 'horizontalMap', fieldName,
+                      'landIceCavities'])
+
+        sectionName = self.taskName
+
+        mpasFieldName = 'timeMonthly_avg_landIceFreshwaterFlux'
+        iselValues = None
+
+        observationTitleLabel = \
+            'Observations (Rignot et al, 2013)'
+
+        observationsDirectory = build_config_full_path(
+            config, 'oceanObservations', 'meltSubdirectory')
+
+        obsFileName = \
+            '{}/Rignot_2013_melt_rates_6000.0x6000.0km_10.0km_' \
+            'Antarctic_stereo.nc'.format(observationsDirectory)
+        obsFieldName = 'meltRate'
+
+        # read in what seasons we want to plot
+        seasons = config.getExpression(sectionName, 'seasons')
+
+        if len(seasons) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of seasons'.format(sectionName))
+
+        comparisonGridNames = config.getExpression(sectionName,
+                                                   'comparisonGrids')
+
+        if len(comparisonGridNames) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of comparison grids'.format(sectionName))
+
+        # the variable 'timeMonthly_avg_landIceFreshwaterFlux' will be added to
+        # mpasClimatologyTask along with the seasons.
+        remapClimatologySubtask = RemapMpasAntarcticMeltClimatology(
+            mpasClimatologyTask=mpasClimatologyTask,
+            parentTask=self,
+            climatologyName=fieldName,
+            variableList=[mpasFieldName],
+            comparisonGridNames=comparisonGridNames,
+            seasons=seasons,
+            iselValues=iselValues)
+
+        remapObservationsSubtask = RemapObservedAntarcticMeltClimatology(
+                parentTask=self, seasons=seasons, fileName=obsFileName,
+                outFilePrefix=obsFieldName,
+                comparisonGridNames=comparisonGridNames)
+        self.add_subtask(remapObservationsSubtask)
+        for comparisonGridName in comparisonGridNames:
+            for season in seasons:
+                # make a new subtask for this season and comparison grid
+                subtask = PlotClimatologyMapSubtask(self, season,
+                                                    comparisonGridName,
+                                                    remapClimatologySubtask,
+                                                    remapObservationsSubtask)
+
+                subtask.set_plot_info(
+                        outFileLabel='meltRignot',
+                        fieldNameInTitle='Melt Rate',
+                        mpasFieldName=mpasFieldName,
+                        obsFieldName=obsFieldName,
+                        observationTitleLabel=observationTitleLabel,
+                        unitsLabel=r'm a$^{-1}$',
+                        imageCaption='Antarctic Melt Rate',
+                        galleryGroup='Melt Rate',
+                        groupSubtitle=None,
+                        groupLink='antarctic_melt',
+                        galleryName='Observations: Rignot et al. (2013)')
+
+                self.add_subtask(subtask)
+        # }}}
+
+    def setup_and_check(self):  # {{{
+        """
+        Perform steps to set up the analysis and check for errors in the setup.
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        """
+
+        # first, call setup_and_check from the base class
+        # (AnalysisTask), which will perform some common setup
+        super(ClimatologyMapAntarcticMelt, self).setup_and_check()
+
+        landIceFluxMode = self.namelist.get('config_land_ice_flux_mode')
+        if landIceFluxMode not in ['standalone', 'coupled']:
+            raise ValueError('*** climatologyMapMeltAntarctic requires '
+                             'config_land_ice_flux_mode \n'
+                             '    to be standalone or coupled.  Otherwise, no '
+                             'melt rates are available \n'
+                             '    for plotting.')
+        # }}}
+    # }}}
+
+
+class RemapMpasAntarcticMeltClimatology(RemapMpasClimatologySubtask):  # {{{
+    """
+    A subtask for remapping climatologies of Antarctic melt rates and adding
+
+    Attributes
+    ----------
+    landIceMask : xarray.DataArray
+        A mask indicating where there is land ice on the ocean grid (thus,
+        where melt rates are valid)
+
+    Authors
+    -------
+    Xylar Asay-Davis
+    """
+
+    def run_task(self):  # {{{
+        """
+        Compute climatologies of melt rates from E3SM/MPAS output
+
+        This function has been overridden to load ``landIceMask`` from a
+        restart file for later use in masking the melt rate.  It then simply
+        calls the run function from
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        """
+
+        # first, load the land-ice mask from the restart file
+        dsLandIceMask = xr.open_dataset(self.restartFileName)
+        dsLandIceMask = mpas_xarray.subset_variables(dsLandIceMask,
+                                                     ['landIceMask'])
+        dsLandIceMask = dsLandIceMask.isel(Time=0)
+        self.landIceMask = dsLandIceMask.landIceMask > 0.
+
+        # then, call run from the base class (RemapMpasClimatologySubtask),
+        # which will perform the main function of the task
+        super(RemapMpasAntarcticMeltClimatology, self).run_task()
+
+        # }}}
+
+    def customize_masked_climatology(self, climatology):  # {{{
+        """
+        Mask the melt rates using ``landIceMask`` and rescale it to m/yr
+
+        Parameters
+        ----------
+        climatology : ``xarray.Dataset`` object
+            the climatology data set
+
+        Returns
+        -------
+        climatology : ``xarray.Dataset`` object
+            the modified climatology data set
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        """
+
+        fieldName = self.variableList[0]
+
+        # scale the field to m/yr from kg/m^2/s and mask out non-land-ice areas
+        climatology[fieldName] = \
+            constants.sec_per_year/constants.rho_fw * \
+            climatology[fieldName].where(self.landIceMask)
+
+        return climatology  # }}}
+
+    # }}}
+
+
+class RemapObservedAntarcticMeltClimatology(RemapObservedClimatologySubtask):
+    # {{{
+    """
+    A subtask for reading and remapping Antarctic melt-rate observations
+
+    Authors
+    -------
+    Luke Van Roekel, Xylar Asay-Davis, Milena Veneziani
+    """
+
+    def get_observation_descriptor(self, fileName):  # {{{
+        '''
+        get a MeshDescriptor for the observation grid
+
+        Parameters
+        ----------
+        fileName : str
+            observation file name describing the source grid
+
+        Returns
+        -------
+        obsDescriptor : ``MeshDescriptor``
+            The descriptor for the observation grid
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        '''
+
+        # create a descriptor of the observation grid using the x/y polar
+        # stereographic coordinates
+        projection = get_antarctic_stereographic_projection()
+        obsDescriptor = ProjectionGridDescriptor.read(
+            projection, fileName=fileName, xVarName='x', yVarName='y')
+        return obsDescriptor  # }}}
+
+    def build_observational_dataset(self, fileName):  # {{{
+        '''
+        read in the data sets for observations, and possibly rename some
+        variables and dimensions
+
+        Parameters
+        ----------
+        fileName : str
+            observation file name
+
+        Returns
+        -------
+        dsObs : ``xarray.Dataset``
+            The observational dataset
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        '''
+
+        # Load MLD observational data
+        dsObs = xr.open_dataset(fileName)
+
+        return dsObs  # }}}
+
+    # }}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/ocean/climatology_map_mld.py
+++ b/mpas_analysis/ocean/climatology_map_mld.py
@@ -150,11 +150,15 @@ class RemapObservedMLDClimatology(RemapObservedClimatologySubtask):  # {{{
         Xylar Asay-Davis
         '''
 
+        # Load MLD observational data
+        dsObs = self.build_observational_dataset(fileName)
+
         # create a descriptor of the observation grid using the lat/lon
         # coordinates
-        obsDescriptor = LatLonGridDescriptor.read(fileName=fileName,
+        obsDescriptor = LatLonGridDescriptor.read(ds=dsObs,
                                                   latVarName='lat',
                                                   lonVarName='lon')
+        dsObs.close()
         return obsDescriptor  # }}}
 
     def build_observational_dataset(self, fileName):  # {{{

--- a/mpas_analysis/ocean/plot_climatology_map_subtask.py
+++ b/mpas_analysis/ocean/plot_climatology_map_subtask.py
@@ -23,6 +23,12 @@ from ..shared.html import write_image_xml
 from ..shared.grid import interp_extrap_corner
 
 
+def nans_to_numpy_mask(field):
+    field = np.ma.masked_array(
+        field, np.isnan(field))
+    return field
+
+
 class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
     """
     An analysis task for plotting 2D model fields against observations.
@@ -289,15 +295,16 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
         (colormapDifference, colorbarLevelsDifference) = setup_colormap(
             config, configSectionName, suffix='Difference')
 
-        modelOutput = \
-            remappedModelClimatology[self.mpasFieldName].values
+        modelOutput = nans_to_numpy_mask(
+            remappedModelClimatology[self.mpasFieldName].values)
 
         lon = remappedModelClimatology['lon'].values
         lat = remappedModelClimatology['lat'].values
 
         lonTarg, latTarg = np.meshgrid(lon, lat)
 
-        observations = remappedObsClimatology[self.obsFieldName].values
+        observations = nans_to_numpy_mask(
+            remappedObsClimatology[self.obsFieldName].values)
 
         bias = modelOutput - observations
 
@@ -355,10 +362,11 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
             np.ones(oceanMask.shape),
             mask=np.logical_not(np.isnan(oceanMask)))
 
-        modelOutput = \
-            remappedModelClimatology[self.mpasFieldName].values
+        modelOutput = nans_to_numpy_mask(
+            remappedModelClimatology[self.mpasFieldName].values)
 
-        observations = remappedObsClimatology[self.obsFieldName].values
+        observations = nans_to_numpy_mask(
+            remappedObsClimatology[self.obsFieldName].values)
 
         bias = modelOutput - observations
 

--- a/mpas_analysis/shared/constants/constants.py
+++ b/mpas_analysis/shared/constants/constants.py
@@ -58,4 +58,7 @@ tapcoef = 1.055111111111111
 # small value to prevent division by zero
 eps = 1.E-10
 
+# density of freshwater (kg/m^3)
+rho_fw = 1000.
+
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -74,6 +74,8 @@ def build_analysis_list(config):  # {{{
     analyses.append(ocean.ClimatologyMapMLD(config, oceanClimatolgyTask))
     analyses.append(ocean.ClimatologyMapSST(config, oceanClimatolgyTask))
     analyses.append(ocean.ClimatologyMapSSS(config, oceanClimatolgyTask))
+    analyses.append(ocean.ClimatologyMapAntarcticMelt(config,
+                                                      oceanClimatolgyTask))
     analyses.append(ocean.TimeSeriesOHC(config, oceanTimeSeriesTask))
     analyses.append(ocean.TimeSeriesSST(config, oceanTimeSeriesTask))
     analyses.append(ocean.MeridionalHeatTransport(config, oceanClimatolgyTask))

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -76,6 +76,7 @@ def build_analysis_list(config):  # {{{
     analyses.append(ocean.ClimatologyMapSSS(config, oceanClimatolgyTask))
     analyses.append(ocean.ClimatologyMapAntarcticMelt(config,
                                                       oceanClimatolgyTask))
+    analyses.append(oceanTimeSeriesTask)
     analyses.append(ocean.TimeSeriesOHC(config, oceanTimeSeriesTask))
     analyses.append(ocean.TimeSeriesSST(config, oceanTimeSeriesTask))
     analyses.append(ocean.MeridionalHeatTransport(config, oceanClimatolgyTask))
@@ -100,6 +101,7 @@ def build_analysis_list(config):  # {{{
     analyses.append(sea_ice.ClimatologyMapSeaIceThick(config,
                                                       seaIceClimatolgyTask,
                                                       hemisphere='SH'))
+    analyses.append(seaIceTimeSeriesTask)
     analyses.append(sea_ice.TimeSeriesSeaIce(config, seaIceTimeSeriesTask))
 
     return analyses  # }}}


### PR DESCRIPTION
Observations are from Rignot et al. (2013).

To support masking the melt rate field only where land-ice is present and renormalizing the field to change to units of m/yr, a capability to customize climatologies during the remapping process.

A new directory for the melt observations has been added, along with a new section in the config file for this task.

The new task has been added to the auto-documentation.

`'no_climatologyMapAntarcticMelt'` has been added to `generate` lists for all example config files without land-ice cavities.  This way, users aren't concerned when this task fails during `setup_and_check()`.