### PR TITLE
Make non-time-dependent vars be coords in mpas_xarray

### DIFF
--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -244,6 +244,12 @@ def preprocess(ds, calendar, simulationStartTime, timeVariableName,
     and Xylar Asay-Davis
     """
 
+    # following a suggestion by @rabernat
+    # https://github.com/pydata/xarray/issues/2064#issuecomment-381717472
+    concat_dim = 'Time'
+    coord_vars = [v for v in ds.data_vars if concat_dim not in ds[v].dims]
+    ds = ds.set_coords(coord_vars)
+
     ds = _parse_dataset_time(ds=ds,
                              inTimeVariableName=timeVariableName,
                              calendar=calendar,

--- a/mpas_analysis/test/test_generalized_reader.py
+++ b/mpas_analysis/test/test_generalized_reader.py
@@ -15,6 +15,7 @@ Xylar Asay-Davis
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
+import numpy
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.generalized_reader.generalized_reader \
@@ -71,7 +72,8 @@ class TestGeneralizedReader(TestCase):
                 variableMap=variableMap)
 
             # make sure the remapping happened as expected
-            self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
+            dsVarList = list(ds.data_vars.keys()) + list(ds.coords.keys())
+            assert(numpy.all([var in dsVarList for var in variableList]))
 
     def test_open_dataset_fn(self):
         fileName = str(self.datadir.join('example_jan.nc'))
@@ -87,7 +89,8 @@ class TestGeneralizedReader(TestCase):
                 config=config,
                 timeVariableName=timestr,
                 variableList=variableList)
-            self.assertEqual(list(ds.data_vars.keys()), variableList)
+            dsVarList = list(ds.data_vars.keys()) + list(ds.coords.keys())
+            assert(numpy.all([var in dsVarList for var in variableList]))
 
     def test_start_end(self):
         fileName = str(self.datadir.join('example_jan_feb.nc'))

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -15,6 +15,8 @@ Xylar Asay-Davis, Phillip J. Wolfram
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
+import numpy
+
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir
 from mpas_analysis.shared.mpas_xarray import mpas_xarray
@@ -38,7 +40,8 @@ class TestMpasXarray(TestCase):
                                                 calendar=calendar,
                                                 timeVariableName=timestr)
         ds = mpas_xarray.subset_variables(ds, variableList)
-        self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
+        dsVarList = list(ds.data_vars.keys()) + list(ds.coords.keys())
+        assert(numpy.all([var in dsVarList for var in variableList]))
         self.assertEqual(days_to_datetime(days=ds.Time.values,
                                           referenceDate='0001-01-01',
                                           calendar=calendar),
@@ -76,7 +79,8 @@ class TestMpasXarray(TestCase):
             variableList=variableList,
             iselValues=iselvals)
 
-        self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
+        dsVarList = list(ds.data_vars.keys()) + list(ds.coords.keys())
+        assert(numpy.all([var in dsVarList for var in variableList]))
         self.assertEqual(ds[variableList[0]].shape, (1, 7, 3))
         self.assertEqual(ds['refBottomDepth'].shape, (3,))
         self.assertApproxEqual(ds['refBottomDepth'][-1],
@@ -102,7 +106,9 @@ class TestMpasXarray(TestCase):
             simulationStartTime=simulationStartTime,
             timeVariableName=timestr,
             variableList=variableList)
-        self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
+
+        dsVarList = list(ds.data_vars.keys()) + list(ds.coords.keys())
+        assert(numpy.all([var in dsVarList for var in variableList]))
 
         self.assertEqual(days_to_datetime(days=ds.Time.values[0],
                                           referenceDate='0001-01-01',
@@ -157,7 +163,9 @@ class TestMpasXarray(TestCase):
                 variableList=variableList,
                 selValues=selvals)
 
-            self.assertEqual(list(ds.data_vars.keys()), variableList)
+            dsVarList = list(ds.data_vars.keys()) + list(ds.coords.keys())
+            assert(numpy.all([var in dsVarList for var in variableList]))
+
             self.assertEqual(ds[variableList[0]].shape, (1, 7))
             self.assertEqual(ds['refBottomDepth'],
                              dsRef['refBottomDepth'][vertIndex])
@@ -176,7 +184,8 @@ class TestMpasXarray(TestCase):
             timeVariableName=timestr,
             variableList=variableList)
 
-        self.assertEqual(sorted(ds.data_vars.keys()), sorted(variableList))
+        dsVarList = list(ds.data_vars.keys()) + list(ds.coords.keys())
+        assert(numpy.all([var in dsVarList for var in variableList]))
         # There would be 3 time indices if repeat indices had not been removed.
         # Make sure there are 2.
         self.assertEqual(len(ds.Time.values), 2)


### PR DESCRIPTION
This merge converts all variables without the `Time` dimension into coords within mpas_xarray's preprocessor function.  This prevents these variable from being expanded by xarray.open_mfdataset()
to have a Time dimension, which we don't want.

After updating the mpas_xarray unit test to accommodate these changes, it now works as expected with xarray 0.10.3.  It only worked correctly with xarray 0.10.2 and earlier because behavior was inconsistent when opening one file vs. multiple files in `xarray.open_mfdataset()`.