### PR TITLE
Add climatology maps for OHC anomalies

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -723,11 +723,16 @@ colorbarLevelsDifference = numpy.linspace(-2., 2., 11)
 
 # Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['JFM', 'JAS', 'ANN']
+seasons =  ['ANN']
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
 comparisonGrids = ['latlon']
 
+# Minimum and maximum depths (positive up, in meters) to include in the
+# vertical sum.  The default values are intended to cover the full depth of the
+# ocean.
+minDepth = 0.0
+maxDepth = -7000.0
 
 [climatologyMapAntarcticMelt]
 ## options related to plotting horizontally regridded maps of Antarctic

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -150,6 +150,11 @@ generate = ['all']
 ## options related to producing climatologies, typically to compare against
 ## observations and previous runs
 
+# the year from which to compute anomalies if not the start year of the
+# simulation.  This might be useful if a long spin-up cycle is performed and
+# only the anomaly over a later span of years is of interest.
+# anomalyRefYear = 249
+
 # the first year over which to average climatalogies
 startYear = 11
 # the last year over which to average climatalogies
@@ -688,6 +693,33 @@ colormapNameDifference = RdBu_r
 colormapIndicesDifference = [0, 23, 46, 70, 93, 116, 128, 128, 139, 162, 185, 209, 232, 255]
 # colormap levels/values for contour boundaries
 colorbarLevelsDifference = [-100., -80., -60., -40., -20., -10., 0., 10., 20.,  40.,  60.,  80.,  100.]
+
+# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['JFM', 'JAS', 'ANN']
+
+# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+comparisonGrids = ['latlon']
+
+[climatologyMapOHCAnomaly]
+## options related to plotting horizontally remapped climatologies of
+## ocean heat content (OHC) against reference model results (if available)
+
+# colormap for model/observations
+colormapNameResult = BuOr
+# color indices into colormapName for filled contours
+colormapIndicesResult = numpy.array(numpy.linspace(0, 255, 38), int)
+# colormap levels/values for contour boundaries
+colorbarLevelsResult = numpy.linspace(-12., 12., 37)
+# colormap levels/values for ticks (defaults to same as levels)
+colorbarTicksResult = numpy.linspace(-12., 12., 9)
+
+# colormap for differences
+colormapNameDifference = RdBu_r
+# color indices into colormapName for filled contours
+colormapIndicesDifference = numpy.array(numpy.linspace(0, 255, 10), int)
+# colormap levels/values for contour boundaries
+colorbarLevelsDifference = numpy.linspace(-2., 2., 11)
 
 # Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -728,11 +728,12 @@ seasons =  ['ANN']
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
 comparisonGrids = ['latlon']
 
-# Minimum and maximum depths (positive up, in meters) to include in the
-# vertical sum.  The default values are intended to cover the full depth of the
-# ocean.
-minDepth = 0.0
-maxDepth = -7000.0
+# A list of pairs of minimum and maximum depths (positive up, in meters) to
+# include in the vertical sums.  The default values are the equivalents of the
+# default ranges of the timeSeriesOHCAnomaly task, with a value of -10,000 m
+# intended to be well below the bottom of the ocean for all existing MPAS-O
+# meshes.
+depthRanges = [(0.0, -10000.0), (0.0, -700.0), (-700.0, -2000.0), (-2000.0, -10000.0)]
 
 [climatologyMapAntarcticMelt]
 ## options related to plotting horizontally regridded maps of Antarctic

--- a/mpas_analysis/ocean/__init__.py
+++ b/mpas_analysis/ocean/__init__.py
@@ -2,6 +2,8 @@ from mpas_analysis.ocean.climatology_map_sst import ClimatologyMapSST
 from mpas_analysis.ocean.climatology_map_mld import ClimatologyMapMLD
 from mpas_analysis.ocean.climatology_map_sss import ClimatologyMapSSS
 from mpas_analysis.ocean.climatology_map_ssh import ClimatologyMapSSH
+from mpas_analysis.ocean.climatology_map_ohc_anomaly import \
+    ClimatologyMapOHCAnomaly
 from mpas_analysis.ocean.climatology_map_antarctic_melt import \
     ClimatologyMapAntarcticMelt
 from mpas_analysis.ocean.climatology_map_sose import \

--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -214,7 +214,7 @@ class RemapMpasAntarcticMeltClimatology(RemapMpasClimatologySubtask):  # {{{
 
         # }}}
 
-    def customize_masked_climatology(self, climatology):  # {{{
+    def customize_masked_climatology(self, climatology, season):  # {{{
         """
         Mask the melt rates using ``landIceMask`` and rescale it to m/yr
 
@@ -222,6 +222,9 @@ class RemapMpasAntarcticMeltClimatology(RemapMpasClimatologySubtask):  # {{{
         ----------
         climatology : ``xarray.Dataset`` object
             the climatology data set
+
+        season : str
+            The name of the season to be masked
 
         Returns
         -------

--- a/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
+++ b/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
@@ -1,0 +1,303 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+import xarray
+import numpy
+
+from mpas_analysis.shared import AnalysisTask
+
+from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask
+
+from mpas_analysis.ocean.plot_climatology_map_subtask import \
+    PlotClimatologyMapSubtask
+
+
+class ClimatologyMapOHCAnomaly(AnalysisTask):  # {{{
+    """
+    An analysis task for comparison of the anomaly from a reference year
+    (typically the start of the simulation) of ocean heat content (OHC)
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    def __init__(self, config, mpasClimatologyTask, refYearClimatolgyTask,
+                 refConfig=None):  # {{{
+        """
+        Construct the analysis task.
+
+        Parameters
+        ----------
+        config :  ``MpasAnalysisConfigParser``
+            Configuration options
+
+        mpasClimatologyTask : ``MpasClimatologyTask``
+            The task that produced the climatology to be remapped and plotted
+
+        refYearClimatolgyTask : ``RefYearMpasClimatologyTask``
+            The task that produced the climatology from the first year to be
+            remapped and then subtracted from the main climatology
+
+        refConfig :  ``MpasAnalysisConfigParser``, optional
+            Configuration options for a reference run (if any)
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        fieldName = 'deltaOHC'
+        # call the constructor from the base class (AnalysisTask)
+        super(ClimatologyMapOHCAnomaly, self).__init__(
+                config=config, taskName='climatologyMapOHCAnomaly',
+                componentName='ocean',
+                tags=['climatology', 'horizontalMap', fieldName])
+
+        sectionName = self.taskName
+
+        mpasFieldName = 'deltaOHC'
+
+        # read in what seasons we want to plot
+        seasons = config.getExpression(sectionName, 'seasons')
+
+        if len(seasons) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of seasons'.format(sectionName))
+
+        comparisonGridNames = config.getExpression(sectionName,
+                                                   'comparisonGrids')
+
+        if len(comparisonGridNames) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of comparison grids'.format(sectionName))
+
+        variableList = ['timeMonthly_avg_activeTracers_temperature',
+                        'timeMonthly_avg_layerThickness']
+
+        # the variable 'timeMonthly_avg_landIceFreshwaterFlux' will be added to
+        # mpasClimatologyTask along with the seasons.
+        remapClimatologySubtask = RemapMpasOHCClimatology(
+            mpasClimatologyTask=mpasClimatologyTask,
+            refYearClimatolgyTask=refYearClimatolgyTask,
+            parentTask=self,
+            climatologyName=fieldName,
+            variableList=variableList,
+            comparisonGridNames=comparisonGridNames,
+            seasons=seasons)
+
+        self.add_subtask(remapClimatologySubtask)
+
+        outFileLabel = 'deltaOHC'
+        remapObservationsSubtask = None
+        if refConfig is None:
+            refTitleLabel = None
+            refFieldName = None
+            diffTitleLabel = 'Model - Observations'
+
+        else:
+            refRunName = refConfig.get('runs', 'mainRunName')
+            refTitleLabel = 'Ref: {}'.format(refRunName)
+            refFieldName = mpasFieldName
+            diffTitleLabel = 'Main - Reference'
+
+        for comparisonGridName in comparisonGridNames:
+            for season in seasons:
+                # make a new subtask for this season and comparison grid
+                subtask = PlotClimatologyMapSubtask(self, season,
+                                                    comparisonGridName,
+                                                    remapClimatologySubtask,
+                                                    remapObservationsSubtask,
+                                                    refConfig)
+
+                subtask.set_plot_info(
+                        outFileLabel=outFileLabel,
+                        fieldNameInTitle='OHC Anomaly',
+                        mpasFieldName=mpasFieldName,
+                        refFieldName=refFieldName,
+                        refTitleLabel=refTitleLabel,
+                        diffTitleLabel=diffTitleLabel,
+                        unitsLabel=r'GJ m$^{-2}$',
+                        imageCaption='Anomaly in Ocean Heat Content',
+                        galleryGroup='OHC Anomaly',
+                        groupSubtitle=None,
+                        groupLink='ohc_anom',
+                        galleryName=None)
+
+                self.add_subtask(subtask)
+        # }}}
+    # }}}
+
+
+class RemapMpasOHCClimatology(RemapMpasClimatologySubtask):  # {{{
+    """
+    A subtask for computing climatologies of ocean heat content from
+    climatologies of temperature
+
+    Attributes
+    ----------
+    landIceMask : xarray.DataArray
+        A mask indicating where there is land ice on the ocean grid (thus,
+        where melt rates are valid)
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    def __init__(self, mpasClimatologyTask, refYearClimatolgyTask, parentTask,
+                 climatologyName, variableList, seasons, comparisonGridNames):
+        # {{{
+        '''
+        Construct the analysis task and adds it as a subtask of the
+        ``parentTask``.
+
+        Parameters
+        ----------
+        mpasClimatologyTask : ``MpasClimatologyTask``
+            The task that produced the climatology to be remapped
+
+        refYearClimatolgyTask : ``RefYearMpasClimatologyTask``
+            The task that produced the climatology from the first year to be
+            remapped and then subtracted from the main climatology
+
+        parentTask :  ``AnalysisTask``
+            The parent task, used to get the ``taskName``, ``config`` and
+            ``componentName``
+
+        climatologyName : str
+            A name that describes the climatology (e.g. a short version of
+            the important field(s) in the climatology) used to name the
+            subdirectories for each stage of the climatology
+
+        variableList : list of str
+            A list of variable names in ``timeSeriesStatsMonthly`` to be
+            included in the climatologies
+
+        seasons : list of str, optional
+            A list of seasons (keys in ``shared.constants.monthDictionary``)
+            to be computed or ['none'] (not ``None``) if only monthly
+            climatologies are needed.
+
+        comparisonGridNames : list of {'latlon', 'antarctic'}
+            The name(s) of the comparison grid to use for remapping.
+
+        '''
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        # call the constructor from the base class
+        # (RemapMpasClimatologySubtask)
+        super(RemapMpasOHCClimatology, self).__init__(
+                 mpasClimatologyTask, parentTask, climatologyName,
+                 variableList, seasons, comparisonGridNames)
+
+        self.refYearClimatolgyTask = refYearClimatolgyTask
+        self.run_after(refYearClimatolgyTask)
+        # }}}
+
+    def setup_and_check(self):  # {{{
+        '''
+        Perform steps to set up the analysis and check for errors in the setup.
+
+        Raises
+        ------
+        IOError :
+            If a restart file is not available from which to read mesh
+            information or if no history files are available from which to
+            compute the climatology in the desired time range.
+        '''
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        # first, call setup_and_check from the base class
+        # (RemapMpasClimatologySubtask), which will set up remappers and add
+        # variables to mpasClimatologyTask
+        super(RemapMpasOHCClimatology, self).setup_and_check()
+
+        # don't add the variables and seasons to mpasClimatologyTask until
+        # we're sure this subtask is supposed to run
+        self.refYearClimatolgyTask.add_variables(self.variableList,
+                                                 self.seasons)
+
+        # }}}
+
+    def customize_masked_climatology(self, climatology, season):  # {{{
+        """
+        Mask the melt rates using ``landIceMask`` and rescale it to m/yr
+
+        Parameters
+        ----------
+        climatology : ``xarray.Dataset`` object
+            the climatology data set
+
+        season : str
+            The name of the season to be masked
+
+        Returns
+        -------
+        climatology : ``xarray.Dataset`` object
+            the modified climatology data set
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        ohc = self._compute_ohc(climatology)
+        refFileName = self.refYearClimatolgyTask.get_file_name(season)
+        refYearClimo = xarray.open_dataset(refFileName)
+        refYearClimo = refYearClimo.isel(Time=0)
+        refOHC = self._compute_ohc(refYearClimo)
+
+        climatology['deltaOHC'] = ohc - refOHC
+        climatology.deltaOHC.attrs['units'] = 'GJ m$^{-2}$'
+        climatology.deltaOHC.attrs['description'] = \
+            'Anomaly from year {} in Ocean heat contentG in each region'.format(
+                    self.refYearClimatolgyTask.startYear)
+
+        climatology = climatology.drop(self.variableList)
+
+        return climatology  # }}}
+
+    def _compute_ohc(self, climatology):  # {{{
+        """
+        Compute the OHC from the temperature and layer thicknesses in a given
+        climatology data sets.
+        """
+        dsRestart = xarray.open_dataset(self.restartFileName)
+        dsRestart = dsRestart.isel(Time=0)
+
+        # specific heat [J/(kg*degC)]
+        cp = self.namelist.getfloat('config_specific_heat_sea_water')
+        # [kg/m3]
+        rho = self.namelist.getfloat('config_density0')
+
+        unitsScalefactor = 1e-9
+
+        nVertLevels = dsRestart.sizes['nVertLevels']
+
+        vertIndex = xarray.DataArray.from_dict(
+                {'dims': ('nVertLevels',), 'data': numpy.arange(nVertLevels)})
+
+        mask = vertIndex < dsRestart.maxLevelCell
+
+        temperature = \
+            climatology['timeMonthly_avg_activeTracers_temperature'].where(
+                    mask)
+        layerThickness = \
+            climatology['timeMonthly_avg_layerThickness'].where(mask)
+
+        ohc = unitsScalefactor*rho*cp * layerThickness * temperature
+        ohc = ohc.sum(dim='nVertLevels')
+        return ohc  # }}}
+
+    # }}}
+
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/ocean/climatology_map_ssh.py
+++ b/mpas_analysis/ocean/climatology_map_ssh.py
@@ -161,14 +161,18 @@ class RemapSSHClimatology(RemapMpasClimatologySubtask):  # {{{
     # -------
     # Xylar Asay-Davis
 
-    def customize_masked_climatology(self, climatology):  # {{{
+    def customize_masked_climatology(self, climatology, season):  # {{{
         """
         Mask the melt rates using ``landIceMask`` and rescale it to m/yr
 
         Parameters
         ----------
-        climatology : ``xarray.Dataset`` object
-            the climatology data set
+        climatology : ``xarray.Dataset```
+            The MPAS climatology data set that has had a mask added but has
+            not yet been remapped
+
+        season : str
+            The name of the season to be masked
 
         Returns
         -------

--- a/mpas_analysis/ocean/plot_climatology_map_subtask.py
+++ b/mpas_analysis/ocean/plot_climatology_map_subtask.py
@@ -118,8 +118,8 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
 
     def __init__(self, parentTask, season, comparisonGridName,
                  remapMpasClimatologySubtask, remapObsClimatologySubtask=None,
-                 refConfig=None, depth=None, removeMean=False):
-        # {{{
+                 refConfig=None, depth=None, removeMean=False,
+                 subtaskName=None):  # {{{
         '''
         Construct one analysis subtask for each plot (i.e. each season and
         comparison grid) and a subtask for computing climatologies.
@@ -157,6 +157,11 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
             subtracted from both the model and reference results.  This is
             useful for data sets where the desire is to compare the spatial
             pattern but the mean offset is not meaningful (e.g. SSH)
+
+        subtaskName : str, optinal
+            The name of the subtask.  If not specified, it is
+            ``plot<season>_<comparisonGridName>`` with a suffix indicating the
+            depth being sliced (if any)
         '''
         # Authors
         # -------
@@ -169,13 +174,16 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
         self.remapObsClimatologySubtask = remapObsClimatologySubtask
         self.refConfig = refConfig
         self.removeMean = removeMean
-        subtaskName = 'plot{}_{}'.format(season, comparisonGridName)
 
         if depth is None:
             self.depthSuffix = ''
         else:
             self.depthSuffix = 'depth_{}'.format(depth)
-            subtaskName = '{}_{}'.format(subtaskName, self.depthSuffix)
+
+        if subtaskName is None:
+            subtaskName = 'plot{}_{}'.format(season, comparisonGridName)
+            if depth is not None:
+                subtaskName = '{}_{}'.format(subtaskName, self.depthSuffix)
 
         config = parentTask.config
         taskName = parentTask.taskName

--- a/mpas_analysis/ocean/remap_depth_slices_subtask.py
+++ b/mpas_analysis/ocean/remap_depth_slices_subtask.py
@@ -172,7 +172,7 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):  # {{{
         # which will perform the main function of the task
         super(RemapDepthSlicesSubtask, self).run_task()
 
-    def customize_masked_climatology(self, climatology):  # {{{
+    def customize_masked_climatology(self, climatology, season):  # {{{
         """
         Uses ``verticalIndex`` to slice the 3D climatology field at each
         requested depth.  The resulting field has the depth appended to
@@ -182,6 +182,9 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):  # {{{
         ----------
         climatology : ``xarray.Dataset`` object
             the climatology data set
+
+        season : str
+            The name of the season to be masked
 
         Returns
         -------

--- a/mpas_analysis/ocean/utility.py
+++ b/mpas_analysis/ocean/utility.py
@@ -45,8 +45,7 @@ def compute_zmid(bottomDepth, maxLevelCell, layerThickness):  # {{{
     # -------
     # Xylar Asay-Davis
 
-    nVertLevels = \
-        layerThickness.shape[layerThickness.dims.index('nVertLevels')]
+    nVertLevels = layerThickness.sizes['nVertLevels']
 
     vertIndex = \
         xarray.DataArray.from_dict({'dims': ('nVertLevels',),

--- a/mpas_analysis/shared/climatology/__init__.py
+++ b/mpas_analysis/shared/climatology/__init__.py
@@ -8,6 +8,8 @@ from mpas_analysis.shared.climatology.climatology import get_remapper, \
 
 from mpas_analysis.shared.climatology.mpas_climatology_task import \
     MpasClimatologyTask
+from mpas_analysis.shared.climatology.ref_year_mpas_climatology_task import \
+    RefYearMpasClimatologyTask
 from mpas_analysis.shared.climatology.remap_mpas_climatology_subtask import \
     RemapMpasClimatologySubtask
 from mpas_analysis.shared.climatology.remap_observed_climatology_subtask \

--- a/mpas_analysis/shared/climatology/ref_year_mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/ref_year_mpas_climatology_task.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+try:
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
+from mpas_analysis.configuration import MpasAnalysisConfigParser
+
+from mpas_analysis.shared.climatology import MpasClimatologyTask
+from mpas_analysis.shared.timekeeping.utility import get_simulation_start_time
+
+
+class RefYearMpasClimatologyTask(MpasClimatologyTask):  # {{{
+    '''
+    An analysis tasks for computing a reference-year climatology for computing
+    climatology anomalies from the``timeSeriesStatsMonthly`` analysis member.
+
+    Attributes
+    ----------
+
+    anomalyRefYear : int
+        The reference year over which to compute the climatology
+    '''
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    def __init__(self, config, componentName, taskName=None):  # {{{
+        '''
+        Construct the analysis task and adds it as a subtask of the
+        ``parentTask``.
+
+        Parameters
+        ----------
+        config : ``MpasAnalysisConfigParser``
+            Contains configuration options
+
+        componentName : {'ocean', 'seaIce'}
+            The name of the component (same as the folder where the task
+            resides)
+
+        taskName : str, optional
+            the name of the task, defaults to mpasClimatology<ComponentName>
+        '''
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        if taskName is None:
+            suffix = componentName[0].upper() + componentName[1:]
+            taskName = 'refYearMpasClimatology{}'.format(suffix)
+
+        # make a deep copy of the config so we can change the start and end
+        # years and dates without causing trouble for other tasks
+
+        config_string = StringIO()
+        config.write(config_string)
+        # We must reset the buffer to make it ready for reading.
+        config_string.seek(0)
+        new_config = MpasAnalysisConfigParser()
+        new_config.readfp(config_string)
+
+        # call the constructor from the base class (AnalysisTask)
+        super(RefYearMpasClimatologyTask, self).__init__(
+            config=new_config,
+            componentName=componentName,
+            taskName=taskName)
+        # }}}
+
+    def get_start_and_end(self):  # {{{
+        """
+        Get the start and end years and dates for the climatology.  This
+        function is provided to allow a custom method for setting the start
+        and end years of the climatology.
+
+        Returns
+        -------
+        startYear, endYear : int
+           The start and end years of the climatology
+
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        config = self.config
+        if config.has_option('climatolgoy', 'anomalyRefYear'):
+            anomalyRefYear = config.getint('climatolgoy', 'anomalyRefYear')
+        else:
+            # we want the start year of the simulation, which we can't get yet
+            anomalyRefDate = get_simulation_start_time(self.runStreams)
+            anomalyRefYear = int(anomalyRefDate[0:4])
+
+        startYear = anomalyRefYear
+        endYear = anomalyRefYear
+
+        startDate = '{:04d}-01-01_00:00:00'.format(startYear)
+        endDate = '{:04d}-12-31_23:59:59'.format(endYear)
+
+        config.set('climatology', 'startYear', str(startYear))
+        config.set('climatology', 'startDate', startDate)
+        config.set('climatology', 'endYear', str(endYear))
+        config.set('climatology', 'endDate', endDate)
+
+        return startYear, endYear
+
+        # }}}
+    # }}}
+
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -243,7 +243,8 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
                     self._remap(inFileName=maskedClimatologyFileName,
                                 outFileName=remappedFileName,
                                 remapper=self.remappers[comparisonGridName],
-                                comparisonGridName=comparisonGridName)
+                                comparisonGridName=comparisonGridName,
+                                season=season)
         # }}}
 
     def get_masked_file_name(self, season):  # {{{
@@ -302,6 +303,60 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
 
         return fileName  # }}}
 
+    def customize_masked_climatology(self, climatology, season):  # {{{
+        """
+        Override this function to customize the climatology during the masking
+        phase (before remapping)
+
+        Parameters
+        ----------
+        climatology : ``xarray.Dataset```
+            The MPAS climatology data set that has had a mask added but has
+            not yet been remapped
+
+        season : str
+            The name of the season to be masked
+
+        Returns
+        -------
+        climatology : ``xarray.Dataset```
+            The same data set with any custom fields added or modifications
+            made
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        return climatology  # }}}
+
+    def customize_remapped_climatology(self, climatology, comparisonGridNames,
+                                       season):  # {{{
+        """
+        Override this function to customize the climatology after remapping
+
+        Parameters
+        ----------
+        climatology : ``xarray.Dataset```
+            The MPAS climatology data set that has been remapped
+
+        comparisonGridNames : {'latlon', 'antarctic'}
+            The name of the comparison grid to use for remapping.
+
+        season : str
+            The name of the season to be remapped
+
+       Returns
+        -------
+        climatology : ``xarray.Dataset```
+            The same data set with any custom fields added or modifications
+            made
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        return climatology  # }}}
+
     def _setup_remappers(self):  # {{{
         """
         Set up the remappers for remapping from the MPAS to the comparison
@@ -334,50 +389,6 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
                 logger=self.logger)
 
         # }}}
-
-    def customize_masked_climatology(self, climatology):  # {{{
-        """
-        Override this function to customize the climatology during the masking
-        phase (before remapping)
-
-        Parameters
-        ----------
-        climatology : ``xarray.Dataset```
-            The MPAS climatology data set that has had a mask added but has
-            not yet been remapped
-
-        Returns
-        -------
-        climatology : ``xarray.Dataset```
-            The same data set with any custom fields added or modifications
-            made
-        """
-        # Authors
-        # -------
-        # Xylar Asay-Davis
-
-        return climatology  # }}}
-
-    def customize_remapped_climatology(self, climatology):  # {{{
-        """
-        Override this function to customize the climatology after remapping
-
-        Parameters
-        ----------
-        climatology : ``xarray.Dataset```
-            The MPAS climatology data set that has been remapped
-
-        Returns
-        -------
-        climatology : ``xarray.Dataset```
-            The same data set with any custom fields added or modifications
-            made
-        """
-        # Authors
-        # -------
-        # Xylar Asay-Davis
-
-        return climatology  # }}}
 
     def _setup_file_names(self):  # {{{
         """
@@ -495,13 +506,14 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
                         dsMask[variableName] != self._fillValue)
 
             # customize (if this function has been overridden)
-            climatology = self.customize_masked_climatology(climatology)
+            climatology = self.customize_masked_climatology(climatology,
+                                                            season)
 
             write_netcdf(climatology, maskedClimatologyFileName)
         # }}}
 
-    def _remap(self, inFileName, outFileName, remapper, comparisonGridName):
-        # {{{
+    def _remap(self, inFileName, outFileName, remapper, comparisonGridName,
+               season):  # {{{
         """
         Performs remapping either using ``ncremap`` or the native python code,
         depending on the requested setting and the comparison grid
@@ -521,6 +533,9 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
 
         comparisonGridNames : {'latlon', 'antarctic'}
             The name of the comparison grid to use for remapping.
+
+        season : str
+            The name of the season to be remapped
         """
         # Authors
         # -------
@@ -553,10 +568,9 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
 
         # customize (if this function has been overridden)
         remappedClimatology = self.customize_remapped_climatology(
-                remappedClimatology)
+                remappedClimatology, comparisonGridName, season)
 
-        write_netcdf(remappedClimatology, outFileName)
-        # }}}
+        write_netcdf(remappedClimatology, outFileName)  # }}}
 
     # }}}
 

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -486,7 +486,7 @@ def plot_global_comparison(
         diffTitle='Model-Observations',
         cbarlabel='units',
         titleFontSize=None,
-        figsize=(8, 13),
+        figsize=None,
         dpi=None,
         lineWidth=1,
         lineColor='black'):
@@ -578,6 +578,12 @@ def plot_global_comparison(
     # set up figure
     if dpi is None:
         dpi = config.getint('plot', 'dpi')
+    if figsize is None:
+        # set the defaults, depending on if we have 1 or 3 panels
+        if refArray is None:
+            figsize = (8, 5)
+        else:
+            figsize = (8, 13)
     fig = plt.figure(figsize=figsize, dpi=dpi)
     if (title is not None):
         if titleFontSize is None:

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -130,7 +130,8 @@ class TestMpasClimatologyTask(TestCase):
         startDate = '{:04d}-01-01_00:00:00'.format(startYear)
         endDate = '{:04d}-12-31_23:59:59'.format(endYear)
 
-        mpasClimatologyTask._update_climatology_bounds_and_create_symlinks()
+        mpasClimatologyTask._update_climatology_bounds()
+        mpasClimatologyTask._create_symlinks()
 
         assert(mpasClimatologyTask.startYear == startYear)
         assert(mpasClimatologyTask.endYear == endYear)
@@ -149,7 +150,8 @@ class TestMpasClimatologyTask(TestCase):
         config.set('climatology', 'startDate', startDate)
         config.set('climatology', 'endDate', endDate)
 
-        mpasClimatologyTask._update_climatology_bounds_and_create_symlinks()
+        mpasClimatologyTask._update_climatology_bounds()
+        mpasClimatologyTask._create_symlinks()
 
         startYear = 2
         endYear = 2

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -68,7 +68,8 @@ def build_analysis_list(config, refConfig):  # {{{
     # analysis can only be imported after the right MPL renderer is selected
     from mpas_analysis import ocean
     from mpas_analysis import sea_ice
-    from mpas_analysis.shared.climatology import MpasClimatologyTask
+    from mpas_analysis.shared.climatology import MpasClimatologyTask, \
+        RefYearMpasClimatologyTask
     from mpas_analysis.shared.time_series import MpasTimeSeriesTask
 
     analyses = []
@@ -82,7 +83,11 @@ def build_analysis_list(config, refConfig):  # {{{
                                         componentName='ocean',
                                         section='index')
 
+    oceanRefYearClimatolgyTask = RefYearMpasClimatologyTask(
+            config=config,  componentName='ocean')
+
     analyses.append(oceanClimatolgyTask)
+    analyses.append(oceanRefYearClimatolgyTask)
 
     analyses.append(ocean.ClimatologyMapMLD(config, oceanClimatolgyTask,
                                             refConfig))
@@ -92,6 +97,9 @@ def build_analysis_list(config, refConfig):  # {{{
                                             refConfig))
     analyses.append(ocean.ClimatologyMapSSH(config, oceanClimatolgyTask,
                                             refConfig))
+    analyses.append(ocean.ClimatologyMapOHCAnomaly(
+            config, oceanClimatolgyTask, oceanRefYearClimatolgyTask,
+            refConfig))
     analyses.append(ocean.ClimatologyMapSoseTemperature(
             config, oceanClimatolgyTask, refConfig))
     analyses.append(ocean.ClimatologyMapSoseSalinity(


### PR DESCRIPTION
The maps show the OHC (per unit area) integrated over a list of depth ranges (by default 0 to 10,000 m, 0 to 700 m, 700 to 2000 m and 2000 to 10,000 m).  10,000 m is expected to be below the bottom of the ocean in all of our MPAS-O configurations.