### PR TITLE
Fix encoding headers in python files

### DIFF
--- a/licenses/_headers/license-bump-copyright.sh
+++ b/licenses/_headers/license-bump-copyright.sh
@@ -16,51 +16,49 @@
 # Get the source dir and ignore variables
 source license-setup.sh
 
-OLD="Copyright (c) 2015,2016, UT"
-NEW="Copyright (c) 2017, UT"
-
-ALWAYS_IGNORE=(-not -path "*.git*" -not -path "*docs/*")
-FILE_IGNORE=(-not -iname "*.md" -not -iname "*.json" -not -iname "*.txt" \
-             -not -iname "*.png" -not -iname "*.jpg" -not -iname "*.svg" )
+OLD="Copyright (c) 2017, UT"
+NEW="Copyright (c) 2017-2018, UT"
 
 echo "--------------------------------------------------------------------------------"
 echo "    THESE FILES HAVE AN OUTDATED LICENSE HEADER:"
 echo "--------------------------------------------------------------------------------"
-find $SOURCE_DIR -type f "${ALWAYS_IGNORE[@]}" \
+find ${SOURCE_DIR} -type f "${ALWAYS_IGNORE[@]}" \
     "${FILE_IGNORE[@]}" \
-    | xargs grep -l "$OLD" \
+    "${PYTHON_IGNORE[@]}" \
+    | xargs -r grep -l "$OLD" \
     | sort
 
+# Also, bump any copyright statements in the documentation
 find ${SOURCE_DIR}/docs -type f \
     -not -path "*_build*" \
     -not -path "*source*" \
     "${FILE_IGNORE[@]}" \
-    | xargs grep -l "$OLD" \
+    | xargs -r grep -l "$OLD" \
     | sort
 
 
 echo "--------------------------------------------------------------------------------"
 echo "    UPDATING THE LICENSE HEADERS:"
 echo "--------------------------------------------------------------------------------"
-find $SOURCE_DIR -type f "${ALWAYS_IGNORE[@]}" \
+find ${SOURCE_DIR} -type f "${ALWAYS_IGNORE[@]}" \
     "${FILE_IGNORE[@]}" \
-    | xargs grep -l "$OLD" \
+    | xargs -r grep -l "$OLD" \
     | sort \
     | while read SRC
 do
     echo "Bumping $SRC"
-    sed -i "s/$OLD/$NEW/g" $SRC
+    sed -i "s/$OLD/$NEW/g" ${SRC}
 done
 
-
+# Also, bump any copyright statements in the documentation
 find ${SOURCE_DIR}/docs -type f \
     -not -path "*_build*" \
     -not -path "*source*" \
     "${FILE_IGNORE[@]}" \
-    | xargs grep -l "$OLD" \
+    | xargs -r grep -l "$OLD" \
     | sort \
     | while read SRC
 do
     echo "Bumping $SRC"
-    sed -i "s/$OLD/$NEW/g" $SRC
+    sed -i "s/$OLD/$NEW/g" ${SRC}
 done

--- a/licenses/_headers/license-find-missing.sh
+++ b/licenses/_headers/license-find-missing.sh
@@ -12,10 +12,9 @@ source license-setup.sh
 echo "--------------------------------------------------------------------------------"
 echo "    THESE FILES ARE MISSING A CURRENT LICENSE HEADER:"
 echo "--------------------------------------------------------------------------------"
-find $SOURCE_DIR -type f "${ALWAYS_IGNORE[@]}" \
+find ${SOURCE_DIR} -type f "${ALWAYS_IGNORE[@]}" \
     "${FILE_IGNORE[@]}" \
     "${PYTHON_IGNORE[@]}" \
-    "${CSS_IGNORE[@]}" \
-    | xargs grep -L "$CURRENT" \
+    | xargs -r grep -L "$CURRENT" \
     | sort
 

--- a/licenses/_headers/license-prepend-missing.sh
+++ b/licenses/_headers/license-prepend-missing.sh
@@ -16,17 +16,13 @@
 # Get the source dir and ignore variables
 source license-setup.sh
 
-GET=( -iname "*.py" -or -iname "*.sh" -or -iname "*.bash" -or -iname "*.csh" \
-     -or -iname "*.pbs" -or -iname "*.html" -or -iname "*.css" -or -iname "*.js" )
-
 echo "--------------------------------------------------------------------------------"
-echo "    PREPENDING A LICENSE HEADER ONTO THESE FILES:"
+echo "    ATTEMPTING TO PREPEND A LICENSE HEADER ONTO THESE FILES:"
 echo "--------------------------------------------------------------------------------"
-find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" \
+find ${SOURCE_DIR} -type f "${ALWAYS_IGNORE[@]}" \
     "${FILE_IGNORE[@]}" \
     "${PYTHON_IGNORE[@]}" \
-    "${CSS_IGNORE[@]}" \
-    | xargs grep -L "$CURRENT" \
+    | xargs -r grep -L "$CURRENT" \
     | sort
 
 echo "--------------------------------------------------------------------------------"
@@ -40,7 +36,7 @@ echo "--------------------------------------------------------------------------
 ############################################################
 GET=( -iname "*.py" )
 
-find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
+find ${SOURCE_DIR} -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
     | xargs -r grep -l --max-count=1 "#!" \
     | xargs -r grep -l --max-count=1 "# -\*-" \
     | xargs -r grep -L "$CURRENT" \
@@ -62,7 +58,7 @@ done
 #######################################################################
 GET=( -iname "*.py" )
 
-find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
+find ${SOURCE_DIR} -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
     | xargs -r grep -l --max-count=1 "# -\*-" \
     | xargs -r grep -L "$CURRENT" \
     | while read SRC
@@ -83,7 +79,7 @@ done
 ############################################################
 GET=( -iname "*.py" )
 
-find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
+find ${SOURCE_DIR} -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
     | xargs -r grep -L "#!" \
     | xargs -r grep -L "$CURRENT" \
     | while read SRC
@@ -103,7 +99,7 @@ done
 #######################################################################
 GET=( -iname "*.py" -or -iname "*.sh" -or -iname "*.bash" -or -iname "*.csh" -or -iname "*.pbs")
 
-find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
+find ${SOURCE_DIR} -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
     | xargs -r grep -l --max-count=1 "#!" \
     | xargs -r grep -L "$CURRENT" \
     | while read SRC
@@ -124,7 +120,7 @@ done
 ####################################################
 GET=( -iname "*.html")
 
-find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" \
+find ${SOURCE_DIR} -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" \
     | xargs -r grep -L "$CURRENT" \
     | while read SRC
 do
@@ -142,7 +138,7 @@ done
 ####################################################
 GET=( -iname "*.css" -or -iname "*.js" )
 
-find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${CSS_IGNORE[@]}" \
+find ${SOURCE_DIR} -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" \
     | xargs -r grep -L "$CURRENT" \
     | while read SRC
 do
@@ -156,5 +152,27 @@ done
 
 echo "--------------------------------------------------------------------------------"
 echo "    DONE PREPENDING!"
-echo "--------------------------------------------------------------------------------"
 
+
+MISSED=`find ${SOURCE_DIR} -type f "${ALWAYS_IGNORE[@]}" \
+    "${FILE_IGNORE[@]}" \
+    "${PYTHON_IGNORE[@]}" \
+    | xargs -r grep -L "$CURRENT"`
+
+if [ "$MISSED" ]
+then
+    echo ""
+    echo "    WARNING: There is no method to prepend a license header onto the following"
+    echo "             files. Please either manually add the license head to these files,"
+    echo "             add a method to prepend a license header onto these type of files,"
+    echo "             or set them to be ignored in 'license-setup.sh'. "
+    echo "--------------------------------------------------------------------------------"
+    find ${SOURCE_DIR} -type f "${ALWAYS_IGNORE[@]}" \
+        "${FILE_IGNORE[@]}" \
+        "${PYTHON_IGNORE[@]}" \
+        | xargs -r grep -L "$CURRENT" \
+        | sort
+    echo "--------------------------------------------------------------------------------"
+else
+    echo "--------------------------------------------------------------------------------"
+fi

--- a/licenses/_headers/license-prepend-missing.sh
+++ b/licenses/_headers/license-prepend-missing.sh
@@ -16,10 +16,13 @@
 # Get the source dir and ignore variables
 source license-setup.sh
 
+GET=( -iname "*.py" -or -iname "*.sh" -or -iname "*.bash" -or -iname "*.csh" \
+     -or -iname "*.pbs" -or -iname "*.html" -or -iname "*.css" -or -iname "*.js" )
+
 echo "--------------------------------------------------------------------------------"
 echo "    PREPENDING A LICENSE HEADER ONTO THESE FILES:"
 echo "--------------------------------------------------------------------------------"
-find $SOURCE_DIR -type f "${ALWAYS_IGNORE[@]}" \
+find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" \
     "${FILE_IGNORE[@]}" \
     "${PYTHON_IGNORE[@]}" \
     "${CSS_IGNORE[@]}" \
@@ -29,6 +32,51 @@ find $SOURCE_DIR -type f "${ALWAYS_IGNORE[@]}" \
 echo "--------------------------------------------------------------------------------"
 echo "    BEGIN PREPENDING:"
 echo "--------------------------------------------------------------------------------"
+
+
+############################################################
+# Prepend license header to python files with a shebang and an encoding header.
+# Will ignore files with a current license header.
+############################################################
+GET=( -iname "*.py" )
+
+find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
+    | xargs -r grep -l --max-count=1 "#!" \
+    | xargs -r grep -l --max-count=1 "# -\*-" \
+    | xargs -r grep -L "$CURRENT" \
+    | while read SRC
+do
+    BN=`basename ${SRC}`
+    echo HEADING ${SRC}
+    cat ${SRC} | head -n 2 > /tmp/licHead
+    cat header-py >> /tmp/licHead
+    cat ${SRC} | tail -n +3 >> /tmp/licHead
+    chmod --reference=${SRC} /tmp/licHead
+    mv /tmp/licHead ${SRC}
+done
+
+
+#######################################################################
+# Prepend license header to python files with encoding header.
+# Will ignore files with a current license header.
+#######################################################################
+GET=( -iname "*.py" )
+
+find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
+    | xargs -r grep -l --max-count=1 "# -\*-" \
+    | xargs -r grep -L "$CURRENT" \
+    | while read SRC
+do
+    BN=`basename ${SRC}`
+    echo HEADING ${SRC}
+    cat ${SRC} | head -n 1 > /tmp/licHead
+    cat header-py >> /tmp/licHead
+    cat ${SRC} | tail -n +2 >> /tmp/licHead
+    chmod --reference=${SRC} /tmp/licHead
+    mv /tmp/licHead ${SRC}
+done
+
+
 ############################################################
 # Prepend license header to python files without a shebang.
 # Will ignore files with a current license header.
@@ -36,8 +84,8 @@ echo "--------------------------------------------------------------------------
 GET=( -iname "*.py" )
 
 find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
-    | xargs grep -L "#!" \
-    | xargs grep -L "$CURRENT" \
+    | xargs -r grep -L "#!" \
+    | xargs -r grep -L "$CURRENT" \
     | while read SRC
 do
     BN=`basename ${SRC}`
@@ -48,6 +96,7 @@ do
     mv /tmp/licHead ${SRC}
 done
 
+
 #######################################################################
 # Prepend license header to python, bash, and sh files with a shebang.
 # Will ignore files with a current license header.
@@ -55,8 +104,8 @@ done
 GET=( -iname "*.py" -or -iname "*.sh" -or -iname "*.bash" -or -iname "*.csh" -or -iname "*.pbs")
 
 find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${PYTHON_IGNORE[@]}" \
-    | xargs grep -l --max-count=1 "#!" \
-    | xargs grep -L "$CURRENT" \
+    | xargs -r grep -l --max-count=1 "#!" \
+    | xargs -r grep -L "$CURRENT" \
     | while read SRC
 do
     BN=`basename ${SRC}`
@@ -76,7 +125,7 @@ done
 GET=( -iname "*.html")
 
 find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" \
-    | xargs grep -L "$CURRENT" \
+    | xargs -r grep -L "$CURRENT" \
     | while read SRC
 do
     BN=`basename ${SRC}`
@@ -94,7 +143,7 @@ done
 GET=( -iname "*.css" -or -iname "*.js" )
 
 find $SOURCE_DIR -type f \( "${GET[@]}" \) "${ALWAYS_IGNORE[@]}" "${CSS_IGNORE[@]}" \
-    | xargs grep -L "$CURRENT" \
+    | xargs -r grep -L "$CURRENT" \
     | while read SRC
 do
     BN=`basename ${SRC}`

--- a/licenses/_headers/license-setup.sh
+++ b/licenses/_headers/license-setup.sh
@@ -17,14 +17,21 @@ SOURCE_DIR="../.."
 
 CURRENT="Copyright (c)"
 
-ALWAYS_IGNORE=(-not -path "*.git*" -not -path "*docs/*" -not -path "build/*" \
-               -not -path "dist/*" -not -path "*.egg-info/*" \
-               -not -path "licenses/*" )
+ALWAYS_IGNORE=(-not -path "*.git*" \
+               -not -path "${SOURCE_DIR}/docs/*"  \
+               -not -path "${SOURCE_DIR}/licenses/*" \
+               -not -path "${SOURCE_DIR}/build/*" \
+               -not -path "${SOURCE_DIR}/dist/*" \
+               -not -path "${SOURCE_DIR}/.idea/*" \
+               -not -path "*.egg-info/*" \
+               -not -path "${SOURCE_DIR}/conda/recipe/meta.yaml" \
+               -not -path "${SOURCE_DIR}/setup.cfg")
 
-FILE_IGNORE=(-not -iname "*.md" -not -iname "*.json" -not -iname "*.txt" \
+FILE_IGNORE=(-not -iname "*.ocean" -not -iname "*_in" \
+             -not -iname "*.md" -not -iname "*.json" -not -iname "*.txt" \
              -not -iname "*.png" -not -iname "*.jpg" -not -iname "*.svg" \
              -not -iname "config.*" -not -iname "*.nc"\
              -not -iname "*.pyc" \
-             -not -iname "*.sl" -not -iname "*.ps1" -not -iname "*.yml"    )
+             -not -iname "*.sl" -not -iname "*.ps1" -not -iname "*.yml")
 
 PYTHON_IGNORE=(-not -iname "__init__.py")

--- a/mpas_analysis/ocean/climatology_map_argo.py
+++ b/mpas_analysis/ocean/climatology_map_argo.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 '''
 Analysis tasks for comparing Global climatology maps against ARGO data.
 

--- a/mpas_analysis/ocean/compute_anomaly_subtask.py
+++ b/mpas_analysis/ocean/compute_anomaly_subtask.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
@@ -5,7 +7,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
 #
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
@@ -5,7 +7,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
 #
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
+++ b/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
@@ -5,7 +7,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
 #
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/ocean/plot_hovmoller_subtask.py
+++ b/mpas_analysis/ocean/plot_hovmoller_subtask.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
@@ -5,7 +7,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
 #
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
@@ -5,7 +7,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
 #
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/ocean/time_series_ohc_anomaly.py
+++ b/mpas_analysis/ocean/time_series_ohc_anomaly.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
@@ -5,7 +7,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
 #
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/ocean/time_series_salinity_anomaly.py
+++ b/mpas_analysis/ocean/time_series_salinity_anomaly.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
@@ -5,7 +7,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
 #
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/ocean/time_series_temperature_anomaly.py
+++ b/mpas_analysis/ocean/time_series_temperature_anomaly.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
@@ -5,7 +7,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
 #
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/shared/time_series/anomaly.py
+++ b/mpas_analysis/shared/time_series/anomaly.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
@@ -5,7 +7,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
 #
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/mpas_analysis/shared/time_series/moving_average.py
+++ b/mpas_analysis/shared/time_series/moving_average.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
@@ -5,7 +7,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
 #
-# -*- coding: utf-8 -*-
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -1,4 +1,11 @@
 #!/usr/bin/env python
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
 
 """
 Runs MPAS-Analysis via a configuration file (e.g. `config.analysis`)


### PR DESCRIPTION
This merge moves the encoding headers to the top of python files.  It also updates the code for prepending license headers to make sure encoding headers go before the license header.

A few files have had license headers added to them.