### PR TITLE
Fix zero line in time series

### DIFF
--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -164,14 +164,13 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                   'color': config.get('plot', 'titleFontColor'),
                   'weight': config.get('plot', 'titleFontWeight')}
 
+    plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)
+
     # Add a y=0 line if y ranges between positive and negative values
     yaxLimits = ax.get_ylim()
     if yaxLimits[0]*yaxLimits[1] < 0:
-        indgood = np.where(np.logical_not(np.isnan(mean)))
-        x = mean['Time'][indgood]
+        x = ax.get_xlim()
         plt.plot(x, np.zeros(np.size(x)), 'k-', linewidth=1.2, zorder=1)
-
-    plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)
 
     if title is not None:
         plt.title(title, **title_font)

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -460,6 +460,10 @@ if __name__ == "__main__":
                         type=str, nargs='*', help='config file')
     args = parser.parse_args()
 
+    for configFile in args.configFiles:
+        if not os.path.exists(configFile):
+            raise OSError('Config file {} not found.'.format(configFile))
+
     # add config.default to cover default not included in the config files
     # provided on the command line
     if pkg_resources.resource_exists('mpas_analysis', 'config.default'):


### PR DESCRIPTION
Before this merge, the zero line has the same extent as the first (valid) curve being plotted, whereas it should really have the full extent of the axis.

Also adds an error message when a config file is requested but that file doesn't actually exist.  Previously, it seems that no error was raised in such cases and config options were simply read in from those config files that *were* found.