### PR TITLE
Fix decoding of string in python 3 when rerunning time series

### DIFF
--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -279,7 +279,9 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
             totalMonths = 12*inYears + inMonths
 
             with xr.open_dataset(self.outputFile) as ds:
-                lastDate = str(ds.xtime_startMonthly[-1].values)
+                dates = [bytes.decode(name) for name in
+                           ds.xtime_startMonthly.values]
+                lastDate = dates[-1]
 
             lastYear = int(lastDate[0:4])
             lastMonth = int(lastDate[5:7])


### PR DESCRIPTION
There is a bug when rerunning analysis in python 3 with time series output.  The `xtime_startMonthly` variable was not being converted correctly to a string.  This has been fixed.