### PR TITLE
Rename cice to seaice

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,12 +103,19 @@ for more details.
       * `mpaso.rst.0002-01-01_00000.nc` (or any other mpas-o restart file)
       * `streams.ocean`
       * `mpas-o_in`
-  * mpas-cice files:
-      * `mpascice.hist.am.timeSeriesStatsMonthly.*.nc`
-      * `mpascice.rst.0002-01-01_00000.nc` (or any other mpas-cice restart
+  * mpas-seaice files:
+      * `mpasseaice.hist.am.timeSeriesStatsMonthly.*.nc`
+      * `mpasseaice.rst.0002-01-01_00000.nc` (or any other mpas-seaice restart
         file)
-      * `streams.cice`
-      * `mpas-cice_in`
+      * `streams.seaice`
+      * `mpas-seaice_in`
+
+Note: for older runs, mpas-seaice files will be named:
+  * `mpascice.hist.am.timeSeriesStatsMonthly.*.nc`
+  * `mpascice.rst.0002-01-01_00000.nc`
+  * `streams.cice`
+  * `mpas-cice_in`
+
 
 ## Purge Old Analysis
 

--- a/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+++ b/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
@@ -32,6 +32,13 @@ mpasMeshName = oEC60to30v3
 # placed in the output mappingSubdirectory
 mappingDirectory = /lcrc/group/acme/mpas_analysis/mapping
 
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpas-o_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpas-cice_in
+seaIceStreamsFileName = streams.cice
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -43,6 +43,13 @@ mpasMeshName = oRRS30to10v3wLI
 # placed in the output mappingSubdirectory
 mappingDirectory = /global/project/projectdirs/acme/mpas_analysis/mapping
 
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpas-o_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpas-cice_in
+seaIceStreamsFileName = streams.cice
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/configs/edison/config.20170807.beta1.G_oQU240.edison
+++ b/configs/edison/config.20170807.beta1.G_oQU240.edison
@@ -32,6 +32,13 @@ mpasMeshName = oQU240
 # placed in the output mappingSubdirectory
 # mappingDirectory = /dir/for/mapping/files
 
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpas-o_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpas-cice_in
+seaIceStreamsFileName = streams.cice
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/configs/edison/config.20171102.beta3rc02_1850.ne30_oECv3_ICG.edison
+++ b/configs/edison/config.20171102.beta3rc02_1850.ne30_oECv3_ICG.edison
@@ -33,6 +33,13 @@ mpasMeshName = oEC60to30v3
 # placed in the output mappingSubdirectory
 mappingDirectory = /global/project/projectdirs/acme/mpas_analysis/mapping
 
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpas-o_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpas-cice_in
+seaIceStreamsFileName = streams.cice
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -43,6 +43,13 @@ mpasMeshName = oEC60to30v3wLI
 # placed in the output mappingSubdirectory
 mappingDirectory = /global/project/projectdirs/acme/mpas_analysis/mapping
 
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpas-o_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpas-cice_in
+seaIceStreamsFileName = streams.cice
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -32,6 +32,13 @@ mpasMeshName = QU60
 # placed in the output mappingSubdirectory
 # mappingDirectory = /dir/for/mapping/files
 
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpas-o_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpas-cice_in
+seaIceStreamsFileName = streams.cice
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -32,6 +32,13 @@ mpasMeshName = oEC60to30v3
 # placed in the output mappingSubdirectory
 mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/mapping/
 
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpas-o_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpas-cice_in
+seaIceStreamsFileName = streams.cice
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -32,6 +32,13 @@ mpasMeshName = oEC60to30v3
 # placed in the output mappingSubdirectory
 mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mapping/
 
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpas-o_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpas-cice_in
+seaIceStreamsFileName = streams.cice
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -32,6 +32,13 @@ mpasMeshName = oRRS18to6v3
 # placed in the output mappingSubdirectory
 mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mapping
 
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpas-o_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpas-cice_in
+seaIceStreamsFileName = streams.cice
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/theta/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -45,6 +45,13 @@ mpasMeshName = oEC60to30v3wLI
 # placed in the output mappingSubdirectory
 mappingDirectory = /projects/OceanClimate/mpas-analysis_data/mpas_analysis/mapping
 
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpas-o_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpas-cice_in
+seaIceStreamsFileName = streams.cice
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/docs/mpasseaice.rst
+++ b/docs/mpasseaice.rst
@@ -14,7 +14,8 @@ In order to support all sea=ice analysis tasks from MPAS-Analysis, certain
 simulation, need to be enabled.
 
 The following is a list of suggested values for namelist options, typically
-found in ``namelist.cice`` or ``mpas-cice_in``::
+found in ``namelist.seaice`` or ``mpas-seaice_in`` (or ``mpas-cice_in`` in
+older E3SM runs)::
 
      config_AM_timeSeriesStatsMonthly_enable = .true.
 
@@ -24,13 +25,13 @@ typically longer before most analysis is useful::
      config_run_duration = '0002-00-00_00:00:00'
 
 Several streams must be defined in the streams file, typically
-``streams.cice``, (even if they will not be written out --
-``output_interval=="none"``)::
+``streams.seaice`` or ``streams.cice`` in older E3SM runs, (even if they will
+not be written out -- ``output_interval=="none"``)::
 
   <stream name="timeSeriesStatsMonthlyRestart"
           type="input;output"
           io_type="pnetcdf"
-          filename_template="mpascice.rst.am.timeSeriesStatsMonthly.$Y-$M-$D_$S.nc"
+          filename_template="mpasseaice.rst.am.timeSeriesStatsMonthly.$Y-$M-$D_$S.nc"
           filename_interval="output_interval"
           clobber_mode="truncate"
           packages="timeSeriesStatsMonthlyAMPKG"
@@ -41,7 +42,7 @@ Several streams must be defined in the streams file, typically
   <stream name="timeSeriesStatsMonthlyOutput"
           type="output"
           io_type="pnetcdf"
-          filename_template="mpascice.hist.am.timeSeriesStatsMonthly.$Y-$M-$D.nc"
+          filename_template="mpasseaice.hist.am.timeSeriesStatsMonthly.$Y-$M-$D.nc"
           filename_interval="00-01-00_00:00:00"
           output_interval="00-01-00_00:00:00"
           clobber_mode="truncate"

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -74,8 +74,8 @@ seaIceHistorySubdirectory = .
 # or an absolute path.
 oceanNamelistFileName = mpas-o_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpas-seaice_in
+seaIceStreamsFileName = streams.seaice
 
 # names of ocean and sea ice meshes (e.g. oEC60to30, oQU240, oRRS30to10, etc.)
 mpasMeshName = mesh


### PR DESCRIPTION
...everywhere except where used by ncclimo and in namelist and streams files in config files for existing E3SM runs.

Following @akturner's work to rename MPAS-Seaice (from MPAS-CICE), we need to make the same update in MPAS-Analysis.  In practice this affects relatively few parts of the code because output file names from E3SM runs are read in from the streams file and we don't happen to use any namelist options that included `cice` in the name.