### PR TITLE
User-specified tick start and stride for time axes

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -328,10 +328,12 @@ preprocessedFieldPrefix = ohc
 # window)
 movingAveragePoints = 12
 
-# An optional first year for the tick marks on the x axis
+# An optional first year for the tick marks on the x axis. Leare commented out
+# to start at the beginning of the time series.
 # firstYearXTicks = 1
 
-# An optional number of years between tick marks on the x axis
+# An optional number of years between tick marks on the x axis.  Leave
+# commented out to determine the distance between ticks automatically.
 # yearStrideXTicks = 1
 
 [hovmollerOHCAnomaly]
@@ -350,10 +352,13 @@ colorbarLevels = [-2.4, -0.8, -0.4, -0.2, 0, 0.2, 0.4, 0.8, 2.4]
 # contour line levels
 contourLevels = np.arange(-2.5, 2.6, 0.5)
 
-# An optional first year for the tick marks on the x axis
+# An optional first year for the tick marks on the x axis. Leare commented out
+# to start at the beginning of the time series.
+
 # firstYearXTicks = 1
 
-# An optional number of years between tick marks on the x axis
+# An optional number of years between tick marks on the x axis.  Leave
+# commented out to determine the distance between ticks automatically.
 # yearStrideXTicks = 1
 
 [hovmollerTemperatureAnomaly]
@@ -376,10 +381,14 @@ colorbarLevels = [-1, -0.5, -0.2, -0.05, 0, 0.05, 0.2, 0.5, 1]
 # contour line levels
 contourLevels = np.arange(-1.0, 1.26, 0.25)
 
-# An optional first year for the tick marks on the x axis
+# An optional first year for the tick marks on the x axis. Leare commented out
+# to start at the beginning of the time series.
+
 # firstYearXTicks = 1
 
-# An optional number of years between tick marks on the x axis
+# An optional number of years between tick marks on the x axis.  Leave
+# commented out to determine the distance between ticks automatically.
+
 # yearStrideXTicks = 1
 
 [hovmollerSalinityAnomaly]
@@ -402,10 +411,14 @@ colorbarLevels = [-0.1, -0.02, -0.003, -0.001, 0, 0.001, 0.003, 0.02, 0.1]
 # contour line levels
 contourLevels = np.arange(-0.1, 0.11, 0.02)
 
-# An optional first year for the tick marks on the x axis
+# An optional first year for the tick marks on the x axis. Leare commented out
+# to start at the beginning of the time series.
+
 # firstYearXTicks = 1
 
-# An optional number of years between tick marks on the x axis
+# An optional number of years between tick marks on the x axis.  Leave
+# commented out to determine the distance between ticks automatically.
+
 # yearStrideXTicks = 1
 
 [timeSeriesSST]
@@ -420,10 +433,14 @@ regions = ['global']
 # window)
 movingAveragePoints = 12
 
-# An optional first year for the tick marks on the x axis
+# An optional first year for the tick marks on the x axis. Leare commented out
+# to start at the beginning of the time series.
+
 # firstYearXTicks = 1
 
-# An optional number of years between tick marks on the x axis
+# An optional number of years between tick marks on the x axis.  Leave
+# commented out to determine the distance between ticks automatically.
+
 # yearStrideXTicks = 1
 
 [indexNino34]
@@ -534,10 +551,14 @@ movingAveragePoints = 12
 # latitude) for climatological MOC plots
 movingAveragePointsClimatological = 1
 
-# An optional first year for the tick marks on the x axis
+# An optional first year for the tick marks on the x axis. Leare commented out
+# to start at the beginning of the time series.
+
 # firstYearXTicks = 1
 
-# An optional number of years between tick marks on the x axis
+# An optional number of years between tick marks on the x axis.  Leave
+# commented out to determine the distance between ticks automatically.
+
 # yearStrideXTicks = 1
 
 [timeSeriesSeaIceAreaVol]
@@ -554,10 +575,14 @@ titleFontSize = 18
 # plot on polar plot
 polarPlot = False
 
-# An optional first year for the tick marks on the x axis
+# An optional first year for the tick marks on the x axis. Leare commented out
+# to start at the beginning of the time series.
+
 # firstYearXTicks = 1
 
-# An optional number of years between tick marks on the x axis
+# An optional number of years between tick marks on the x axis.  Leave
+# commented out to determine the distance between ticks automatically.
+
 # yearStrideXTicks = 1
 
 [climatologyMapSST]
@@ -715,10 +740,14 @@ iceShelvesToPlot = ['Antarctica']
 # Number of months over which to compute moving average
 movingAverageMonths = 1
 
-# An optional first year for the tick marks on the x axis
+# An optional first year for the tick marks on the x axis. Leare commented out
+# to start at the beginning of the time series.
+
 # firstYearXTicks = 1
 
-# An optional number of years between tick marks on the x axis
+# An optional number of years between tick marks on the x axis.  Leave
+# commented out to determine the distance between ticks automatically.
+
 # yearStrideXTicks = 1
 
 [climatologyMapSoseTemperature]

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -328,6 +328,12 @@ preprocessedFieldPrefix = ohc
 # window)
 movingAveragePoints = 12
 
+# An optional first year for the tick marks on the x axis
+# firstYearXTicks = 1
+
+# An optional number of years between tick marks on the x axis
+# yearStrideXTicks = 1
+
 [hovmollerOHCAnomaly]
 ## options related to time vs. depth Hovmoller plots of ocean heat content
 ## (OHC) anomalies from year 1
@@ -343,6 +349,12 @@ colormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 colorbarLevels = [-2.4, -0.8, -0.4, -0.2, 0, 0.2, 0.4, 0.8, 2.4]
 # contour line levels
 contourLevels = np.arange(-2.5, 2.6, 0.5)
+
+# An optional first year for the tick marks on the x axis
+# firstYearXTicks = 1
+
+# An optional number of years between tick marks on the x axis
+# yearStrideXTicks = 1
 
 [hovmollerTemperatureAnomaly]
 ## options related to plotting time series of temperature vs. depth
@@ -364,6 +376,12 @@ colorbarLevels = [-1, -0.5, -0.2, -0.05, 0, 0.05, 0.2, 0.5, 1]
 # contour line levels
 contourLevels = np.arange(-1.0, 1.26, 0.25)
 
+# An optional first year for the tick marks on the x axis
+# firstYearXTicks = 1
+
+# An optional number of years between tick marks on the x axis
+# yearStrideXTicks = 1
+
 [hovmollerSalinityAnomaly]
 ## options related to plotting time series of salinity vs. depth
 
@@ -384,6 +402,12 @@ colorbarLevels = [-0.1, -0.02, -0.003, -0.001, 0, 0.001, 0.003, 0.02, 0.1]
 # contour line levels
 contourLevels = np.arange(-0.1, 0.11, 0.02)
 
+# An optional first year for the tick marks on the x axis
+# firstYearXTicks = 1
+
+# An optional number of years between tick marks on the x axis
+# yearStrideXTicks = 1
+
 [timeSeriesSST]
 ## options related to plotting time series of sea surface temperature (SST)
 
@@ -395,6 +419,12 @@ regions = ['global']
 # output, movingAveragePoints=12 corresponds to a 12-month moving average
 # window)
 movingAveragePoints = 12
+
+# An optional first year for the tick marks on the x axis
+# firstYearXTicks = 1
+
+# An optional number of years between tick marks on the x axis
+# yearStrideXTicks = 1
 
 [indexNino34]
 ## options related to plotting time series of the El Nino 3.4 index
@@ -504,6 +534,12 @@ movingAveragePoints = 12
 # latitude) for climatological MOC plots
 movingAveragePointsClimatological = 1
 
+# An optional first year for the tick marks on the x axis
+# firstYearXTicks = 1
+
+# An optional number of years between tick marks on the x axis
+# yearStrideXTicks = 1
+
 [timeSeriesSeaIceAreaVol]
 ## options related to plotting time series of sea ice area and volume
 
@@ -517,6 +553,12 @@ movingAveragePoints = 1
 titleFontSize = 18
 # plot on polar plot
 polarPlot = False
+
+# An optional first year for the tick marks on the x axis
+# firstYearXTicks = 1
+
+# An optional number of years between tick marks on the x axis
+# yearStrideXTicks = 1
 
 [climatologyMapSST]
 ## options related to plotting horizontally remapped climatologies of
@@ -672,6 +714,12 @@ iceShelvesToPlot = ['Antarctica']
 
 # Number of months over which to compute moving average
 movingAverageMonths = 1
+
+# An optional first year for the tick marks on the x axis
+# firstYearXTicks = 1
+
+# An optional number of years between tick marks on the x axis
+# yearStrideXTicks = 1
 
 [climatologyMapSoseTemperature]
 ## options related to plotting climatology maps of Antarctic

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -635,7 +635,7 @@ class IndexNino34(AnalysisTask):  # {{{
             minDays = time.min()
             maxDays = time.max()
 
-            plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)
+            plot_xtick_format(calendar, minDays, maxDays, maxXTicks)
 
         plt.tight_layout(rect=[0, 0.03, 1, 0.90])
 

--- a/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
+++ b/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
@@ -437,11 +437,25 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                 maxPoints.append(points[rangeIndex])
                 legendText.append(None)
 
+        if config.has_option(self.taskName, 'firstYearXTicks'):
+            firstYearXTicks = config.getint(self.taskName,
+                                            'firstYearXTicks')
+        else:
+            firstYearXTicks = None
+
+        if config.has_option(self.taskName, 'yearStrideXTicks'):
+            yearStrideXTicks = config.getint(self.taskName,
+                                             'yearStrideXTicks')
+        else:
+            yearStrideXTicks = None
+
         timeseries_analysis_plot(config=config, dsvalues=timeSeries, N=None,
                                  title=title, xlabel=xLabel, ylabel=yLabel,
                                  fileout=figureName, lineStyles=lineStyles,
                                  lineWidths=lineWidths, maxPoints=maxPoints,
-                                 legendText=legendText, calendar=calendar)
+                                 legendText=legendText, calendar=calendar,
+                                 firstYearXTicks=firstYearXTicks,
+                                 yearStrideXTicks=yearStrideXTicks)
 
         write_image_xml(
             config=config,

--- a/mpas_analysis/ocean/plot_hovmoller_subtask.py
+++ b/mpas_analysis/ocean/plot_hovmoller_subtask.py
@@ -264,11 +264,25 @@ class PlotHovmollerSubtask(AnalysisTask):
 
         figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefix)
 
+        if config.has_option(self.sectionName, 'firstYearXTicks'):
+            firstYearXTicks = config.getint(self.sectionName,
+                                            'firstYearXTicks')
+        else:
+            firstYearXTicks = None
+
+        if config.has_option(self.sectionName, 'yearStrideXTicks'):
+            yearStrideXTicks = config.getint(self.sectionName,
+                                            'yearStrideXTicks')
+        else:
+            yearStrideXTicks = None
+
         plot_vertical_section(config, Time, depth, field, self.sectionName,
                               suffix='', colorbarLabel=self.unitsLabel,
                               title=title, xlabel=xLabel, ylabel=yLabel,
                               fileout=figureName, linewidths=1,
-                              xArrayIsTime=True, calendar=self.calendar)
+                              xArrayIsTime=True, calendar=self.calendar,
+                              firstYearXTicks=firstYearXTicks,
+                              yearStrideXTicks=yearStrideXTicks)
 
         write_image_xml(
             config=config,

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -68,7 +68,6 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
         # -------
         # Xylar Asay-Davis
 
-# 
         # first, call the constructor from the base class (AnalysisTask)
         super(StreamfunctionMOC, self).__init__(
             config=config,
@@ -242,11 +241,25 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
 
         figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
+        if config.has_option(self.taskName, 'firstYearXTicks'):
+            firstYearXTicks = config.getint(self.taskName,
+                                            'firstYearXTicks')
+        else:
+            firstYearXTicks = None
+
+        if config.has_option(self.taskName, 'yearStrideXTicks'):
+            yearStrideXTicks = config.getint(self.taskName,
+                                             'yearStrideXTicks')
+        else:
+            yearStrideXTicks = None
+
         timeseries_analysis_plot(config, [dsMOCTimeSeries.mocAtlantic26],
                                  movingAveragePoints, title,
                                  xLabel, yLabel, figureName,
                                  lineStyles=['k-'], lineWidths=[2],
-                                 legendText=[None], calendar=self.calendar)
+                                 legendText=[None], calendar=self.calendar,
+                                 firstYearXTicks=firstYearXTicks,
+                                 yearStrideXTicks=yearStrideXTicks)
 
         caption = u'Time Series of maximum Meridional Overturning ' \
                   u'Circulation at 26.5°N'

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -340,6 +340,18 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                 lineWidths.append(1.2)
                 legendText.append(refRunName)
 
+            if config.has_option(self.taskName, 'firstYearXTicks'):
+                firstYearXTicks = config.getint(self.taskName,
+                                                'firstYearXTicks')
+            else:
+                firstYearXTicks = None
+
+            if config.has_option(self.taskName, 'yearStrideXTicks'):
+                yearStrideXTicks = config.getint(self.taskName,
+                                                 'yearStrideXTicks')
+            else:
+                yearStrideXTicks = None
+
             timeseries_analysis_plot(config, fields, movingAverageMonths,
                                      title, xLabel, yLabel, figureName,
                                      lineStyles=lineStyles,
@@ -347,7 +359,9 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
                                      legendText=legendText,
                                      calendar=calendar, obsMean=obsMeltRate,
                                      obsUncertainty=obsMeltRateUnc,
-                                     obsLegend=list(obsDict.keys()))
+                                     obsLegend=list(obsDict.keys()),
+                                     firstYearXTicks=firstYearXTicks,
+                                     yearStrideXTicks=yearStrideXTicks)
 
             caption = 'Running Mean of Area-averaged Melt Rate under Ice ' \
                       'Shelves in the {} Region'.format(title)

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -252,11 +252,25 @@ class TimeSeriesSST(AnalysisTask):
                 lineWidths.append(1.5)
                 legendText.append(preprocessedReferenceRunName)
 
+            if config.has_option(self.taskName, 'firstYearXTicks'):
+                firstYearXTicks = config.getint(self.taskName,
+                                                'firstYearXTicks')
+            else:
+                firstYearXTicks = None
+
+            if config.has_option(self.taskName, 'yearStrideXTicks'):
+                yearStrideXTicks = config.getint(self.taskName,
+                                                 'yearStrideXTicks')
+            else:
+                yearStrideXTicks = None
+
             timeseries_analysis_plot(config, fields, movingAveragePoints,
                                      title, xLabel, yLabel, figureName,
                                      lineStyles=lineStyles,
                                      lineWidths=lineWidths,
-                                     legendText=legendText, calendar=calendar)
+                                     legendText=legendText, calendar=calendar,
+                                     firstYearXTicks=firstYearXTicks,
+                                     yearStrideXTicks=yearStrideXTicks)
 
             caption = 'Running Mean of {} Sea Surface Temperature'.format(
                     region)

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -418,6 +418,18 @@ class TimeSeriesSeaIce(AnalysisTask):
                     lineStyles.append('g-')
                     lineWidths.append(1.2)
 
+                if config.has_option(self.taskName, 'firstYearXTicks'):
+                    firstYearXTicks = config.getint(self.taskName,
+                                                    'firstYearXTicks')
+                else:
+                    firstYearXTicks = None
+
+                if config.has_option(self.taskName, 'yearStrideXTicks'):
+                    yearStrideXTicks = config.getint(self.taskName,
+                                                     'yearStrideXTicks')
+                else:
+                    yearStrideXTicks = None
+
                 # separate plots for nothern and southern hemispheres
                 timeseries_analysis_plot(config, dsvalues,
                                          movingAveragePoints,
@@ -428,7 +440,10 @@ class TimeSeriesSeaIce(AnalysisTask):
                                          lineWidths=lineWidths,
                                          legendText=legendText,
                                          titleFontSize=titleFontSize,
-                                         calendar=calendar)
+                                         calendar=calendar,
+                                         firstYearXTicks=firstYearXTicks,
+                                         yearStrideXTicks=yearStrideXTicks)
+
                 filePrefix = '{}{}_{}'.format(variableName,
                                               hemisphere,
                                               mainRunName)

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -1214,8 +1214,8 @@ def plot_xtick_format(calendar, minDays, maxDays, maxXTicks, yearStride=None):
         the maximum number of tick marks to display, used to sub-sample ticks
         if there are too many
 
-    stride : int, optionoal
-        the number of months or years to skip over between ticks
+    yearStride : int, optional
+        the number of years to skip over between ticks
     '''
     # Authors
     # -------
@@ -1229,6 +1229,8 @@ def plot_xtick_format(calendar, minDays, maxDays, maxXTicks, yearStride=None):
     if yearStride is not None or end.year - start.year > maxXTicks/2:
         if yearStride is None:
             yearStride = 1
+        else:
+            maxXTicks = None
         major = [date_to_days(year=year, calendar=calendar)
                  for year in np.arange(start.year, end.year+1, yearStride)]
         formatterFun = partial(_date_tick, calendar=calendar,

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -41,7 +41,8 @@ from six.moves import configparser
 def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                              fileout, lineStyles, lineWidths, legendText,
                              calendar, maxPoints=None, titleFontSize=None,
-                             figsize=(15, 6), dpi=None, maxXTicks=20,
+                             figsize=(15, 6), dpi=None, firstYearXTicks=None,
+                             yearStrideXTicks=None, maxXTicks=20,
                              obsMean=None, obsUncertainty=None,
                              obsLegend=None, legendLocation='lower left'):
 
@@ -91,6 +92,14 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
     dpi : int, optional
         the number of dots per inch of the figure, taken from section ``plot``
         option ``dpi`` in the config file by default
+
+    firstYearXTicks : int, optional
+        The year of the first tick on the x axis.  By default, the first time
+        entry is the first tick.
+
+    yearStrideXTicks : int, optional
+        The number of years between x ticks. By default, the stride is chosen
+        automatically to have ``maxXTicks`` tick marks or fewer.
 
     maxXTicks : int, optional
         the maximum number of tick marks that will be allowed along the x axis.
@@ -171,7 +180,11 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                   'color': config.get('plot', 'titleFontColor'),
                   'weight': config.get('plot', 'titleFontWeight')}
 
-    plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)
+    if firstYearXTicks is not None:
+        minDays = date_to_days(year=firstYearXTicks, calendar=calendar)
+
+    plot_xtick_format(calendar, minDays, maxDays, maxXTicks,
+                      yearStride=yearStrideXTicks)
 
     # Add a y=0 line if y ranges between positive and negative values
     yaxLimits = ax.get_ylim()
@@ -915,6 +928,8 @@ def plot_vertical_section(
         invertYAxis=True,
         xArrayIsTime=False,
         N=None,
+        firstYearXTicks=None,
+        yearStrideXTicks=None,
         maxXTicks=20,
         calendar='gregorian'):  # {{{
 
@@ -985,6 +1000,14 @@ def plot_vertical_section(
         average calculation is based on number of points, not actual x axis
         values, so for best results, the values in the xArray should be equally
         spaced.
+
+    firstYearXTicks : int, optional
+        The year of the first tick on the x axis.  By default, the first time
+        entry is the first tick.
+
+    yearStrideXTicks : int, optional
+        The number of years between x ticks. By default, the stride is chosen
+        automatically to have ``maxXTicks`` tick marks or fewer.
 
     maxXTicks : int, optional
         the maximum number of tick marks that will be allowed along the x axis.
@@ -1069,9 +1092,14 @@ def plot_vertical_section(
         plt.ylim(yLim)
 
     if xArrayIsTime:
-        minDays = [xArray[0]]
+        if firstYearXTicks is None:
+            minDays = [xArray[0]]
+        else:
+            minDays = date_to_days(year=firstYearXTicks, calendar=calendar)
         maxDays = [xArray[-1]]
-        plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks)
+
+        plot_xtick_format(calendar, minDays, maxDays, maxXTicks,
+                          yearStride=yearStrideXTicks)
 
     if (fileout is not None):
         plt.savefig(fileout, dpi=dpi, bbox_inches='tight', pad_inches=0.1)
@@ -1166,20 +1194,28 @@ def setup_colormap(config, configSectionName, suffix=''):
             'lineColor': lineColor}
 
 
-def plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks):
+def plot_xtick_format(calendar, minDays, maxDays, maxXTicks, yearStride=None):
     '''
     Formats tick labels and positions along the x-axis for time series
     / index plots
 
     Parameters
     ----------
-    plt : plt handle on which to change ticks
+    calendar : str
+        the calendar to use for formatting the time axis
 
-    calendar : specified calendar for the plot
+    minDays : float
+        start time for labels
 
-    minDays : start time for labels
+    maxDays : float
+        end time for labels
 
-    maxDays : end time for labels
+    maxXTicks : int
+        the maximum number of tick marks to display, used to sub-sample ticks
+        if there are too many
+
+    stride : int, optionoal
+        the number of months or years to skip over between ticks
     '''
     # Authors
     # -------
@@ -1190,9 +1226,11 @@ def plot_xtick_format(plt, calendar, minDays, maxDays, maxXTicks):
     start = days_to_datetime(np.amin(minDays), calendar=calendar)
     end = days_to_datetime(np.amax(maxDays), calendar=calendar)
 
-    if (end.year - start.year > maxXTicks/2):
+    if yearStride is not None or end.year - start.year > maxXTicks/2:
+        if yearStride is None:
+            yearStride = 1
         major = [date_to_days(year=year, calendar=calendar)
-                 for year in np.arange(start.year, end.year+1)]
+                 for year in np.arange(start.year, end.year+1, yearStride)]
         formatterFun = partial(_date_tick, calendar=calendar,
                                includeMonth=False)
     else:


### PR DESCRIPTION
A config file can now be used to specify `firstYearXTicks` and
`yearStrideXTicks` to control how ticks are set for a time axis, e.g.:

```
[hovmollerOHCAnomaly]
firstYearXTicks = 2
yearStrideXTicks = 2

[hovmollerTemperatureAnomaly]
firstYearXTicks = 2
yearStrideXTicks = 2

[hovmollerSalinityAnomaly]
firstYearXTicks = 2
yearStrideXTicks = 2

[timeSeriesSeaIceAreaVol]
firstYearXTicks = 2
yearStrideXTicks = 2

[timeSeriesSST]
firstYearXTicks = 2
yearStrideXTicks = 2

[streamfunctionMOC]
firstYearXTicks = 2
yearStrideXTicks = 2
```