### PR TITLE
Add "only_" prefix to "generate" config option; clarify output from --list command line option

### DIFF
--- a/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+++ b/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
@@ -45,6 +45,10 @@ htmlSubdirectory = html
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/configs/edison/config.20170807.beta1.G_oQU240.edison
+++ b/configs/edison/config.20170807.beta1.G_oQU240.edison
@@ -46,6 +46,10 @@ htmlSubdirectory = html
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/configs/edison/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -61,6 +61,10 @@ htmlSubdirectory = html
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/configs/edison/config.20171102.beta3rc02_1850.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20171102.beta3rc02_1850.ne30_oECv3_ICG.edison
@@ -47,6 +47,10 @@ htmlSubdirectory = html
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -57,6 +57,10 @@ htmlSubdirectory = html
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -41,6 +41,10 @@ baseDirectory = /dir/to/analysis/output
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -41,6 +41,10 @@ baseDirectory = /dir/to/analysis/output
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -46,6 +46,10 @@ htmlSubdirectory = html
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -65,6 +65,10 @@ htmlSubdirectory = html
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -50,6 +50,10 @@ htmlSubdirectory = html
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -54,6 +54,10 @@ baseDirectory = /dir/to/analysis/output
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -126,6 +126,10 @@ htmlSubdirectory = html
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
 #   'no_<task_name>' -- skip the given task
 #   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
 #                                   tasks from the given compoonent or with
@@ -135,7 +139,7 @@ htmlSubdirectory = html
 # an equivalent syntax can be used on the command line to override this
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
-#         all,no_ocean,all_timeSeries
+#         only_ocean,no_timeSeries,timeSeriesSST
 generate = ['all']
 
 [climatology]

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -381,10 +381,14 @@ class AnalysisTask(Process):  # {{{
         if (not isinstance(self.tags, list) and
                 self.tags is not None):
             raise ValueError('Analysis tasks\'s member self.tags '
-                             'must be NOne or a list of strings.')
+                             'must be None or a list of strings.')
 
         config = self.config
         generateList = config.getExpression('output', 'generate')
+        if len(generateList) > 0 and generateList[0][0:5] == 'only_':
+            # add 'all' if the first item in the list has the 'only' prefix.
+            # Otherwise, we would not run any tasks
+            generateList = ['all'] + generateList
         generate = False
         for element in generateList:
             if '_' in element:
@@ -402,6 +406,9 @@ class AnalysisTask(Process):  # {{{
                     generate = True
             elif prefix == 'no':
                 if suffix in noSuffixes:
+                    generate = False
+            if prefix == 'only':
+                if suffix not in allSuffixes:
                     generate = False
             elif element == self.taskName:
                 generate = True

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -440,8 +440,9 @@ if __name__ == "__main__":
     if args.list:
         analyses = build_analysis_list(config)
         for analysisTask in analyses:
-            print('{}\n    tags: {}'.format(analysisTask.taskName,
-                                            ', '.join(analysisTask.tags)))
+            print('task: {}'.format(analysisTask.taskName))
+            print('    component: {}'.format(analysisTask.componentName)),
+            print('    tags: {}'.format(', '.join(analysisTask.tags)))
         sys.exit(0)
 
     if args.purge:


### PR DESCRIPTION
This merge adds support for an `only_` prefix in the generate flag, for example:
```
./run_mpas_analysis --generate=only_ocean,only_horizontalMap config.my_run
```
will run only ocean tasks and only those that have the `horizontalMap` tag (climatology maps).  The `only_` prefix works by excluding all tasks that do *not* have that tag.  (If the first item in the `generate` list has the `only_` prefix,  we implicitly add 'all' to the beginning of the `generate` list, because otherwise no tasks would run.)

The output from the `--list` command line argument has been clarified:
* `task: ` has been added in front of each task name to make clear which are tasks and which are tags
* the component for each task is also displayed.