### PR TITLE
Add support for specifying the anomaly ref year

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -184,6 +184,11 @@ renormalizationThreshold = 0.01
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
+# the year from which to compute anomalies if not the start year of the
+# simulation.  This might be useful if a long spin-up cycle is performed and
+# only the anomaly over a later span of years is of interest.
+# anomalyRefYear = 249
+
 # start and end years for timeseries analysis. Using out-of-bounds values
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.

--- a/mpas_analysis/ocean/compute_anomaly_subtask.py
+++ b/mpas_analysis/ocean/compute_anomaly_subtask.py
@@ -145,12 +145,16 @@ class ComputeAnomalySubtask(AnalysisTask):
         startDate = config.get('timeSeries', 'startDate')
         endDate = config.get('timeSeries', 'endDate')
 
-        simulationStartTime = get_simulation_start_time(self.runStreams)
+        if config.has_option('timeSeries', 'anomalyRefYear'):
+            anomalyYear = config.getint('timeSeries', 'anomalyRefYear')
+            anomalyRefDate = '{:04d}-01-01_00:00:00'.format(anomalyYear)
+        else:
+            anomalyRefDate = get_simulation_start_time(self.runStreams)
 
         ds = compute_moving_avg_anomaly_from_start(
                 timeSeriesFileName=self.inputFile,
                 variableList=self.variableList,
-                simulationStartTime=simulationStartTime,
+                simulationStartTime=anomalyRefDate,
                 startDate=startDate,
                 endDate=endDate,
                 calendar=self.calendar,

--- a/mpas_analysis/ocean/compute_anomaly_subtask.py
+++ b/mpas_analysis/ocean/compute_anomaly_subtask.py
@@ -148,13 +148,17 @@ class ComputeAnomalySubtask(AnalysisTask):
         if config.has_option('timeSeries', 'anomalyRefYear'):
             anomalyYear = config.getint('timeSeries', 'anomalyRefYear')
             anomalyRefDate = '{:04d}-01-01_00:00:00'.format(anomalyYear)
+            anomalyEndDate = '{:04d}-12-31_23:59:59'.format(anomalyYear)
         else:
             anomalyRefDate = get_simulation_start_time(self.runStreams)
+            anomalyYear = int(anomalyRefDate[0:4])
+            anomalyEndDate = '{:04d}-12-31_23:59:59'.format(anomalyYear)
 
         ds = compute_moving_avg_anomaly_from_start(
                 timeSeriesFileName=self.inputFile,
                 variableList=self.variableList,
-                simulationStartTime=anomalyRefDate,
+                anomalyStartTime=anomalyRefDate,
+                anomalyEndTime=anomalyEndDate,
                 startDate=startDate,
                 endDate=endDate,
                 calendar=self.calendar,

--- a/mpas_analysis/shared/time_series/anomaly.py
+++ b/mpas_analysis/shared/time_series/anomaly.py
@@ -8,8 +8,8 @@ from mpas_analysis.shared.time_series.moving_average import compute_moving_avg
 
 
 def compute_moving_avg_anomaly_from_start(timeSeriesFileName, variableList,
-                                          simulationStartTime, startDate,
-                                          endDate, calendar,
+                                          anomalyStartTime, anomalyEndTime,
+                                          startDate, endDate, calendar,
                                           movingAveragePoints=12,
                                           alter_dataset=None):  # {{{
 
@@ -67,7 +67,8 @@ def compute_moving_avg_anomaly_from_start(timeSeriesFileName, variableList,
         fileName=timeSeriesFileName,
         calendar=calendar,
         variableList=variableList,
-        startDate=simulationStartTime)
+        startDate=anomalyStartTime,
+        endDate=anomalyEndTime)
 
     if alter_dataset is not None:
         dsStart = alter_dataset(dsStart)

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -161,12 +161,17 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
                                   os.path.basename(self.inputFiles[-1]))
 
         # Make sure first year of data is included for computing anomalies
-        simulationStartTime = get_simulation_start_time(self.runStreams)
-        firstYear = int(simulationStartTime[0:4])
-        endDateFirstYear = '{:04d}-12-31_23:59:59'.format(firstYear)
+        if config.has_option('timeSeries', 'anomalyRefYear'):
+            anomalyYear = config.getint('timeSeries', 'anomalyRefYear')
+            anomalyStartDate = '{:04d}-01-01_00:00:00'.format(anomalyYear)
+        else:
+            anomalyStartDate = get_simulation_start_time(self.runStreams)
+            anomalyYear = int(anomalyStartDate[0:4])
+
+        anomalyEndDate = '{:04d}-12-31_23:59:59'.format(anomalyYear)
         firstYearInputFiles = self.historyStreams.readpath(
-                streamName, startDate=simulationStartTime,
-                endDate=endDateFirstYear,
+                streamName, startDate=anomalyStartDate,
+                endDate=anomalyEndDate,
                 calendar=self.calendar)
         for fileName in firstYearInputFiles:
             if fileName not in self.inputFiles:


### PR DESCRIPTION
This is useful for runs that include a spin-up phase and anomalies are only of interest after the spin-up has completed (e.g. the last CORE-II cycle in a G-case E3SM run).