### PR TITLE
Add -4 flag to force NetCDF4 output format from NCO

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ available:
  * bottleneck
  * basemap
  * lxml
- * nco >= 4.6.8
+ * nco >= 4.7.0
  * pyproj
  * pillow
 

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -397,6 +397,7 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         parallelMode = self.config.get('execute', 'ncclimoParallelMode')
 
         args = ['ncclimo',
+                '-4',
                 '--clm_md=mth',
                 '-a', 'sdd',
                 '-m', self.ncclimoModel,

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -321,7 +321,7 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         variableList = self.variableList + ['xtime_startMonthly',
                                             'xtime_endMonthly']
 
-        args = ['ncrcat', '--record_append', '--no_tmp_fl',
+        args = ['ncrcat', '-4', '--record_append', '--no_tmp_fl',
                 '-v', ','.join(variableList)]
 
         printCommand = '{} {} ... {} {}'.format(' '.join(args), inputFiles[0],


### PR DESCRIPTION
This prevents certain issues with very large NetCDF3 files (e.g. from high resolution MPAS-O output).

Without this fix, an error occurs when running analysis on large MPAS files:
```
...
netCDF3 NETCDF_64BIT_OFFSET format limits fixed variables to sizes smaller than 2^32 B = 4 GiB ~ 4.2 GB, and record variables to that size per record.
```
From @czender:
> Since the MPAS input is NETCDF_64BIT_OFFSET, that's what ncclimo uses for the output. However,  `timeMonthly_avg_normalVelocity` is > 8 GB, and exceeds the format constraint. (How MPAS wrote the input dataset without error is...unknown to me, perhaps PnetCDF trickery?).