### PR TITLE
Change diff color map to be white near zero

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -521,9 +521,9 @@ colorbarLevelsResult = [-2, 0, 2, 6, 10, 16, 22, 26, 28, 32]
 # colormap for differences
 colormapNameDifference = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = [-5, -3, -2, -1, 0, 1, 2, 3, 5]
+colorbarLevelsDifference = [-5, -3, -2, -1, -0.1, 0, 0.1, 1, 2, 3, 5]
 
 # Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
@@ -546,9 +546,9 @@ colorbarLevelsResult = [28, 29, 30, 31, 32, 33, 34, 35, 36, 38]
 # colormap for differences
 colormapNameDifference = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = [-3, -2, -1, -0.5, 0, 0.5, 1, 2, 3]
+colorbarLevelsDifference = [-3, -2, -1, -0.5, -0.02, 0,  0.02, 0.5, 1, 2, 3]
 
 # Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
@@ -571,9 +571,9 @@ colorbarLevelsResult = [0, 20, 40, 60, 80, 100, 150, 200, 400, 800]
 # colormap for differences
 colormapNameDifference = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = [-150, -80, -30, -10, 0, 10, 30, 80, 150]
+colorbarLevelsDifference = [-150, -80, -30, -10, -1, 0, 1, 10, 30, 80, 150]
 
 # Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
@@ -711,9 +711,9 @@ colorbarLevelsResult = [0.15, 0.3, 0.5, 0.7, 0.8, 0.85, 0.9, 0.95, 1]
 # colormap for differences
 colormapNameDifference = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 32, 64, 96, 128, 128, 160, 192, 224, 255]
+colormapIndicesDifference = [0, 32, 64, 96, 112, 128, 128, 144, 160, 192, 224, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8, 1.]
+colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, -0.1, 0, 0.1, 0.2, 0.4, 0.6, 0.8, 1.]
 
 # Times for comparison times (These should be left unchanged, since
 # observations are only available for these seasons)
@@ -747,9 +747,9 @@ colorbarLevelsResult = [0.15, 0.3, 0.5, 0.7, 0.8, 0.85, 0.9, 0.95, 1]
 # colormap for differences
 colormapNameDifference = RdBu_r
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 32, 64, 96, 128, 128, 160, 192, 224, 255]
+colormapIndicesDifference = [0, 32, 64, 96, 112, 128, 128, 144, 160, 192, 224, 255]
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8, 1.]
+colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, -0.1, 0, 0.1, 0.2, 0.4, 0.6, 0.8, 1.]
 
 # Times for comparison times (These should be left unchanged, since
 # observations are only available for these seasons)


### PR DESCRIPTION
This was not the case for SST, SSS and MLD, which could lead to
meaningless blue/pink speckle.