### PR TITLE
Clean up the nino34 index task

### DIFF
--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -87,8 +87,8 @@ class IndexNino34(AnalysisTask):  # {{{
         #     self.calendar
         super(IndexNino34, self).setup_and_check()
 
-        self.startDate = self.config.get('timeSeries', 'startDate')
-        self.endDate = self.config.get('timeSeries', 'endDate')
+        self.startDate = self.config.get('index', 'startDate')
+        self.endDate = self.config.get('index', 'endDate')
 
         self.variableList = \
             ['timeMonthly_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
@@ -694,6 +694,7 @@ class IndexNino34(AnalysisTask):  # {{{
         for y in ys:
             maxY = max(y[mask].max(), maxY)
             # check the function interpolated to the max/min as well
+            # Note: flipping the axis so x is in increasing order
             maxY = max(np.interp(xmin, x[::-1], y[::-1]), maxY)
             maxY = max(np.interp(xmax, x[::-1], y[::-1]), maxY)
 

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -6,14 +6,11 @@ import xarray as xr
 import numpy as np
 import netCDF4
 import os
-import warnings
 
 from ..shared.plot.plotting import plot_vertical_section,\
     setup_colormap, plot_1D
 
 from ..shared.io.utility import build_config_full_path
-
-from ..shared.timekeeping.utility import get_simulation_start_time
 
 from ..shared import AnalysisTask
 from ..shared.html import write_image_xml
@@ -119,8 +116,8 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             if os.path.exists(observationsFile):
                 self.observationsFile = observationsFile
             else:
-                warnings.warn('No MHT observations file found: skip plotting '
-                              'obs')
+                print('Warning: No MHT observations file found: skip plotting '
+                      'obs')
 
         mainRunName = self.config.get('runs', 'mainRunName')
 

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -10,7 +10,6 @@ Xylar Asay-Davis
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-import warnings
 from multiprocessing import Process, Value
 import time
 import traceback
@@ -451,13 +450,12 @@ class AnalysisTask(Process):  # {{{
         except ValueError:
             enabled = default
             if default:
-                message = 'WARNING: namelist option {} not found.\n' \
-                          'This likely indicates that the simulation you ' \
-                          'are analyzing was run with an\n' \
-                          'older version of MPAS-O that did not support ' \
-                          'this flag.  Assuming enabled.'.format(
-                              analysisOptionName)
-                warnings.warn(message)
+                print('Warning: namelist option {} not found.\n'
+                      'This likely indicates that the simulation you '
+                      'are analyzing was run with an\n'
+                      'older version of MPAS-O that did not support '
+                      'this flag.  Assuming enabled.'.format(
+                              analysisOptionName))
 
         if not enabled and raiseException:
             raise RuntimeError('*** MPAS-Analysis relies on {} = .true.\n'

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import, division, print_function, \
 
 import xarray
 import os
-import warnings
 import subprocess
 from distutils.spawn import find_executable
 
@@ -288,14 +287,13 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         endYear = years[lastIndex]
 
         if startYear != requestedStartYear or endYear != requestedEndYear:
-            message = "climatology start and/or end year different from " \
-                      "requested\n" \
-                      "requestd: {:04d}-{:04d}\n" \
-                      "actual:   {:04d}-{:04d}\n".format(requestedStartYear,
-                                                         requestedEndYear,
-                                                         startYear,
-                                                         endYear)
-            warnings.warn(message)
+            print("Warning: climatology start and/or end year different from "
+                  "requested\n"
+                  "requestd: {:04d}-{:04d}\n"
+                  "actual:   {:04d}-{:04d}\n".format(requestedStartYear,
+                                                     requestedEndYear,
+                                                     startYear,
+                                                     endYear))
             config.set('climatology', 'startYear', str(startYear))
             config.set('climatology', 'endYear', str(endYear))
 

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -1144,42 +1144,6 @@ def setup_colormap(config, configSectionName, suffix=''):
     return (colormap, colorbarLevels)
 
 
-def plot_size_y_axis(plt, xaxisValues, **data):
-    '''
-    Resize the y-axis limit based on the curves being plotted
-
-    Parameters
-    ----------
-    plt : plot handle
-
-    xaxisValues : numpy.array
-       Values plotted along the x-axis
-
-    data : dictionary entries must be numpy.array
-       data for curves on plot
-
-    Authors
-    -------
-    Luke Van Roekel
-    '''
-
-    ax = plt.gca()
-    xmin = ax.get_xlim()[0]
-    xmax = ax.get_xlim()[1]
-
-    # find period/frequency bounds for chosen xmin/xmax
-    minIndex = np.abs(xaxisValues - xmin).argmin()
-    maxIndex = np.abs(xaxisValues - xmax).argmin()
-
-    # find maximum value of three curves plotted
-    maxCurveVal = -1E20
-    for key in data:
-        maxTemp = data[key][minIndex:maxIndex].max()
-        maxCurveVal = max(maxTemp, maxCurveVal)
-
-    return maxCurveVal
-
-
 def plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks):
     '''
     Formats tick labels and positions along the x-axis for time series

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -42,7 +42,7 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
     '''
 
     def __init__(self, config, componentName, taskName=None,
-                 subtaskName=None):  # {{{
+                 subtaskName=None, section='timeSeries'):  # {{{
         '''
         Construct the analysis task for extracting time series.
 
@@ -62,19 +62,22 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         subtaskName : str, optional
             The name of the subtask (if any)
 
+        section : str, optional
+            The section of the config file from which to read the start and
+            end times for the time series, also added as a tag
 
         Authors
         -------
         Xylar Asay-Davis
         '''
         self.variableList = []
-        self.seasons = []
+        self.section = section
+        tags = [section]
 
-        tags = ['timeSeries']
-
-        suffix = componentName[0].upper() + componentName[1:]
         if taskName is None:
-            taskName = 'mpasTimeSeries{}'.format(suffix)
+            suffix = section[0].upper() + section[1:] + \
+                componentName[0].upper() + componentName[1:]
+            taskName = 'mpas{}'.format(suffix)
 
         # call the constructor from the base class (AnalysisTask)
         super(MpasTimeSeriesTask, self).__init__(
@@ -138,8 +141,8 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
 
         # get a list of timeSeriesStats output files from the streams file,
         # reading only those that are between the start and end dates
-        startDate = config.get('timeSeries', 'startDate')
-        endDate = config.get('timeSeries', 'endDate')
+        startDate = config.get(self.section, 'startDate')
+        endDate = config.get(self.section, 'endDate')
         streamName = 'timeSeriesStatsMonthlyOutput'
         self.inputFiles = self.historyStreams.readpath(
                 streamName, startDate=startDate, endDate=endDate,
@@ -200,7 +203,7 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         """
 
         config = self.config
-        section = 'timeSeries'
+        section = self.section
 
         requestedStartYear = config.getint(section, 'startYear')
         requestedEndYear = config.getint(section, 'endYear')
@@ -280,7 +283,7 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
 
             with xr.open_dataset(self.outputFile) as ds:
                 dates = [bytes.decode(name) for name in
-                           ds.xtime_startMonthly.values]
+                         ds.xtime_startMonthly.values]
                 lastDate = dates[-1]
 
             lastYear = int(lastDate[0:4])

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 import os
-import warnings
 import subprocess
 from distutils.spawn import find_executable
 import xarray as xr
@@ -225,14 +224,14 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         endYear = years[lastIndex]
 
         if startYear != requestedStartYear or endYear != requestedEndYear:
-            message = "time series start and/or end year different from " \
-                      "requested\n" \
-                      "requestd: {:04d}-{:04d}\n" \
-                      "actual:   {:04d}-{:04d}\n".format(requestedStartYear,
-                                                         requestedEndYear,
-                                                         startYear,
-                                                         endYear)
-            warnings.warn(message)
+            print("Warning: {} start and/or end year different from "
+                  "requested\n" \
+                  "requestd: {:04d}-{:04d}\n" \
+                  "actual:   {:04d}-{:04d}\n".format(section,
+                                                     requestedStartYear,
+                                                     requestedEndYear,
+                                                     startYear,
+                                                     endYear))
             config.set(section, 'startYear', str(startYear))
             config.set(section, 'endYear', str(endYear))
 

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -12,7 +12,6 @@ from __future__ import absolute_import, division, print_function, \
 import xarray as xr
 import numpy
 import os
-import warnings
 
 from ..timekeeping.utility import days_to_datetime
 
@@ -87,7 +86,7 @@ def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
             message = 'Deleting cache file {}, which appears to have ' \
                       'been corrupted.'.format(cacheFileName)
             if logger is None:
-                warnings.warn(message)
+                print('Warning: {}'.format(message))
             else:
                 logger.warning(message)
             os.remove(cacheFileName)

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -142,8 +142,7 @@ class TestMpasClimatologyTask(TestCase):
         config.set('climatology', 'startDate', startDate)
         config.set('climatology', 'endDate', endDate)
 
-        with pytest.warns(UserWarning):
-            mpasClimatologyTask._update_climatology_bounds_from_file_names()
+        mpasClimatologyTask._update_climatology_bounds_from_file_names()
 
         startYear = 2
         endYear = 2

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -70,6 +70,9 @@ def build_analysis_list(config):  # {{{
                                               componentName='ocean')
     oceanTimeSeriesTask = MpasTimeSeriesTask(config=config,
                                              componentName='ocean')
+    oceanIndexTask = MpasTimeSeriesTask(config=config,
+                                        componentName='ocean',
+                                        section='index')
     analyses.append(oceanClimatolgyTask)
     analyses.append(ocean.ClimatologyMapMLD(config, oceanClimatolgyTask))
     analyses.append(ocean.ClimatologyMapSST(config, oceanClimatolgyTask))
@@ -81,7 +84,7 @@ def build_analysis_list(config):  # {{{
     analyses.append(ocean.TimeSeriesSST(config, oceanTimeSeriesTask))
     analyses.append(ocean.MeridionalHeatTransport(config, oceanClimatolgyTask))
     analyses.append(ocean.StreamfunctionMOC(config, oceanClimatolgyTask))
-    analyses.append(ocean.IndexNino34(config, oceanTimeSeriesTask))
+    analyses.append(ocean.IndexNino34(config, oceanIndexTask))
 
     # Sea Ice Analyses
     seaIceClimatolgyTask = MpasClimatologyTask(config=config,


### PR DESCRIPTION
This clean up is needed to generalize the task in preparation for supporting comparison with a reference run (which will replace one of the panels).

A new task has been added to extract time series needed by indices (which may have different time bounds than time series).  Support for separate time bounds was eliminated, perhaps accidentally, in  #271.

Nino34 spectra are now packed into dictionaries for easier iteration and panels are plotted in loops.

The function for determining the maximum value of all spectra (to determine the bounds of the y axes of these plots) has been cleaned up so it no longer relies on a plot already having been performed). 

All warnings previously produced with `warnings.warn` have been switched to just using `print('Warning:..')` because this produces much more intuitive output without a (nearly always useless) stack trace. 