### PR TITLE
Updates mpas-o_in and mpas-seaice_in names

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,19 +102,21 @@ for more details.
         `hist.am.meridionalHeatTransport` file)
       * `mpaso.rst.0002-01-01_00000.nc` (or any other mpas-o restart file)
       * `streams.ocean`
-      * `mpas-o_in`
+      * `mpaso_in`
   * mpas-seaice files:
       * `mpasseaice.hist.am.timeSeriesStatsMonthly.*.nc`
       * `mpasseaice.rst.0002-01-01_00000.nc` (or any other mpas-seaice restart
         file)
       * `streams.seaice`
-      * `mpas-seaice_in`
+      * `mpassi_in`
 
 Note: for older runs, mpas-seaice files will be named:
   * `mpascice.hist.am.timeSeriesStatsMonthly.*.nc`
   * `mpascice.rst.0002-01-01_00000.nc`
   * `streams.cice`
   * `mpas-cice_in`
+  Also, for older runs mpaso-in will be named:
+  * `mpas-o_in`
 
 
 ## Purge Old Analysis

--- a/docs/mpaso.rst
+++ b/docs/mpaso.rst
@@ -24,7 +24,7 @@ In order to support all ocean analysis tasks from MPAS-Analysis, certain
 simulation, need to be enabled.
 
 The following is a list of suggested values for namelist options, typically
-found in ``namelist.ocean`` or ``mpas-o_in``::
+found in ``namelist.ocean`` or ``mpaso_in`` (or ``mpas-o_in`` in older E3SM runs)::
 
    config_AM_surfaceAreaWeightedAverages_enable = .true.
    config_AM_surfaceAreaWeightedAverages_compute_interval = '0000-00-00_01:00:00'

--- a/docs/mpasseaice.rst
+++ b/docs/mpasseaice.rst
@@ -14,7 +14,7 @@ In order to support all sea=ice analysis tasks from MPAS-Analysis, certain
 simulation, need to be enabled.
 
 The following is a list of suggested values for namelist options, typically
-found in ``namelist.seaice`` or ``mpas-seaice_in`` (or ``mpas-cice_in`` in
+found in ``namelist.seaice`` or ``mpassi_in`` (or ``mpas-cice_in`` in
 older E3SM runs)::
 
      config_AM_timeSeriesStatsMonthly_enable = .true.

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -72,9 +72,9 @@ seaIceHistorySubdirectory = .
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-seaice_in
+seaIceNamelistFileName = mpassi_in
 seaIceStreamsFileName = streams.seaice
 
 # names of ocean and sea ice meshes (e.g. oEC60to30, oQU240, oRRS30to10, etc.)


### PR DESCRIPTION
These two files have changed names (again).  The names in E3SM master
are mpaso_in and mpassi_in.  This PR updates those references.