### PR TITLE
 Change to mask directory instead of individual mask files

### DIFF
--- a/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+++ b/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
@@ -55,7 +55,7 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# The climatologyMapAntarcticMelt task is disabled because this run did not
 # include ice-shelf cavities.`
 generate = ['all', 'no_climatologyMapAntarcticMelt']
 
@@ -127,10 +127,8 @@ baseDirectory = /lcrc/group/acme/mpas_analysis/ACMEv0_lowres/B1850C5_ne30_v0.4/i
 # plot on polar plot
 polarPlot = False
 
-[streamfunctionMOC]
-## options related to plotting the streamfunction of the meridional overturning
-## circulation (MOC)
-maxChunkSize = 1000
+[regions]
+## options related to ocean regions used in several analysis modules
 
-# Mask file for ocean basin regional computation
-regionMaskFiles = /lcrc/group/acme/mpas_analysis/region_masks/oEC60to30v3_Atlantic_region_and_southern_transect.nc
+# Directory for region mask files
+regionMaskDirectory = /global/project/projectdirs/acme/mapping/grids/

--- a/configs/anvil/job_script.anvil.bash
+++ b/configs/anvil/job_script.anvil.bash
@@ -54,7 +54,7 @@ ncclimoParallelMode = $ncclimo_mode
 EOF
 
 # first, perform setup only without mpirun to create the mapping files
-$mpas_analysis_dir/run_mpas_analysis --purge --setup_only $run_config_file \
+$mpas_analysis_dir/run_mpas_analysis --setup_only $run_config_file \
     $job_config_file
 # next, do the full run now tht we have mapping files, but this time launching
 # with mpirun

--- a/configs/edison/config.20170807.beta1.G_oQU240.edison
+++ b/configs/edison/config.20170807.beta1.G_oQU240.edison
@@ -56,7 +56,7 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# The climatologyMapAntarcticMelt task is disabled because this run did not
 # include ice-shelf cavities.`
 generate = ['all', 'no_climatologyMapAntarcticMelt']
 
@@ -128,10 +128,8 @@ baseDirectory =  /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.
 # plot on polar plot
 polarPlot = False
 
-[streamfunctionMOC]
-## options related to plotting the streamfunction of the meridional overturning
-## circulation (MOC)
-maxChunkSize = 1000
+[regions]
+## options related to ocean regions used in several analysis modules
 
-# Mask file for ocean basin regional computation
-regionMaskFiles = /global/project/projectdirs/acme/mpas_analysis/region_masks/oQU240v3_SingleRegionAtlanticWTransportTransects_masks.nc
+# Directory for region mask files
+regionMaskDirectory = /global/project/projectdirs/acme/mpas_analysis/region_masks

--- a/configs/edison/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -71,7 +71,7 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# The climatologyMapAntarcticMelt task is disabled because this run did not
 # include ice-shelf cavities.`
 generate = ['all', 'no_climatologyMapAntarcticMelt']
 
@@ -143,6 +143,8 @@ baseDirectory =  /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.
 # plot on polar plot
 polarPlot = False
 
-[streamfunctionMOC]
-# Mask file for ocean basin regional computation
-regionMaskFiles = /global/project/projectdirs/acme/mapping/grids/oEC60to30v3_SingleRegionAtlanticWTransportTransects_masks.nc
+[regions]
+## options related to ocean regions used in several analysis modules
+
+# Directory for region mask files
+regionMaskDirectory = /global/project/projectdirs/acme/mpas_analysis/region_masks

--- a/configs/edison/config.20171102.beta3rc02_1850.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20171102.beta3rc02_1850.ne30_oECv3_ICG.edison
@@ -57,7 +57,7 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# The climatologyMapAntarcticMelt task is disabled because this run did not
 # include ice-shelf cavities.`
 generate = ['all', 'no_climatologyMapAntarcticMelt']
 
@@ -129,6 +129,8 @@ baseDirectory =  /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.
 # plot on polar plot
 polarPlot = False
 
-[streamfunctionMOC]
-# Mask file for ocean basin regional computation
-regionMaskFiles = /global/project/projectdirs/acme/mapping/grids/oEC60to30v3_SingleRegionAtlanticWTransportTransects_masks.nc
+[regions]
+## options related to ocean regions used in several analysis modules
+
+# Directory for region mask files
+regionMaskDirectory = /global/project/projectdirs/acme/mpas_analysis/region_masks

--- a/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -43,6 +43,11 @@ mappingDirectory = /global/project/projectdirs/acme/mpas_analysis/mapping
 # directory where analysis should be written
 baseDirectory = /dir/to/analysis/output
 
+# provide an absolute path to put HTML in an alternative location (e.g. a web
+# portal)
+# htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
+htmlSubdirectory = html
+
 # a list of analyses to generate.  Valid names can be seen by running:
 #   ./run_mpas_analysis --list
 # This command also lists tags for each analysis.
@@ -133,11 +138,8 @@ baseDirectory =  /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.
 # plot on polar plot
 polarPlot = False
 
-[streamfunctionMOC]
-## options related to plotting the streamfunction of the meridional overturning 
-## circulation (MOC)
-maxChunkSize = 1000
+[regions]
+## options related to ocean regions used in several analysis modules
 
-# Mask file for ocean basin regional computation
-regionMaskFiles = /global/project/projectdirs/acme/mpas_analysis/region_masks/oEC60to30v3wLI_SingleRegionAtlanticWTransportTransects_masks.nc
-
+# Directory for region mask files
+regionMaskDirectory = /global/project/projectdirs/acme/mpas_analysis/region_masks

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -51,7 +51,7 @@ baseDirectory = /dir/to/analysis/output
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# The climatologyMapAntarcticMelt task is disabled because this run did not
 # include ice-shelf cavities.`
 generate = ['all', 'no_climatologyMapAntarcticMelt']
 
@@ -111,9 +111,8 @@ baseDirectory = /usr/projects/climate/SHARED_CLIMATE/observations/SeaIce
 # directory where ocean reference simulation results are stored
 baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
 
-[streamfunctionMOC]
-## options related to plotting the streamfunction of the meridional overturning
-## circulation (MOC)
+[regions]
+## options related to ocean regions used in several analysis modules
 
-# Mask file for ocean basin regional computation
-regionMaskFiles = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/region_masks/oEC60to30v3_Atlantic_region_and_southern_transect.nc
+# Directory for region mask files
+regionMaskDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/region_masks

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -32,6 +32,11 @@ mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mapping/
 # directory where analysis should be written
 baseDirectory = /dir/to/analysis/output
 
+# provide an absolute path to put HTML in an alternative location (e.g. a web
+# portal)
+# htmlSubdirectory = /ccs/proj/cli115/www/USERNAME/RUNNAME
+htmlSubdirectory = html
+
 # a list of analyses to generate.  Valid names can be seen by running:
 #   ./run_mpas_analysis --list
 # This command also lists tags for each analysis.
@@ -51,7 +56,7 @@ baseDirectory = /dir/to/analysis/output
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# The climatologyMapAntarcticMelt task is disabled because this run did not
 # include ice-shelf cavities.`
 generate = ['all', 'no_climatologyMapAntarcticMelt']
 
@@ -122,5 +127,8 @@ baseDirectory =  /lustre/atlas/proj-shared/cli115/milena/ACMEv0_lowres/B1850C5_n
 # Supported options are Atlantic and IndoPacific
 regionNames = ['Atlantic']
 
-# Mask file for ocean basin regional computation
-regionMaskFiles = /lustre/atlas/proj-shared/cli115/mpas_analysis/region_masks/oEC60to30v3_SingleRegionAtlanticWTransportTransects_masks.nc
+[regions]
+## options related to ocean regions used in several analysis modules
+
+# Directory for region mask files
+regionMaskDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/region_masks/

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -37,7 +37,7 @@ seaIceNamelistFileName = run/mpas-cice_in
 seaIceStreamsFileName = run/streams.cice
 
 # names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
-mpasMeshName = EC60to30v3
+mpasMeshName = oEC60to30v3
 
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
@@ -50,6 +50,11 @@ mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mapping/
 
 # directory where analysis should be written
 baseDirectory = /dir/to/analysis/output
+
+# provide an absolute path to put HTML in an alternative location (e.g. a web
+# portal)
+# htmlSubdirectory = /ccs/proj/cli115/www/USERNAME/RUNNAME
+htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:
 #   ./run_mpas_analysis --list
@@ -139,5 +144,8 @@ baseDirectory =  /lustre/atlas/proj-shared/cli115/milena/ACMEv0_lowres/B1850C5_n
 # Supported options are Atlantic and IndoPacific
 regionNames = ['Atlantic']
 
-# Mask file for ocean basin regional computation
-regionMaskFiles = /lustre/atlas/proj-shared/cli115/mpas_analysis/region_masks/oEC60to30v3_SingleRegionAtlanticWTransportTransects_masks.nc
+[regions]
+## options related to ocean regions used in several analysis modules
+
+# Directory for region mask files
+regionMaskDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/region_masks

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -19,12 +19,14 @@ preprocessedReferenceRunName = None
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /lustre/atlas1/cli115/scratch/vanroek/GMPAS-IAF_oRRS18to6v3/run
+baseDirectory = /lustre/atlas1/cli115/proj-shared/vanroek/run
+
+mpasMeshName = oRRS18to6v3
 
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-# mappingDirectory = /dir/for/mapping/files
+mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mapping
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
@@ -33,6 +35,11 @@ baseDirectory = /lustre/atlas1/cli115/scratch/vanroek/GMPAS-IAF_oRRS18to6v3/run
 # directory where analysis should be written
 # NOTE: This directory path must be specific to each test case.
 baseDirectory = /dir/to/analysis/output
+
+# provide an absolute path to put HTML in an alternative location (e.g. a web
+# portal)
+# htmlSubdirectory = /ccs/proj/cli115/www/USERNAME/RUNNAME
+htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:
 #   ./run_mpas_analysis --list
@@ -53,7 +60,7 @@ baseDirectory = /dir/to/analysis/output
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-# The climatologyMapAntarcticMelt task is disabled because this run did not 
+# The climatologyMapAntarcticMelt task is disabled because this run did not
 # include ice-shelf cavities.`
 generate = ['all', 'no_climatologyMapAntarcticMelt']
 
@@ -148,20 +155,8 @@ baseDirectory = /dir/to/seaice/reference
 # directory where ocean reference simulation results are stored
 baseDirectory = /dir/to/seaice/reference
 
-[streamfunctionMOC]
-## options related to plotting the streamfunction of the meridional overturning
-## circulation (MOC)
+[regions]
+## options related to ocean regions used in several analysis modules
 
-# Mask file for post-processing regional MOC computation
-regionMaskFiles = /lustre/atlas1/cli115/proj-shared/mpas_analysis/region_masks/oRRS18to6v3.170111.SingleRegionAtlanticWTransportTransects_masks.nc
-
-# xarray (with dask) divides data sets into "chunks", allowing computations
-# to be made on data that is larger than the available memory.  MPAS-Analysis
-# supports setting a maximum chunk size for data sets generally, and a
-# separate option specific to loading the 3D velocity field in the MOC
-# specifically.  By default, maxChunkSize is left undefined, so that chunking
-# is handled automatically.  If the MOC calculation encounters memory problems,
-# consider setting maxChunkSize to a number significantly lower than nEdges
-# in your MPAS mesh so that the calculation will be divided into smaller
-# pieces.
-maxChunkSize = 500
+# Directory for region mask files
+regionMaskDirectory = /lustre/atlas1/cli115/proj-shared/mpas_analysis/region_masks

--- a/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -135,17 +135,9 @@ baseDirectory =  /projects/OceanClimate/mpas-analysis_data/ACMEv0_lowres/B1850C5
 # plot on polar plot
 polarPlot = False
 
-[streamfunctionMOC]
-## options related to plotting the streamfunction of the meridional overturning
-## circulation (MOC)
-maxChunkSize = 1000
-
-# Mask file for ocean basin regional computation
-regionMaskFiles = /projects/OceanClimate/mpas-analysis_data/mpas_analysis/region_masks/oEC60to30v3wLI_Atlantic_region_masks_and_southern_transect.nc
-
 [regions]
 # Directory containing mask files for ocean basins and ice shelves
-regionMaskDirectory = /projects/OceanClimate/mpas-analysis_data/mpas_analysis/region_masks/
+regionMaskDirectory = /projects/OceanClimate/mpas-analysis_data/mpas_analysis/region_masks
 
 [climatologyMapSoseTemperature]
 # Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,

--- a/configs/theta/job_script.theta.bash
+++ b/configs/theta/job_script.theta.bash
@@ -61,7 +61,7 @@ module unload python
 module use /projects/OceanClimate/modulefiles/all
 module load python/anaconda-2.7-acme
 
-$mpas_analysis_dir/run_mpas_analysis --purge \
+$mpas_analysis_dir/run_mpas_analysis \
     $run_config_file $job_config_file
 EOF
 

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -430,9 +430,6 @@ movingAveragePoints = 1
 # Supported options are Atlantic and IndoPacific
 regionNames = ['Atlantic']
 
-# Mask file for post-processing regional MOC computation
-regionMaskFiles = /path/to/MOCregional/mask/file
-
 # xarray (with dask) divides data sets into "chunks", allowing computations
 # to be made on data that is larger than the available memory.  MPAS-Analysis
 # supports setting a maximum chunk size for data sets generally, and a
@@ -757,6 +754,9 @@ regions = ['arctic', 'equatorial', 'so', 'nino3', 'nino4', 'nino3.4', 'global']
 # time-series stats)
 plotTitles = ['Arctic', 'Equatorial (15S-15N)', 'Southern Ocean', 'Nino 3',
               'Nino 4', 'Nino 3.4', 'Global Ocean']
+
+# Directory for region mask files
+regionMaskDirectory = /path/to/masks/
 
 [plot]
 ## options related to plotting that are the defaults across all analysis

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -293,17 +293,21 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
                                                 'regionNames')
 
         # Load basin region related variables and save them to dictionary
-        # NB: The following will need to change with new regional mapping files
-        regionMaskFiles = config.get(self.sectionName, 'regionMaskFiles')
-        if not os.path.exists(regionMaskFiles):
-            raise IOError('Regional masking file for MOC calculation '
-                          'does not exist')
+        mpasMeshName = config.get('input', 'mpasMeshName')
+        regionMaskDirectory = config.get('regions', 'regionMaskDirectory')
+
+        regionMaskFile = '{}/{}_SingleRegionAtlanticWTransportTransects_' \
+                         'masks.nc'.format(regionMaskDirectory, mpasMeshName)
+
+        if not os.path.exists(regionMaskFile):
+            raise IOError('Regional masking file {} for MOC calculation '
+                          'does not exist'.format(regionMaskFile))
         iRegion = 0
         self.dictRegion = {}
         for region in self.regionNames:
             self.logger.info('\n  Reading region and transect mask for '
                              '{}...'.format(region))
-            ncFileRegional = netCDF4.Dataset(regionMaskFiles, mode='r')
+            ncFileRegional = netCDF4.Dataset(regionMaskFile, mode='r')
             maxEdgesInTransect = \
                 ncFileRegional.dimensions['maxEdgesInTransect'].size
             transectEdgeMaskSigns = \


### PR DESCRIPTION
The name of the MOC mask file is constructed automatically from the
mesh name.

This approach is needed in anticipation of having other region masks (notably masks for individual ice shelves, see #237)

Example config files have been updated accordingly.