### PR TITLE
Add tasks for plotting velocity magnitude and components against SOSE 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,14 @@ available:
  * nco >= 4.7.0
  * pyproj
  * pillow
+ * cmocean
 
 You can easily install them via the conda command:
 
 ```
 conda config --add channels conda-forge
 conda install numpy scipy matplotlib netCDF4 xarray dask bottleneck basemap \
-    lxml nco pyproj pillow
+    lxml nco pyproj pillow cmocean
 ```
 
 ## List Analysis

--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -15,3 +15,4 @@ dependencies:
   - nco
   - pyproj
   - pillow
+  - cmocean

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -36,6 +36,7 @@ requirements:
         - lxml
         - nco >=4.7.0
         - pillow
+        - cmocean
 
 about:
     home:  http://gitub.com/MPAS-Dev/MPAS-Analysis

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -57,6 +57,9 @@ Ocean tasks
    ClimatologyMapSoseTemperature
    ClimatologyMapSoseSalinity
    ClimatologyMapSoseMLD
+   ClimatologyMapSoseZonalVel
+   ClimatologyMapSoseMeridVel
+   ClimatologyMapSoseVelMag
    ClimatologyMapArgoTemperature
    ClimatologyMapArgoSalinity
    IndexNino34

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -18,6 +18,7 @@ dependencies:
   - nco
   - pyproj
   - pillow
+  - cmocean
   - sphinx
   - sphinx_rtd_theme
   - numpydoc

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -949,7 +949,6 @@ normArgsResult = {'vmin': 10., 'vmax': 300.}
 # specify the ticks
 colorbarTicksResult = [10, 20, 40, 60, 80, 100, 200, 300]
 
-
 # colormap for differences
 colormapNameDifference = RdBu_r
 # the type of norm used in the colormap
@@ -959,6 +958,110 @@ normArgsDifference = {'linthresh': 10., 'linscale': 0.5, 'vmin': -200.,
                       'vmax': 200.}
 colorbarTicksDifference = [-200., -100., -50., -20., -10., 0., 10., 20., 50., 100., 200.]
 
+[climatologyMapSoseZonalVel]
+## options related to plotting climatology maps of Antarctic
+## zonal velocity against reference model results and SOSE reanalysis data
+
+# comparison grid(s)
+# only the Antarctic really makes sense but lat-lon could technically work.
+comparisonGrids = ['antarctic']
+
+# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['ANN','JFM','JAS']
+
+# list of depths in meters (positive up) at which to analyze, 'top' for the
+# sea surface, 'bot' for the sea floor
+depths = ['top', -200, -400, -600, -800, 'bot']
+
+# colormap for model/observations
+colormapNameResult = delta
+# color indices into colormapName for filled contours
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the SemiLogNorm
+normArgsResult = {'vmin': -0.2, 'vmax': 0.2}
+# determine the ticks automatically by default, uncomment to specify
+# colorbarTicksResult = numpy.linspace(-0.2, 0.2, 9)
+
+# colormap for differences
+colormapNameDifference = RdBu_r
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the SemiLogNorm
+normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
+# determine the ticks automatically by default, uncomment to specify
+# colorbarTicksDifference = numpy.linspace(-0.2, 0.2, 9)
+
+[climatologyMapSoseMeridVel]
+## options related to plotting climatology maps of Antarctic
+## meridional against reference model results and SOSE reanalysis data
+
+# comparison grid(s)
+# only the Antarctic really makes sense but lat-lon could technically work.
+comparisonGrids = ['antarctic']
+
+# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['ANN','JFM','JAS']
+
+# list of depths in meters (positive up) at which to analyze, 'top' for the
+# sea surface, 'bot' for the sea floor
+depths = ['top', -200, -400, -600, -800, 'bot']
+
+# colormap for model/observations
+colormapNameResult = delta
+# color indices into colormapName for filled contours
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the SemiLogNorm
+normArgsResult = {'vmin': -0.2, 'vmax': 0.2}
+# determine the ticks automatically by default, uncomment to specify
+# colorbarTicksResult = numpy.linspace(-0.2, 0.2, 9)
+
+# colormap for differences
+colormapNameDifference = RdBu_r
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the SemiLogNorm
+normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
+# determine the ticks automatically by default, uncomment to specify
+# colorbarTicksDifference = numpy.linspace(-0.2, 0.2, 9)
+
+[climatologyMapSoseVelMag]
+## options related to plotting climatology maps of Antarctic
+## meridional against reference model results and SOSE reanalysis data
+
+# comparison grid(s)
+# only the Antarctic really makes sense but lat-lon could technically work.
+comparisonGrids = ['antarctic']
+
+# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['ANN','JFM','JAS']
+
+# list of depths in meters (positive up) at which to analyze, 'top' for the
+# sea surface, 'bot' for the sea floor
+depths = ['top', -200, -400, -600, -800, 'bot']
+
+# colormap for model/observations
+colormapNameResult = ice
+# color indices into colormapName for filled contours
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the SemiLogNorm
+normArgsResult = {'vmin': 0, 'vmax': 0.2}
+# determine the ticks automatically by default, uncomment to specify
+# colorbarTicksResult = numpy.linspace(0, 0.2, 9)
+
+# colormap for differences
+colormapNameDifference = RdBu_r
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the SemiLogNorm
+normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
+# determine the ticks automatically by default, uncomment to specify
+# colorbarTicksDifference = numpy.linspace(-0.2, 0.2, 9)
 
 [climatologyMapSeaIceConcNH]
 ## options related to plotting horizontally remapped climatologies of

--- a/mpas_analysis/ocean/__init__.py
+++ b/mpas_analysis/ocean/__init__.py
@@ -12,6 +12,12 @@ from mpas_analysis.ocean.climatology_map_sose_salinity import \
     ClimatologyMapSoseSalinity
 from mpas_analysis.ocean.climatology_map_sose_mld import \
     ClimatologyMapSoseMLD
+from mpas_analysis.ocean.climatology_map_sose_zonal_vel import \
+    ClimatologyMapSoseZonalVel
+from mpas_analysis.ocean.climatology_map_sose_merid_vel import \
+    ClimatologyMapSoseMeridVel
+from mpas_analysis.ocean.climatology_map_sose_vel_mag import \
+    ClimatologyMapSoseVelMag
 
 from mpas_analysis.ocean.climatology_map_argo import \
     ClimatologyMapArgoTemperature, ClimatologyMapArgoSalinity

--- a/mpas_analysis/ocean/climatology_map_sose_merid_vel.py
+++ b/mpas_analysis/ocean/climatology_map_sose_merid_vel.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
+'''
+Analysis tasks for comparing Antarctic climatology maps against observations
+and reanalysis data.
+'''
+# Authors
+# -------
+# Xylar Asay-Davis
+
+from mpas_analysis.shared import AnalysisTask
+
+from mpas_analysis.ocean.remap_depth_slices_subtask import \
+    RemapDepthSlicesSubtask
+from mpas_analysis.ocean.plot_climatology_map_subtask import \
+    PlotClimatologyMapSubtask
+from mpas_analysis.ocean.remap_sose_climatology import RemapSoseClimatology
+
+from mpas_analysis.shared.io.utility import build_config_full_path
+
+
+class ClimatologyMapSoseMeridVel(AnalysisTask):  # {{{
+    """
+    An analysis task for comparison of meridional velociy around Antarctica against
+    SOSE fields
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    def __init__(self, config, mpasClimatologyTask,
+                 refConfig=None):  # {{{
+        """
+        Construct the analysis task.
+
+        Parameters
+        ----------
+        config :  ``MpasAnalysisConfigParser``
+            Configuration options
+
+        mpasClimatologyTask : ``MpasClimatologyTask``
+            The task that produced the climatology to be remapped and plotted
+
+        refConfig :  ``MpasAnalysisConfigParser``, optional
+            Configuration options for a reference run (if any)
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        fieldName = 'meridVelSOSE'
+        # call the constructor from the base class (AnalysisTask)
+        super(ClimatologyMapSoseMeridVel, self).__init__(
+                config=config, taskName='climatologyMapSoseMeridVel',
+                componentName='ocean',
+                tags=['climatology', 'horizontalMap', 'sose', 'velocity',
+                      'meridional'])
+
+        sectionName = self.taskName
+
+        mpasFieldName = 'timeMonthly_avg_velocityMeridional'
+        iselValues = None
+
+        # read in what seasons we want to plot
+        seasons = config.getExpression(sectionName, 'seasons')
+
+        if len(seasons) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of seasons'.format(sectionName))
+
+        comparisonGridNames = config.getExpression(sectionName,
+                                                   'comparisonGrids')
+
+        if len(comparisonGridNames) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of comparison grids'.format(sectionName))
+
+        depths = config.getExpression(sectionName, 'depths')
+
+        if len(depths) == 0:
+            raise ValueError('config section {} does not contain valid '
+                             'list of depths'.format(sectionName))
+
+        # the variable 'timeMonthly_avg_landIceFreshwaterFlux' will be added to
+        # mpasClimatologyTask along with the seasons.
+        remapClimatologySubtask = RemapDepthSlicesSubtask(
+            mpasClimatologyTask=mpasClimatologyTask,
+            parentTask=self,
+            climatologyName=fieldName,
+            variableList=[mpasFieldName],
+            seasons=seasons,
+            depths=depths,
+            comparisonGridNames=comparisonGridNames,
+            iselValues=iselValues)
+
+        if refConfig is None:
+
+            refTitleLabel = 'State Estimate (SOSE)'
+
+            observationsDirectory = build_config_full_path(
+                config, 'oceanObservations', 'soseSubdirectory')
+
+            obsFileName = \
+                '{}/SOSE_2005-2010_monthly_merid_vel_6000.0x' \
+                '6000.0km_10.0km_Antarctic_stereo.nc'.format(
+                        observationsDirectory)
+            refFieldName = 'meridVel'
+            outFileLabel = 'meridVelSOSE'
+            galleryName = 'State Estimate: SOSE'
+            diffTitleLabel = 'Model - State Estimate'
+
+            remapObservationsSubtask = RemapSoseClimatology(
+                    parentTask=self, seasons=seasons, fileName=obsFileName,
+                    outFilePrefix='{}SOSE'.format(refFieldName),
+                    fieldName=refFieldName,
+                    botFieldName='botMeridVel',
+                    depths=depths,
+                    comparisonGridNames=comparisonGridNames)
+
+            self.add_subtask(remapObservationsSubtask)
+
+        else:
+            remapObservationsSubtask = None
+            refRunName = refConfig.get('runs', 'mainRunName')
+            galleryName = 'Ref: {}'.format(refRunName)
+            refTitleLabel = galleryName
+
+            refFieldName = mpasFieldName
+            outFileLabel = 'meridVel'
+            diffTitleLabel = 'Main - Reference'
+
+        for comparisonGridName in comparisonGridNames:
+            for season in seasons:
+                for depth in depths:
+                    subtask = PlotClimatologyMapSubtask(
+                        parentTask=self,
+                        season=season,
+                        comparisonGridName=comparisonGridName,
+                        remapMpasClimatologySubtask=remapClimatologySubtask,
+                        remapObsClimatologySubtask=remapObservationsSubtask,
+                        refConfig=refConfig,
+                        depth=depth)
+
+                    subtask.set_plot_info(
+                        outFileLabel=outFileLabel,
+                        fieldNameInTitle='Meridional Velocity',
+                        mpasFieldName=mpasFieldName,
+                        refFieldName=refFieldName,
+                        refTitleLabel=refTitleLabel,
+                        diffTitleLabel=diffTitleLabel,
+                        unitsLabel=r'm s$^{-1}$',
+                        imageCaption='Meridional Velocity',
+                        galleryGroup='Meridional Velocity',
+                        groupSubtitle=None,
+                        groupLink='meridVelSose',
+                        galleryName=galleryName)
+
+                    self.add_subtask(subtask)
+        # }}}
+
+    # }}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/ocean/climatology_map_sose_vel_mag.py
+++ b/mpas_analysis/ocean/climatology_map_sose_vel_mag.py
@@ -1,0 +1,220 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
+'''
+Analysis tasks for comparing Antarctic climatology maps against observations
+and reanalysis data.
+'''
+# Authors
+# -------
+# Xylar Asay-Davis
+
+import xarray
+
+from mpas_analysis.shared import AnalysisTask
+
+from mpas_analysis.ocean.remap_depth_slices_subtask import \
+    RemapDepthSlicesSubtask
+from mpas_analysis.ocean.plot_climatology_map_subtask import \
+    PlotClimatologyMapSubtask
+from mpas_analysis.ocean.remap_sose_climatology import RemapSoseClimatology
+
+from mpas_analysis.shared.io.utility import build_config_full_path
+
+
+class ClimatologyMapSoseVelMag(AnalysisTask):  # {{{
+    """
+    An analysis task for comparison of velocity magnitude around Antarctica
+    against SOSE fields
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    def __init__(self, config, mpasClimatologyTask,
+                 refConfig=None):  # {{{
+        """
+        Construct the analysis task.
+
+        Parameters
+        ----------
+        config :  ``MpasAnalysisConfigParser``
+            Configuration options
+
+        mpasClimatologyTask : ``MpasClimatologyTask``
+            The task that produced the climatology to be remapped and plotted
+
+        refConfig :  ``MpasAnalysisConfigParser``, optional
+            Configuration options for a reference run (if any)
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        fieldName = 'velMagSOSE'
+        # call the constructor from the base class (AnalysisTask)
+        super(ClimatologyMapSoseVelMag, self).__init__(
+                config=config, taskName='climatologyMapSoseVelMag',
+                componentName='ocean',
+                tags=['climatology', 'horizontalMap', 'sose', 'velocity',
+                      'magnitude'])
+
+        sectionName = self.taskName
+
+        variableList = ['timeMonthly_avg_velocityMeridional',
+                        'timeMonthly_avg_velocityZonal']
+        iselValues = None
+
+        # read in what seasons we want to plot
+        seasons = config.getExpression(sectionName, 'seasons')
+
+        if len(seasons) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of seasons'.format(sectionName))
+
+        comparisonGridNames = config.getExpression(sectionName,
+                                                   'comparisonGrids')
+
+        if len(comparisonGridNames) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of comparison grids'.format(sectionName))
+
+        depths = config.getExpression(sectionName, 'depths')
+
+        if len(depths) == 0:
+            raise ValueError('config section {} does not contain valid '
+                             'list of depths'.format(sectionName))
+
+        # the variable 'timeMonthly_avg_landIceFreshwaterFlux' will be added to
+        # mpasClimatologyTask along with the seasons.
+        remapClimatologySubtask = RemapMpasVelMagClimatology(
+            mpasClimatologyTask=mpasClimatologyTask,
+            parentTask=self,
+            climatologyName=fieldName,
+            variableList=variableList,
+            seasons=seasons,
+            depths=depths,
+            comparisonGridNames=comparisonGridNames,
+            iselValues=iselValues)
+
+        if refConfig is None:
+
+            refTitleLabel = 'State Estimate (SOSE)'
+
+            observationsDirectory = build_config_full_path(
+                config, 'oceanObservations', 'soseSubdirectory')
+
+            obsFileName = \
+                '{}/SOSE_2005-2010_monthly_vel_mag_6000.0x' \
+                '6000.0km_10.0km_Antarctic_stereo.nc'.format(
+                        observationsDirectory)
+            refFieldName = 'velMag'
+            outFileLabel = 'velMagSOSE'
+            galleryName = 'State Estimate: SOSE'
+            diffTitleLabel = 'Model - State Estimate'
+
+            remapObservationsSubtask = RemapSoseClimatology(
+                    parentTask=self, seasons=seasons, fileName=obsFileName,
+                    outFilePrefix='{}SOSE'.format(refFieldName),
+                    fieldName=refFieldName,
+                    botFieldName='botVelMag',
+                    depths=depths,
+                    comparisonGridNames=comparisonGridNames)
+
+            self.add_subtask(remapObservationsSubtask)
+
+        else:
+            remapObservationsSubtask = None
+            refRunName = refConfig.get('runs', 'mainRunName')
+            galleryName = 'Ref: {}'.format(refRunName)
+            refTitleLabel = galleryName
+
+            refFieldName = 'velMag'
+            outFileLabel = 'velMag'
+            diffTitleLabel = 'Main - Reference'
+
+        for comparisonGridName in comparisonGridNames:
+            for season in seasons:
+                for depth in depths:
+                    subtask = PlotClimatologyMapSubtask(
+                        parentTask=self,
+                        season=season,
+                        comparisonGridName=comparisonGridName,
+                        remapMpasClimatologySubtask=remapClimatologySubtask,
+                        remapObsClimatologySubtask=remapObservationsSubtask,
+                        refConfig=refConfig,
+                        depth=depth)
+
+                    subtask.set_plot_info(
+                        outFileLabel=outFileLabel,
+                        fieldNameInTitle='Velocity Magnitude',
+                        mpasFieldName='velMag',
+                        refFieldName=refFieldName,
+                        refTitleLabel=refTitleLabel,
+                        diffTitleLabel=diffTitleLabel,
+                        unitsLabel=r'm s$^{-1}$',
+                        imageCaption='Velocity Magnitude',
+                        galleryGroup='Velocity Magnitude',
+                        groupSubtitle=None,
+                        groupLink='velMagSose',
+                        galleryName=galleryName)
+
+                    self.add_subtask(subtask)
+        # }}}
+
+    # }}}
+
+
+class RemapMpasVelMagClimatology(RemapDepthSlicesSubtask):  # {{{
+    """
+    A subtask for computing climatologies of velocity magnitude from zonal
+    and meridional components
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    def customize_masked_climatology(self, climatology, season):  # {{{
+        """
+        Mask the melt rates using ``landIceMask`` and rescale it to m/yr
+
+        Parameters
+        ----------
+        climatology : ``xarray.Dataset`` object
+            the climatology data set
+
+        season : str
+            The name of the season to be masked
+
+        Returns
+        -------
+        climatology : ``xarray.Dataset`` object
+            the modified climatology data set
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        # first, call the base class's version of this function so we extract
+        # the desired slices.
+        climatology = super(RemapMpasVelMagClimatology,
+                            self).customize_masked_climatology(climatology,
+                                                               season)
+
+        zonalVel = climatology.timeMonthly_avg_velocityZonal
+        meridVel = climatology.timeMonthly_avg_velocityMeridional
+        climatology['velMag'] = xarray.ufuncs.sqrt(zonalVel**2 + meridVel**2)
+        climatology.velMag.attrs['units'] = 'm s$^{-1}$'
+        climatology.velMag.attrs['description'] = 'velocity magnitude'
+
+        climatology = climatology.drop(self.variableList)
+
+        return climatology  # }}}
+
+    # }}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/ocean/climatology_map_sose_zonal_vel.py
+++ b/mpas_analysis/ocean/climatology_map_sose_zonal_vel.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
+'''
+Analysis tasks for comparing Antarctic climatology maps against observations
+and reanalysis data.
+'''
+# Authors
+# -------
+# Xylar Asay-Davis
+
+from mpas_analysis.shared import AnalysisTask
+
+from mpas_analysis.ocean.remap_depth_slices_subtask import \
+    RemapDepthSlicesSubtask
+from mpas_analysis.ocean.plot_climatology_map_subtask import \
+    PlotClimatologyMapSubtask
+from mpas_analysis.ocean.remap_sose_climatology import RemapSoseClimatology
+
+from mpas_analysis.shared.io.utility import build_config_full_path
+
+
+class ClimatologyMapSoseZonalVel(AnalysisTask):  # {{{
+    """
+    An analysis task for comparison of zonal velociy around Antarctica against
+    SOSE fields
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    def __init__(self, config, mpasClimatologyTask,
+                 refConfig=None):  # {{{
+        """
+        Construct the analysis task.
+
+        Parameters
+        ----------
+        config :  ``MpasAnalysisConfigParser``
+            Configuration options
+
+        mpasClimatologyTask : ``MpasClimatologyTask``
+            The task that produced the climatology to be remapped and plotted
+
+        refConfig :  ``MpasAnalysisConfigParser``, optional
+            Configuration options for a reference run (if any)
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        fieldName = 'zonalVelSOSE'
+        # call the constructor from the base class (AnalysisTask)
+        super(ClimatologyMapSoseZonalVel, self).__init__(
+                config=config, taskName='climatologyMapSoseZonalVel',
+                componentName='ocean',
+                tags=['climatology', 'horizontalMap', 'sose', 'velocity',
+                      'zonal'])
+
+        sectionName = self.taskName
+
+        mpasFieldName = 'timeMonthly_avg_velocityZonal'
+        iselValues = None
+
+        # read in what seasons we want to plot
+        seasons = config.getExpression(sectionName, 'seasons')
+
+        if len(seasons) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of seasons'.format(sectionName))
+
+        comparisonGridNames = config.getExpression(sectionName,
+                                                   'comparisonGrids')
+
+        if len(comparisonGridNames) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of comparison grids'.format(sectionName))
+
+        depths = config.getExpression(sectionName, 'depths')
+
+        if len(depths) == 0:
+            raise ValueError('config section {} does not contain valid '
+                             'list of depths'.format(sectionName))
+
+        # the variable 'timeMonthly_avg_landIceFreshwaterFlux' will be added to
+        # mpasClimatologyTask along with the seasons.
+        remapClimatologySubtask = RemapDepthSlicesSubtask(
+            mpasClimatologyTask=mpasClimatologyTask,
+            parentTask=self,
+            climatologyName=fieldName,
+            variableList=[mpasFieldName],
+            seasons=seasons,
+            depths=depths,
+            comparisonGridNames=comparisonGridNames,
+            iselValues=iselValues)
+
+        if refConfig is None:
+
+            refTitleLabel = 'State Estimate (SOSE)'
+
+            observationsDirectory = build_config_full_path(
+                config, 'oceanObservations', 'soseSubdirectory')
+
+            obsFileName = \
+                '{}/SOSE_2005-2010_monthly_zonal_vel_6000.0x' \
+                '6000.0km_10.0km_Antarctic_stereo.nc'.format(
+                        observationsDirectory)
+            refFieldName = 'zonalVel'
+            outFileLabel = 'zonalVelSOSE'
+            galleryName = 'State Estimate: SOSE'
+            diffTitleLabel = 'Model - State Estimate'
+
+            remapObservationsSubtask = RemapSoseClimatology(
+                    parentTask=self, seasons=seasons, fileName=obsFileName,
+                    outFilePrefix='{}SOSE'.format(refFieldName),
+                    fieldName=refFieldName,
+                    botFieldName='botZonalVel',
+                    depths=depths,
+                    comparisonGridNames=comparisonGridNames)
+
+            self.add_subtask(remapObservationsSubtask)
+
+        else:
+            remapObservationsSubtask = None
+            refRunName = refConfig.get('runs', 'mainRunName')
+            galleryName = 'Ref: {}'.format(refRunName)
+            refTitleLabel = galleryName
+
+            refFieldName = mpasFieldName
+            outFileLabel = 'zonalVel'
+            diffTitleLabel = 'Main - Reference'
+
+        for comparisonGridName in comparisonGridNames:
+            for season in seasons:
+                for depth in depths:
+                    subtask = PlotClimatologyMapSubtask(
+                        parentTask=self,
+                        season=season,
+                        comparisonGridName=comparisonGridName,
+                        remapMpasClimatologySubtask=remapClimatologySubtask,
+                        remapObsClimatologySubtask=remapObservationsSubtask,
+                        refConfig=refConfig,
+                        depth=depth)
+
+                    subtask.set_plot_info(
+                        outFileLabel=outFileLabel,
+                        fieldNameInTitle='Zonal Velocity',
+                        mpasFieldName=mpasFieldName,
+                        refFieldName=refFieldName,
+                        refTitleLabel=refTitleLabel,
+                        diffTitleLabel=diffTitleLabel,
+                        unitsLabel=r'm s$^{-1}$',
+                        imageCaption='Zonal Velocity',
+                        galleryGroup='Zonal Velocity',
+                        groupSubtitle=None,
+                        groupLink='zonalVelSose',
+                        galleryName=galleryName)
+
+                    self.add_subtask(subtask)
+        # }}}
+
+    # }}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -37,6 +37,8 @@ from mpas_analysis.shared.constants import constants
 
 from six.moves import configparser
 
+import cmocean
+
 
 def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                              fileout, lineStyles, lineWidths, legendText,
@@ -1546,5 +1548,13 @@ def _register_custom_colormaps():
         name, colorList, N=255)
 
     plt.register_cmap(name, colorMap)
+
+    # add the cmocean color maps
+    mapNames = list(cmocean.cm.cmapnames)
+    # don't bother with gray (already exists, I think)
+    mapNames.pop(mapNames.index('gray'))
+    for mapName in mapNames:
+        plt.register_cmap(mapName, getattr(cmocean.cm, mapName))
+
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -100,12 +100,20 @@ def build_analysis_list(config, refConfig):  # {{{
     analyses.append(ocean.ClimatologyMapOHCAnomaly(
             config, oceanClimatolgyTask, oceanRefYearClimatolgyTask,
             refConfig))
+
     analyses.append(ocean.ClimatologyMapSoseTemperature(
             config, oceanClimatolgyTask, refConfig))
     analyses.append(ocean.ClimatologyMapSoseSalinity(
             config, oceanClimatolgyTask, refConfig))
     analyses.append(ocean.ClimatologyMapSoseMLD(
             config, oceanClimatolgyTask, refConfig))
+    analyses.append(ocean.ClimatologyMapSoseZonalVel(
+            config, oceanClimatolgyTask, refConfig))
+    analyses.append(ocean.ClimatologyMapSoseMeridVel(
+            config, oceanClimatolgyTask, refConfig))
+    analyses.append(ocean.ClimatologyMapSoseVelMag(
+            config, oceanClimatolgyTask, refConfig))
+
     analyses.append(ocean.ClimatologyMapArgoTemperature(
             config, oceanClimatolgyTask, refConfig))
     analyses.append(ocean.ClimatologyMapArgoSalinity(

--- a/setup.py
+++ b/setup.py
@@ -49,5 +49,5 @@ setup(name='mpas_analysis',
                     'mpas_analysis.test': ['test*/*', 'test*/*/*']},
       install_requires=['numpy', 'scipy', 'matplotlib', 'netCDF4', 'xarray',
                         'dask', 'bottleneck', 'basemap', 'lxml', 'nco',
-                        ' pyproj', 'pillow'],
+                        ' pyproj', 'pillow', 'cmocean'],
       scripts=['run_mpas_analysis'])


### PR DESCRIPTION
The default color maps for these fields are from the `cmocean` package, so this has been added as a dependency (in a bunch of places!) and the color maps are registered with `matplotlib` as part of our standard handling of color maps.