### PR TITLE
Support standalone MPAS runs

### DIFF
--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,0 +1,19 @@
+Main Authors
+============
+* Xylar Asay-Davis
+* Milena Veniziani
+* Philip Wolfram
+
+Contributors
+============
+* Luke Van Roekel
+* Greg Streletz
+* Mark Petersen
+* Stephen Price
+* Joseph Kennedy
+* Adrian Turner
+* Matthew Hoffman
+* Jeremy Fyke
+
+For a list of all the contributions:
+https://github.com/MPAS-Dev/MPAS-Analysis/graphs/contributors

--- a/docs/e3sm.rst
+++ b/docs/e3sm.rst
@@ -1,0 +1,20 @@
+E3SM
+====
+
+The Energy Exascale Earth System Model (E3SM) project, previously known as
+ACME, is central to ESM as well as many of the Climate and Environmental
+Sciences Division activities, as it is developing a computationally advanced
+coupled climate-energy model to investigate the challenges posed by the
+interactions of weather-climate scale variability with energy and related
+sectors.
+
+A Full description of E3SM is available at:
+https://climatemodeling.science.energy.gov/projects/energy-exascale-earth-system-model
+
+Setting up E3SM runs
+--------------------
+
+All online analysis and output stream within MPAS components (MPAS-O and
+MPAS-SeaIce) are configured to support MPAS-Analysis without any modifications
+to namelists or streams files.
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,25 @@ Documentation
    api
    design_docs
 
+MPAS Components and E3SM
+========================
+
+.. toctree::
+   :maxdepth: 2
+
+   mpaso
+   mpascice
+   e3sm
+
+
 Indices and tables
 ==================
 
 * :ref:`genindex`
+
+Authors
+=======
+.. toctree::
+   :maxdepth: 1
+
+   authors

--- a/docs/mpascice.rst
+++ b/docs/mpascice.rst
@@ -1,0 +1,63 @@
+MPAS Sea Ice
+============
+
+The Model for Prediction Across Scales Sea Ice (MPAS Sea Ice, sometimes called
+MPAS-CICE because of the physics it has inherited from the CICE sea-ice model)
+is designed for the simulations of sea ice on unstructured grids supported by
+the MPAS framework.  The model has not yet been publicly released and does not
+have public documentation.
+
+Setting up Standalone MPAS Sea Ice Runs
+---------------------------------------
+
+In order to support all sea=ice analysis tasks from MPAS-Analysis, certain
+"analysis members", Fortran modules that perform analysis during the
+simulation, need to be enabled.
+
+The following is a list of suggested values for namelist options, typically
+found in ``namelist.cice`` or ``mpas-cice_in``::
+
+     config_AM_timeSeriesStatsMonthly_enable = .true.
+
+Additionally, the duration of the run should be set to at least two years and
+typically longer before most analysis is useful::
+
+     config_run_duration = '0002-00-00_00:00:00'
+
+Several streams must be defined in the streams file, typically
+``streams.cice``, (even if they will not be written out --
+``output_interval=="none"``)::
+
+  <stream name="timeSeriesStatsMonthlyRestart"
+          type="input;output"
+          io_type="pnetcdf"
+          filename_template="mpascice.rst.am.timeSeriesStatsMonthly.$Y-$M-$D_$S.nc"
+          filename_interval="output_interval"
+          clobber_mode="truncate"
+          packages="timeSeriesStatsMonthlyAMPKG"
+          input_interval="initial_only"
+          output_interval="stream:restart:output_interval">
+  </stream>
+
+  <stream name="timeSeriesStatsMonthlyOutput"
+          type="output"
+          io_type="pnetcdf"
+          filename_template="mpascice.hist.am.timeSeriesStatsMonthly.$Y-$M-$D.nc"
+          filename_interval="00-01-00_00:00:00"
+          output_interval="00-01-00_00:00:00"
+          clobber_mode="truncate"
+          packages="timeSeriesStatsMonthlyAMPKG">
+
+          <var name="icePresent"/>
+          <var name="iceAreaCell"/>
+          <var name="iceVolumeCell"/>
+          <var name="xtime"/>
+  </stream>
+
+The ``filename_tempalate`` can be modified as desired (these are the defalult
+values from E3SM).  For the ``timeSeriesStatsMonthlyOutput`` stream, both the
+filename_interval and the output_interval must currently be monthly
+(``"0000-01-00_00:00:00"``).
+
+Additional fields can be included in the ``timeSeriesStatsMonthlyOutput``
+streams.  These are the minimum that allow the analysis to run successfully.

--- a/docs/mpaso.rst
+++ b/docs/mpaso.rst
@@ -1,0 +1,156 @@
+MPAS Ocean
+==========
+
+The Model for Prediction Across Scales Ocean (MPAS-O) is designed for the
+simulation of the ocean system from time scales of months to millenia and
+spatial scales from sub 1 km to global circulations.
+
+MPAS-O has demonstrated the ability to accurately reproduce mesoscale ocean
+activity with a local mesh refinement strategy.
+
+In addition to faciliating the study of multiscale phenomena within the ocean
+system, MPAS-O is intended for the study of anthropogenic climate change as
+the ocean component of climate system models.
+
+
+Full documentaiton is available at:
+https://mpas-dev.github.io/ocean/ocean.html
+
+Setting up Standalone MPAS-O Runs
+---------------------------------
+
+In order to support all ocean analysis tasks from MPAS-Analysis, certain
+"analysis members", Fortran modules that perform analysis during the
+simulation, need to be enabled.
+
+The following is a list of suggested values for namelist options, typically
+found in ``namelist.ocean`` or ``mpas-o_in``::
+
+   config_AM_surfaceAreaWeightedAverages_enable = .true.
+   config_AM_surfaceAreaWeightedAverages_compute_interval = '0000-00-00_01:00:00'
+   config_AM_layerVolumeWeightedAverage_enable = .true.
+   config_AM_layerVolumeWeightedAverage_compute_interval = '0000-00-00_01:00:00'
+   config_AM_meridionalHeatTransport_enable = .true.
+   config_AM_meridionalHeatTransport_compute_interval = '0000-00-00_01:00:00'
+   config_AM_mixedLayerDepths_enable = .true.
+   config_AM_timeSeriesStatsMonthly_enable = .true.
+
+Additionally, the duration of the run should be set to at least two years and
+typically longer before most analysis is useful::
+
+   config_run_duration = '0002-00-00_00:00:00'
+
+Several streams must be defined in the streams file, typically
+``streams.ocean``, (even if they will not be written out --
+``output_intervale=="none"``)::
+
+  <stream name="timeSeriesStatsMonthlyRestart"
+          type="input;output"
+          filename_template="restarts/restart.AM.timeSeriesStatsMonthly.$Y-$M-$D_$h.$m.$s.nc"
+          filename_interval="output_interval"
+          reference_time="0001-01-01_00:00:00"
+          clobber_mode="truncate"
+          packages="timeSeriesStatsMonthlyAMPKG"
+          input_interval="initial_only"
+          output_interval="stream:restart:output_interval" >
+  </stream>
+
+  <stream name="timeSeriesStatsMonthlyOutput"
+          type="output"
+          filename_template="analysis_members/timeSeriesStatsMonthly.$Y-$M.nc"
+          filename_interval="0000-01-00_00:00:00"
+          reference_time="0001-01-01_00:00:00"
+          clobber_mode="truncate"
+          packages="timeSeriesStatsMonthlyAMPKG"
+          output_interval="00-01-00_00:00:00" >
+
+          <var_array name="activeTracers"/>
+          <var name="normalVelocity"/>
+          <var name="vertVelocityTop"/>
+          <var_array name="avgValueWithinOceanRegion"/>
+          <var_array name="avgValueWithinOceanLayerRegion"/>
+          <var name="dThreshMLD"/>
+          <var name="meridionalHeatTransportLatZ"/>
+          <var name="meridionalHeatTransportLat"/>
+          <var name="binBoundaryMerHeatTrans"/>
+          <var name="xtime"/>
+  </stream>
+
+  <stream name="layerVolumeWeightedAverageOutput"
+          type="output"
+          io_type="pnetcdf"
+          filename_template="mpaso.hist.am.layerVolumeWeightedAverage.$Y-$M-$D.nc"
+          filename_interval="00-01-00_00:00:00"
+          output_interval="none"
+          clobber_mode="truncate"
+          packages="layerVolumeWeightedAverageAMPKG">
+
+      <var name="xtime"/>
+      <var name="daysSinceStartOfSim"/>
+      <var_array name="minValueWithinOceanLayerRegion"/>
+      <var_array name="maxValueWithinOceanLayerRegion"/>
+      <var_array name="avgValueWithinOceanLayerRegion"/>
+      <var_array name="minValueWithinOceanVolumeRegion"/>
+      <var_array name="maxValueWithinOceanVolumeRegion"/>
+      <var_array name="avgValueWithinOceanVolumeRegion"/>
+  </stream>
+
+  <stream name="meridionalHeatTransportOutput"
+          type="output"
+          io_type="pnetcdf"
+          filename_template="mpaso.hist.am.meridionalHeatTransport.$Y-$M-$D.nc"
+          filename_interval="00-01-00_00:00:00"
+          output_interval="none"
+          clobber_mode="truncate"
+          packages="meridionalHeatTransportAMPKG">
+
+      <var name="xtime"/>
+      <var name="daysSinceStartOfSim"/>
+      <var name="binBoundaryMerHeatTrans"/>
+      <var name="meridionalHeatTransportLatZ"/>
+      <var name="meridionalHeatTransportLat"/>
+      <var name="refZMid"/>
+      <var name="refBottomDepth"/>
+  </stream>
+
+  <stream name="surfaceAreaWeightedAveragesOutput"
+          type="output"
+          io_type="netcdf"
+          filename_template="mpaso.hist.am.surfaceAreaWeightedAverages.$Y-$M-$D.nc"
+          filename_interval="00-01-00_00:00:00"
+          output_interval="none"
+          clobber_mode="truncate"
+          packages="surfaceAreaWeightedAveragesAMPKG">
+
+      <var name="xtime"/>
+      <var name="daysSinceStartOfSim"/>
+      <var_array name="minValueWithinOceanRegion"/>
+      <var_array name="maxValueWithinOceanRegion"/>
+      <var_array name="avgValueWithinOceanRegion"/>
+  </stream>
+
+  <stream name="mixedLayerDepthsOutput"
+          type="output"
+          io_type="pnetcdf"
+          filename_template="mpaso.hist.am.mixedLayerDepths.$Y-$M-$D.nc"
+          filename_interval="00-01-00_00:00:00"
+          output_interval="none"
+          clobber_mode="truncate"
+          packages="mixedLayerDepthsAMPKG">
+
+      <var name="xtime"/>
+      <var name="daysSinceStartOfSim"/>
+      <stream name="mesh"/>
+      <var name="tThreshMLD"/>
+      <var name="dThreshMLD"/>
+      <var name="tGradMLD"/>
+      <var name="dGradMLD"/>
+  </stream>
+
+The ``filename_tempalate`` can be modified as desired (in most cases, these are
+the defalult values from E3SM).  For the ``timeSeriesStatsMonthlyOutput``
+stream, both the filename_interval and the output_interval must currently be
+monthly (``"0000-01-00_00:00:00"``).
+
+Additional fields can be included in the ``timeSeriesStatsMonthlyOutput``
+streams.  These are the minimum that allow the analysis to run successfully.

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -13,7 +13,7 @@ from mpas_analysis.shared.plot.plotting import plot_vertical_section, \
     timeseries_analysis_plot, setup_colormap
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    make_directories
+    make_directories, get_files_year_month
 
 from mpas_analysis.shared.io import open_mpas_dataset
 
@@ -485,13 +485,9 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
                 streamName, startDate=self.startDateTseries,
                 endDate=self.endDateTseries, calendar=self.calendar))
 
-        template = self.historyStreams.read_datetime_template(streamName)
-        template = os.path.basename(template)
-        dts = [datetime.strptime(os.path.basename(fileName), template) for
-               fileName in inputFilesTseries]
-
-        years = [dt.year for dt in dts]
-        months = [dt.month for dt in dts]
+        years, months = get_files_year_month(inputFilesTseries,
+                                             self.historyStreams,
+                                             'timeSeriesStatsMonthlyOutput')
 
         mocRegion = np.zeros(len(inputFilesTseries))
         times = np.zeros(len(inputFilesTseries))

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -9,7 +9,7 @@ import netCDF4
 import os
 
 from mpas_analysis.shared.constants.constants import m3ps_to_Sv
-from mpas_analysis.shared.plot.plotting import plot_vertical_section,\
+from mpas_analysis.shared.plot.plotting import plot_vertical_section, \
     timeseries_analysis_plot, setup_colormap
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
@@ -485,9 +485,13 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
                 streamName, startDate=self.startDateTseries,
                 endDate=self.endDateTseries, calendar=self.calendar))
 
-        dates = sorted([fileName[-13:-6] for fileName in inputFilesTseries])
-        years = np.array([int(date[0:4]) for date in dates])
-        months = np.array([int(date[5:7]) for date in dates])
+        template = self.historyStreams.read_datetime_template(streamName)
+        template = os.path.basename(template)
+        dts = [datetime.strptime(os.path.basename(fileName), template) for
+               fileName in inputFilesTseries]
+
+        years = [dt.year for dt in dts]
+        months = [dt.month for dt in dts]
 
         mocRegion = np.zeros(len(inputFilesTseries))
         times = np.zeros(len(inputFilesTseries))

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -13,7 +13,8 @@ from mpas_analysis.shared.climatology.climatology import \
     get_unmasked_mpas_climatology_directory, \
     get_unmasked_mpas_climatology_file_name
 
-from ..io.utility import get_files_year_month
+from ..io.utility import build_config_full_path, make_directories, \
+    get_files_year_month
 
 
 class MpasClimatologyTask(AnalysisTask):  # {{{
@@ -170,7 +171,8 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
             raise IOError('No files were found in stream {} between {} and '
                           '{}.'.format(streamName, startDate, endDate))
 
-        self._update_climatology_bounds_from_file_names()
+        self.symlinkDirectory = \
+            self._update_climatology_bounds_and_create_symlinks()
 
         # }}}
 
@@ -219,7 +221,7 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
 
         if not allExist:
             self._compute_climatologies_with_ncclimo(
-                    inDirectory=self.historyDirectory,
+                    inDirectory=self.symlinkDirectory,
                     outDirectory=climatologyDirectory)
 
         # }}}
@@ -249,10 +251,18 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
 
         # }}}
 
-    def _update_climatology_bounds_from_file_names(self):  # {{{
+    def _update_climatology_bounds_and_create_symlinks(self):  # {{{
         """
         Update the start and end years and dates for climatologies based on the
-        years actually available in the list of files.
+        years actually available in the list of files.  Create symlinks to
+        monthly mean files so they have the expected file naming convention
+        for ncclimo.
+
+        Returns
+        -------
+        symlinkDirectory : str
+            The path to the symlinks created for each timeSeriesStatsMonthly
+            input file
 
         Authors
         -------
@@ -305,6 +315,25 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         self.endDate = endDate
         self.startYear = startYear
         self.endYear = endYear
+
+        # now, create the symlinks
+        climatologyBaseDirectory = build_config_full_path(
+            config, 'output', 'mpasClimatologySubdirectory')
+
+        symlinkDirectory = '{}/source_symlinks'.format(
+                climatologyBaseDirectory)
+
+        make_directories(symlinkDirectory)
+
+        for inFileName, year, month in zip(fileNames, years, months):
+            outFileName = '{}/{}.hist.am.timeSeriesStatsMonthly.{:04d}-' \
+                '{:02d}-01.nc'.format(symlinkDirectory, self.ncclimoModel,
+                                      year, month)
+
+            if not os.path.exists(outFileName):
+                os.symlink(inFileName, outFileName)
+
+        return symlinkDirectory
 
         # }}}
 

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -13,6 +13,8 @@ from mpas_analysis.shared.climatology.climatology import \
     get_unmasked_mpas_climatology_directory, \
     get_unmasked_mpas_climatology_file_name
 
+from ..io.utility import get_files_year_month
+
 
 class MpasClimatologyTask(AnalysisTask):  # {{{
     '''
@@ -262,9 +264,10 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         requestedStartYear = config.getint('climatology', 'startYear')
         requestedEndYear = config.getint('climatology', 'endYear')
 
-        dates = sorted([fileName[-13:-6] for fileName in self.inputFiles])
-        years = [int(date[0:4]) for date in dates]
-        months = [int(date[5:7]) for date in dates]
+        fileNames = sorted(self.inputFiles)
+        years, months = get_files_year_month(fileNames,
+                                             self.historyStreams,
+                                             'timeSeriesStatsMonthlyOutput')
 
         # search for the start of the first full year
         firstIndex = 0

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -329,6 +329,40 @@ class StreamsFile:
                 return stream.get(attribname)
         return None
 
+    def read_datetime_template(self, streamname):
+        """
+        Get the value of the given attribute in the given stream
+
+        Parameters
+        ----------
+        streamname : str
+            The name of the stream
+
+        Returns
+        -------
+        value : str
+            The template for file names from this stream in a format accepted
+            by ``datetime.strptime``.  This is useful for parsing the date
+            from a given file name.
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        """
+        template = self.read(streamname, 'filename_template')
+        replacements = {'$Y': '%Y',
+                        '$M': '%m',
+                        '$D': '%d',
+                        '$S': '00000',  # datetime doesn't handle seconds alone
+                        '$h': '%H',
+                        '$m': '%M',
+                        '$s': '%S'}
+
+        for old in replacements:
+            template = template.replace(old, replacements[old])
+
+        return template
+
     def readpath(self, streamName, startDate=None, endDate=None,
                  calendar=None):
         """

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -11,6 +11,7 @@ import glob
 import os
 import random
 import string
+from datetime import datetime
 
 
 def paths(*args):  # {{{
@@ -95,7 +96,7 @@ def make_directories(path):  # {{{
 
 def build_config_full_path(config, section, relativePathOption,
                            relativePathSection=None,
-                           defaultPath=None): # {{{
+                           defaultPath=None):  # {{{
     """
     Returns a full path from a base directory and a relative path
 
@@ -134,7 +135,7 @@ def build_config_full_path(config, section, relativePathOption,
 
     if defaultPath is not None and not os.path.exists(fullPath):
         fullPath = defaultPath
-    return fullPath # }}}
+    return fullPath  # }}}
 
 
 def check_path_exists(path):  # {{{
@@ -158,5 +159,40 @@ def check_path_exists(path):  # {{{
     if not (os.path.isdir(path) or os.path.isfile(path)):
         raise OSError('Path {} not found'.format(path))  # }}}
 
+
+def get_files_year_month(fileNames, streamsFile, streamName):  # {{{
+    """
+    Extract the year and month from file names associated with a stream
+
+    Parameters
+    ----------
+    fileNames : list of str
+        The names of files with a year and month in their names.
+
+    streamsFile : ``StreamsFile``
+        The parsed streams file, used to get a template for the
+
+    streamName : str
+        The name of the stream with a file-name template for ``fileNames``
+
+    Returns
+    -------
+    years, months : list of int
+        The years and months for each file in ``fileNames``
+
+    Authors
+    -------
+    Xylar Asay-Davis
+    """
+
+    template = streamsFile.read_datetime_template(streamName)
+    template = os.path.basename(template)
+    dts = [datetime.strptime(os.path.basename(fileName), template) for
+           fileName in fileNames]
+
+    years = [dt.year for dt in dts]
+    months = [dt.month for dt in dts]
+
+    return years, months  # }}}
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -10,8 +10,8 @@ import numpy
 
 from mpas_analysis.shared.analysis_task import AnalysisTask
 
-from mpas_analysis.shared.io.utility import \
-    build_config_full_path, make_directories
+from mpas_analysis.shared.io.utility import build_config_full_path, \
+    make_directories, get_files_year_month
 from mpas_analysis.shared.timekeeping.utility import get_simulation_start_time
 
 
@@ -211,9 +211,10 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         requestedStartYear = config.getint(section, 'startYear')
         requestedEndYear = config.getint(section, 'endYear')
 
-        dates = sorted([fileName[-13:-6] for fileName in self.inputFiles])
-        years = [int(date[0:4]) for date in dates]
-        months = [int(date[5:7]) for date in dates]
+        fileNames = sorted(self.inputFiles)
+        years, months = get_files_year_month(fileNames,
+                                             self.historyStreams,
+                                             'timeSeriesStatsMonthlyOutput')
 
         # search for the start of the first full year
         firstIndex = 0
@@ -289,10 +290,14 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
                 if updateSubset:
                     # add only input files wiht times that aren't already in
                     # the output file
-                    dates = sorted([fileName[-13:-6] for fileName in
-                                    self.inputFiles])
-                    inYears = numpy.array([int(date[0:4]) for date in dates])
-                    inMonths = numpy.array([int(date[5:7]) for date in dates])
+
+                    fileNames = sorted(self.inputFiles)
+                    inYears, inMonths = get_files_year_month(
+                            fileNames, self.historyStreams,
+                            'timeSeriesStatsMonthlyOutput')
+
+                    inYears = numpy.array(inYears)
+                    inMonths = numpy.array(inMonths)
                     totalMonths = 12*inYears + inMonths
 
                     dates = [bytes.decode(name) for name in
@@ -304,7 +309,7 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
                     lastTotalMonths = 12*lastYear + lastMonth
 
                     inputFiles = []
-                    for index, inputFile in enumerate(self.inputFiles):
+                    for index, inputFile in enumerate(fileNames):
                         if totalMonths[index] > lastTotalMonths:
                             inputFiles.append(inputFile)
 

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -112,7 +112,7 @@ class TestMpasClimatologyTask(TestCase):
             fileName = mpasClimatologyTask.get_file_name(season=season)
             assert(os.path.exists(fileName))
 
-    def test_update_climatology_bounds_from_file_names(self):
+    def test_update_climatology_bounds_and_create_symlinks(self):
         mpasClimatologyTask = self.setup_task()
         config = mpasClimatologyTask.config
 
@@ -123,7 +123,7 @@ class TestMpasClimatologyTask(TestCase):
         startDate = '{:04d}-01-01_00:00:00'.format(startYear)
         endDate = '{:04d}-12-31_23:59:59'.format(endYear)
 
-        mpasClimatologyTask._update_climatology_bounds_from_file_names()
+        mpasClimatologyTask._update_climatology_bounds_and_create_symlinks()
 
         assert(mpasClimatologyTask.startYear == startYear)
         assert(mpasClimatologyTask.endYear == endYear)
@@ -142,7 +142,7 @@ class TestMpasClimatologyTask(TestCase):
         config.set('climatology', 'startDate', startDate)
         config.set('climatology', 'endDate', endDate)
 
-        mpasClimatologyTask._update_climatology_bounds_from_file_names()
+        mpasClimatologyTask._update_climatology_bounds_and_create_symlinks()
 
         startYear = 2
         endYear = 2


### PR DESCRIPTION
We haven't been testing standalone MPAS-O and MPAS-SeaIce runs on a regular basis.  As a result, they were no longer working and this merge attempts to remedy that situation.

File names produced by standalone MPAS runs don't necessarily conform to E3SM standards, and are therefore not supported by `ncclimo` all versions of NCO.  (`ncclimo` in NCO 4.7.3 will include more general file-name parsing so this could be a partial solution to the problem.)  The solution here is to create symlinks to the timeSeriesStatsMonthlyOutput files in the analysis output directory where the links have the expected E3SM file names.

Additionally, there are 3 places in MPAS-Analysis where years and months are extracted from file names.  Previously, this was done in a lazy way assuming the E3SM file-naming convention.  With this merge, file names are instead parsed based on the `filename_template` attribute in the associated stream.

Finally, the documentation has been updated to give instructions on how to set up analysis members, including output streams, in standalone MPAS runs to they are compatible with MPAS-Analysis.  These instructions will need to be updated as new variables are used in analysis task.  (A documentation page with a list of authors has also been added.)