### PR TITLE
Check for requested variables in timeSeriesStatsMonthly

### DIFF
--- a/mpas_analysis/ocean/climatology_map_mld.py
+++ b/mpas_analysis/ocean/climatology_map_mld.py
@@ -149,6 +149,29 @@ class ClimatologyMapMLD(AnalysisTask):  # {{{
 
                 self.add_subtask(subtask)
         # }}}
+
+    def setup_and_check(self):  # {{{
+        '''
+        Check if MLD capability was turned on in the run.
+
+        Authors
+        -------
+        Xylar Asay-Davis
+        '''
+
+        # first, call setup_and_check from the base class (AnalysisTask),
+        # which will perform some common setup, including storing:
+        #     self.runDirectory , self.historyDirectory, self.plotsDirectory,
+        #     self.namelist, self.runStreams, self.historyStreams,
+        #     self.calendar
+        super(ClimatologyMapMLD, self).setup_and_check()
+
+        self.check_analysis_enabled(
+            analysisOptionName='config_am_mixedlayerdepths_enable',
+            raiseException=True)
+
+        # }}}
+
     # }}}
 
 


### PR DESCRIPTION
Before calling NCO tools, raise exceptions if the requested variables are not available so only tasks requesting unavailable variables fail, not the full analysis.