### PR TITLE
Fix the docs

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,1 +1,2 @@
 generated
+*_obs_table.rst

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,7 +21,4 @@ clean:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	python parse_table.py -x ../mpas_analysis/obs/observationstable.xml -r landicobservationstable.rst -c landice
-	python parse_table.py -x ../mpas_analysis/obs/observationstable.xml -r oceanobservationstable.rst -c ocean
-	python parse_table.py -x ../mpas_analysis/obs/observationstable.xml -r seaicobservationstable.rst -c seaice
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 import mpas_analysis
+from docs.parse_table import build_rst_table_from_xml
 
 
 # -- General configuration ------------------------------------------------
@@ -181,3 +182,10 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'xarray': ('http://xarray.pydata.org/en/stable/', None)}
+
+
+# Build some custom rst files
+xmlFileName = '../mpas_analysis/obs/observationstable.xml'
+for component in ['ocean', 'seaice', 'landice']:
+    build_rst_table_from_xml(xmlFileName, '{}_obs_table.rst'.format(component),
+                             component)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -22,5 +22,4 @@ dependencies:
   - sphinx_rtd_theme
   - numpydoc
   - tabulate >= 0.8.2
-  - pip:
-    - recommonmark
+  - recommonmark

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,8 +32,8 @@ MPAS Components and E3SM
    mpasseaice
    e3sm
 
-Observations
-============
+Observational Data Sets
+=======================
 .. toctree::
 
   observations

--- a/docs/observations.rst
+++ b/docs/observations.rst
@@ -1,18 +1,13 @@
-Observations
-============
-
 A variety of observational datasets are used within MPAS-Analysis:
 
-Land Ice metrics
-----------------
-.. include::  landicobservationstable.rst
+Ocean Observations
+------------------
+.. include::  ocean_obs_table.rst
 
-Ocean metrics
--------------
+Sea Ice Observations
+--------------------
+.. include::  seaice_obs_table.rst
 
-.. include::  oceanobservationstable.rst
-
-Sea Ice metrics
----------------
-.. include::  seaicobservationstable.rst
-
+Land Ice Observations
+---------------------
+.. include::  landice_obs_table.rst


### PR DESCRIPTION
To avoid a complicated custom build on ReadTheDocs, the 3 obs. tables are now built in conf.py since the Makefile is not used.

The rst files have been renamed for easier readability.  They have been added to `.gitignore`

This merge also includes some minor renaming and re-arranging in the docs.