### PR TITLE
 Add SOSE potential density task

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ within the `mpas_analysis/shared` directory.
 
 To generate the `sphinx` documentation, run:
 ```bash
-conda install sphinx sphinx_rtd_theme numpydoc recommonmark
+conda install sphinx sphinx_rtd_theme numpydoc recommonmark tabulate
 cd docs
 make html
 ```

--- a/docs/analysis_tasks.rst
+++ b/docs/analysis_tasks.rst
@@ -11,6 +11,7 @@ Analysis Tasks
    tasks/climatologyMapOHCAnomaly
    tasks/climatologyMapSoseTemperature
    tasks/climatologyMapSoseSalinity
+   tasks/climatologyMapSosePotentialDensity
    tasks/climatologyMapSoseMLD
    tasks/climatologyMapSoseZonalVel
    tasks/climatologyMapSoseMeridVel

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -881,6 +881,41 @@ normArgsDifference = {'vmin': -0.5, 'vmax': 0.5}
 # place the ticks automatically by default
 # colorbarTicksDifference = numpy.linspace(-0.5, 0.5, 9)
 
+[climatologyMapSosePotentialDensity]
+## options related to plotting climatology maps of Antarctic
+## potential density at various levels, including the sea floor against
+## reference model results and SOSE reanalysis data
+
+# comparison grid(s)
+# only the Antarctic really makes sense but lat-lon could technically work.
+comparisonGrids = ['antarctic']
+
+# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['ANN','JFM','JAS']
+
+# list of depths in meters (positive up) at which to analyze, 'top' for the
+# sea surface, 'bot' for the sea floor
+depths = ['top', -200, -400, -600, -800, 'bot']
+
+# colormap for model/observations
+colormapNameResult = dense
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the SemiLogNorm
+normArgsResult = {'vmin': 1026., 'vmax': 1028.}
+# place the ticks automatically by default
+# colorbarTicksResult = numpy.linspace(1026., 1028., 9)
+
+# colormap for differences
+colormapNameDifference = RdBu_r
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the SemiLogNorm
+normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
+# place the ticks automatically by default
+# colorbarTicksDifference = numpy.linspace(-0.2, 0.2, 9)
+
 [climatologyMapSoseMLD]
 ## options related to plotting climatology maps of Antarctic
 ## mixed layer depth against reference model results and SOSE reanalysis data

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -899,22 +899,22 @@ seasons =  ['ANN','JFM','JAS']
 depths = ['top', -200, -400, -600, -800, 'bot']
 
 # colormap for model/observations
-colormapNameResult = dense
+colormapNameResult = Spectral_r
 # the type of norm used in the colormap
 normTypeResult = linear
 # A dictionary with keywords for the SemiLogNorm
-normArgsResult = {'vmin': 1026., 'vmax': 1028.}
+normArgsResult = {'vmin': 1026.5, 'vmax': 1028.}
 # place the ticks automatically by default
 # colorbarTicksResult = numpy.linspace(1026., 1028., 9)
 
 # colormap for differences
-colormapNameDifference = RdBu_r
+colormapNameDifference = balance
 # the type of norm used in the colormap
 normTypeDifference = linear
 # A dictionary with keywords for the SemiLogNorm
-normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
+normArgsDifference = {'vmin': -0.3, 'vmax': 0.3}
 # place the ticks automatically by default
-# colorbarTicksDifference = numpy.linspace(-0.2, 0.2, 9)
+# colorbarTicksDifference = numpy.linspace(-0.3, 0.3, 9)
 
 [climatologyMapSoseMLD]
 ## options related to plotting climatology maps of Antarctic

--- a/mpas_analysis/obs/observational_datasets.xml
+++ b/mpas_analysis/obs/observational_datasets.xml
@@ -374,14 +374,15 @@
 
   <observation>
     <name>
-      SOSE potential temperature and salinity
+      2005-2010 climatology from SOSE the Southern Ocean State Estimate (SOSE)
     </name>
     <component>
       ocean
     </component>
     <description>
-      Monthly potential temperature and salinity output from the Southern Ocean
-      State Estimate (SOSE) covering years 2005-2010
+      Monthly potential temperature, salinity velocity components and neutral
+      density output from the Southern Ocean State Estimate (SOSE) covering
+      years 2005-2010
     </description>
     <source>
       [SOSE Website at UCSD]
@@ -416,10 +417,19 @@
       }
     </bibtex>
     <dataUrls>
+      - http://sose.ucsd.edu/DATA/SO6_V2/grid.mat
       - http://sose.ucsd.edu/DATA/SO6_V2/THETA_mnthlyBar.0000000100.data.gz
       - http://sose.ucsd.edu/DATA/SO6_V2/THETA_mnthlyBar.0000000100.meta
       - http://sose.ucsd.edu/DATA/SO6_V2/SALT_mnthlyBar.0000000100.data.gz
       - http://sose.ucsd.edu/DATA/SO6_V2/SALT_mnthlyBar.0000000100.meta
+      - http://sose.ucsd.edu/DATA/SO6_V2/MLD_mnthlyBar.0000000100.data.gz
+      - http://sose.ucsd.edu/DATA/SO6_V2/MLD_mnthlyBar.0000000100.meta
+      - http://sose.ucsd.edu/DATA/SO6_V2/UVEL_mnthlyBar.0000000100.data.gz
+      - http://sose.ucsd.edu/DATA/SO6_V2/UVEL_mnthlyBar.0000000100.meta
+      - http://sose.ucsd.edu/DATA/SO6_V2/VVEL_mnthlyBar.0000000100.data.gz
+      - http://sose.ucsd.edu/DATA/SO6_V2/VVEL_mnthlyBar.0000000100.meta
+      - http://sose.ucsd.edu/DATA/SO6_V2/GAMMA_mnthlyBar.0000000100.data.gz
+      - http://sose.ucsd.edu/DATA/SO6_V2/GAMMA_mnthlyBar.0000000100.meta
     </dataUrls>
     <preprocessing>
       preprocess_observations/preprocess_SOSE_data.py
@@ -427,6 +437,11 @@
     <tasks>
       - climatologyMapSoseTemperature
       - climatologyMapSoseSalinity
+      - climatologyMapSosePotentialDensity
+      - climatologyMapSoseMLD
+      - climatologyMapSoseZonalVel
+      - climatologyMapSoseMeridVel
+      - climatologyMapSoseVelMag
     </tasks>
     <subdirectory>
       Ocean/SOSE

--- a/mpas_analysis/ocean/__init__.py
+++ b/mpas_analysis/ocean/__init__.py
@@ -10,6 +10,8 @@ from mpas_analysis.ocean.climatology_map_sose_temperature import \
     ClimatologyMapSoseTemperature
 from mpas_analysis.ocean.climatology_map_sose_salinity import \
     ClimatologyMapSoseSalinity
+from mpas_analysis.ocean.climatology_map_sose_potential_density import \
+    ClimatologyMapSosePotentialDensity
 from mpas_analysis.ocean.climatology_map_sose_mld import \
     ClimatologyMapSoseMLD
 from mpas_analysis.ocean.climatology_map_sose_zonal_vel import \

--- a/mpas_analysis/ocean/climatology_map_sose_potential_density.py
+++ b/mpas_analysis/ocean/climatology_map_sose_potential_density.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
+
+from mpas_analysis.shared import AnalysisTask
+
+from mpas_analysis.ocean.remap_depth_slices_subtask import \
+    RemapDepthSlicesSubtask
+from mpas_analysis.ocean.plot_climatology_map_subtask import \
+    PlotClimatologyMapSubtask
+from mpas_analysis.ocean.remap_sose_climatology import RemapSoseClimatology
+
+from mpas_analysis.shared.io.utility import build_config_full_path
+
+
+class ClimatologyMapSosePotentialDensity(AnalysisTask):  # {{{
+    """
+    An analysis task for comparison of antarctic potential density against SOSE
+    fields
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    def __init__(self, config, mpasClimatologyTask,
+                 refConfig=None):  # {{{
+        """
+        Construct the analysis task.
+
+        Parameters
+        ----------
+        config :  ``MpasAnalysisConfigParser``
+            Configuration options
+
+        mpasClimatologyTask : ``MpasClimatologyTask``
+            The task that produced the climatology to be remapped and plotted
+
+        refConfig :  ``MpasAnalysisConfigParser``, optional
+            Configuration options for a reference run (if any)
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        fieldName = 'potentialDensitySOSE'
+        # call the constructor from the base class (AnalysisTask)
+        super(ClimatologyMapSosePotentialDensity, self).__init__(
+                config=config, taskName='climatologyMapSosePotentialDensity',
+                componentName='ocean',
+                tags=['climatology', 'horizontalMap', 'sose',
+                      'potentialDensity'])
+
+        sectionName = self.taskName
+
+        mpasFieldName = 'timeMonthly_avg_potentialDensity'
+        iselValues = None
+
+        # read in what seasons we want to plot
+        seasons = config.getExpression(sectionName, 'seasons')
+
+        if len(seasons) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of seasons'.format(sectionName))
+
+        comparisonGridNames = config.getExpression(sectionName,
+                                                   'comparisonGrids')
+
+        if len(comparisonGridNames) == 0:
+            raise ValueError('config section {} does not contain valid list '
+                             'of comparison grids'.format(sectionName))
+
+        depths = config.getExpression(sectionName, 'depths')
+
+        if len(depths) == 0:
+            raise ValueError('config section {} does not contain valid '
+                             'list of depths'.format(sectionName))
+
+        # the variable 'timeMonthly_avg_landIceFreshwaterFlux' will be added to
+        # mpasClimatologyTask along with the seasons.
+        remapClimatologySubtask = RemapDepthSlicesSubtask(
+            mpasClimatologyTask=mpasClimatologyTask,
+            parentTask=self,
+            climatologyName=fieldName,
+            variableList=[mpasFieldName],
+            seasons=seasons,
+            depths=depths,
+            comparisonGridNames=comparisonGridNames,
+            iselValues=iselValues)
+
+        if refConfig is None:
+
+            refTitleLabel = 'State Estimate (SOSE)'
+
+            observationsDirectory = build_config_full_path(
+                config, 'oceanObservations', 'soseSubdirectory')
+
+            obsFileName = \
+                '{}/SOSE_2005-2010_monthly_pot_den_6000.0x' \
+                '6000.0km_10.0km_Antarctic_stereo.nc'.format(
+                        observationsDirectory)
+            refFieldName = 'potentialDensity'
+            outFileLabel = 'potDenSOSE'
+            galleryName = 'State Estimate: SOSE'
+            diffTitleLabel = 'Model - State Estimate'
+
+            remapObservationsSubtask = RemapSoseClimatology(
+                    parentTask=self, seasons=seasons, fileName=obsFileName,
+                    outFilePrefix='{}SOSE'.format(refFieldName),
+                    fieldName=refFieldName,
+                    botFieldName='botPotentialDensity',
+                    depths=depths,
+                    comparisonGridNames=comparisonGridNames)
+
+            self.add_subtask(remapObservationsSubtask)
+
+        else:
+            remapObservationsSubtask = None
+            refRunName = refConfig.get('runs', 'mainRunName')
+            galleryName = None
+            refTitleLabel = 'Ref: {}'.format(refRunName)
+
+            refFieldName = mpasFieldName
+            outFileLabel = 'potDen'
+            diffTitleLabel = 'Main - Reference'
+
+        for comparisonGridName in comparisonGridNames:
+            for season in seasons:
+                for depth in depths:
+                    subtask = PlotClimatologyMapSubtask(
+                        parentTask=self,
+                        season=season,
+                        comparisonGridName=comparisonGridName,
+                        remapMpasClimatologySubtask=remapClimatologySubtask,
+                        remapObsClimatologySubtask=remapObservationsSubtask,
+                        refConfig=refConfig,
+                        depth=depth)
+
+                    subtask.set_plot_info(
+                        outFileLabel=outFileLabel,
+                        fieldNameInTitle='Potential Density',
+                        mpasFieldName=mpasFieldName,
+                        refFieldName=refFieldName,
+                        refTitleLabel=refTitleLabel,
+                        diffTitleLabel=diffTitleLabel,
+                        unitsLabel=r'kg m$^{-3}$',
+                        imageCaption='Potential Density',
+                        galleryGroup='Potential Density',
+                        groupSubtitle=None,
+                        groupLink='potDenSose',
+                        galleryName=galleryName)
+
+                    self.add_subtask(subtask)
+        # }}}
+
+    # }}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/ocean/remap_sose_climatology.py
+++ b/mpas_analysis/ocean/remap_sose_climatology.py
@@ -150,13 +150,13 @@ class RemapSoseClimatology(RemapObservedClimatologySubtask):
             slices = []
             for depth in self.depths:
                 if depth == 'top':
-                    slices.append(field.sel(method='nearest', depth=0.).drop(
-                            'depth'))
+                    slices.append(field.sel(method='nearest', z=0.).drop(
+                            'z'))
                 elif depth == 'bot':
                     slices.append(dsObs[self.botFieldName])
                 else:
-                    level = field.sel(method='nearest', depth=depth).drop(
-                            'depth')
+                    level = field.sel(method='nearest', z=depth).drop(
+                            'z')
                     slices.append(level)
 
             depthNames = [str(depth) for depth in self.depths]

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -105,6 +105,8 @@ def build_analysis_list(config, refConfig):  # {{{
             config, oceanClimatolgyTask, refConfig))
     analyses.append(ocean.ClimatologyMapSoseSalinity(
             config, oceanClimatolgyTask, refConfig))
+    analyses.append(ocean.ClimatologyMapSosePotentialDensity(
+            config, oceanClimatolgyTask, refConfig))
     analyses.append(ocean.ClimatologyMapSoseMLD(
             config, oceanClimatolgyTask, refConfig))
     analyses.append(ocean.ClimatologyMapSoseZonalVel(


### PR DESCRIPTION
This merge also makes various changes to the script for preprocessing SOSE data:
* switch `depth` to `z` in SOSE output, since it is positive up.  This will mean having to replace SOSE data on all machines once the update is in place. Once we do that, old versions of MPAS-Analysis will break with the new SOSE data. It seems like the change should be made sooner rather than later to avoid this problem once SOSE data is widely used.
* To facilitate computing bottom potential density, `zBot` was added as a coordinate.  A trick was needed to make sure `zBot` gets remapped, since coordinates are not normally remapped.
* There were issues with velocity magnitude on the original lat/lon grid (the 2 components aren't on the same grid) so velocity magnitude is now only available on the Antarctic grid.
