### PR TITLE
Make line colors consistent across plots

### DIFF
--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -266,7 +266,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
                  self.startYear, self.endYear, mainRunName)
         filePrefix = self.filePrefixes['mht']
         figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
-        lineColors = ['r']
+        lineColors = ['k']
         lineWidths = [1.6]
         legendText = [mainRunName]
         xArrays = [x]
@@ -302,7 +302,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             dsRef = xr.open_dataset(refFileName)
             refRunName = self.refConfig.get('runs', 'mainRunName')
 
-            lineColors.append('k')
+            lineColors.append('r')
             lineWidths.append(1.2)
             legendText.append(refRunName)
             xArrays.append(dsRef.binBoundaryMerHeatTrans)
@@ -315,9 +315,9 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             legendText = [None]
 
         plot_1D(config, xArrays, fieldArrays, errArrays,
-                lineColors, lineWidths, legendText,
-                title, xLabel, yLabel, figureName,
-                xLim=xLimGlobal)
+                lineColors=lineColors, lineWidths=lineWidths,
+                legendText=legendText, title=title, xlabel=xLabel,
+                ylabel=yLabel, fileout=figureName, xLim=xLimGlobal)
 
         self._write_xml(filePrefix)
 

--- a/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
+++ b/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
@@ -293,7 +293,8 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                 legends.append('{}m-{}m'.format(top, bottom))
 
         # more possible symbols than we typically use
-        lines = ['-', '-', '--', '+', 'o', '^', 'v']
+        lines = ['-', '-', '--', None, None, None, None]
+        markers = [None, None, None, '+', 'o', '^', 'v']
         widths = [5, 3, 3, 3, 3, 3, 3]
         points = [None, None, None, 300, 300, 300, 300]
 
@@ -309,7 +310,9 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
         figureName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefix)
 
         timeSeries = []
+        lineColors = []
         lineStyles = []
+        lineMarkers = []
         lineWidths = []
         maxPoints = []
         legendText = []
@@ -321,7 +324,9 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
             field = field.where(ds.depth <= bottom)
             timeSeries.append(field.sum('nVertLevels'))
 
-            lineStyles.append('{}{}'.format(color, lines[rangeIndex]))
+            lineColors.append(color)
+            lineStyles.append(lines[rangeIndex])
+            lineMarkers.append(markers[rangeIndex])
             lineWidths.append(widths[rangeIndex])
             maxPoints.append(points[rangeIndex])
             legendText.append(legends[rangeIndex])
@@ -371,8 +376,8 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
             dsPreprocessed = xarray.open_dataset(self.preprocessedFileName)
 
         if preprocessedReferenceRunName != 'None':
-            color = 'r'
-            title = '{} \n {} (red)'.format(title,
+            color = 'purple'
+            title = '{} \n {} (purple)'.format(title,
                                             preprocessedReferenceRunName)
 
             preprocessedFieldPrefix = config.get(self.sectionName,
@@ -398,7 +403,9 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                                                 variableName))
                     timeSeries.extend(None)
 
-                lineStyles.append('{}{}'.format(color, lines[rangeIndex]))
+                lineColors.append(color)
+                lineStyles.append(lines[rangeIndex])
+                lineMarkers.append(markers[rangeIndex])
                 lineWidths.append(widths[rangeIndex])
                 maxPoints.append(points[rangeIndex])
                 legendText.append(None)
@@ -407,7 +414,7 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
 
             refRunName = self.refConfig.get('runs', 'mainRunName')
 
-            title = '{} \n {} (blue)'.format(title, refRunName)
+            title = '{} \n {} (red)'.format(title, refRunName)
 
             self.logger.info('  Load ocean data from reference run...')
             refStartYear = self.refConfig.getint('timeSeries', 'startYear')
@@ -423,7 +430,7 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                                       endDate=refEndDate)
             dsRef = dsRef.isel(nOceanRegionsTmp=regionIndex)
 
-            color = 'b'
+            color = 'r'
 
             for rangeIndex in range(len(topDepths)):
                 top = topDepths[rangeIndex]
@@ -432,7 +439,9 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                 field = field.where(dsRef.depth <= bottom)
                 timeSeries.append(field.sum('nVertLevels'))
 
-                lineStyles.append('{}{}'.format(color, lines[rangeIndex]))
+                lineColors.append(color)
+                lineStyles.append(lines[rangeIndex])
+                lineMarkers.append(markers[rangeIndex])
                 lineWidths.append(widths[rangeIndex])
                 maxPoints.append(points[rangeIndex])
                 legendText.append(None)
@@ -451,9 +460,10 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
 
         timeseries_analysis_plot(config=config, dsvalues=timeSeries, N=None,
                                  title=title, xlabel=xLabel, ylabel=yLabel,
-                                 fileout=figureName, lineStyles=lineStyles,
-                                 lineWidths=lineWidths, maxPoints=maxPoints,
-                                 legendText=legendText, calendar=calendar,
+                                 fileout=figureName, calendar=calendar,
+                                 lineColors=lineColors, lineStyles=lineStyles,
+                                 markers=lineMarkers, lineWidths=lineWidths,
+                                 maxPoints=maxPoints, legendText=legendText,
                                  firstYearXTicks=firstYearXTicks,
                                  yearStrideXTicks=yearStrideXTicks)
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -290,21 +290,22 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
             figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
             fields = [timeSeries]
-            lineStyles = ['k-']
+            lineColors = ['k']
             lineWidths = [2.5]
             legendText = [mainRunName]
             if plotRef:
                 fields.append(refTotalMeltFlux.isel(nRegions=iRegion))
-                lineStyles.append('r-')
+                lineColors.append('r')
                 lineWidths.append(1.2)
                 legendText.append(refRunName)
 
             timeseries_analysis_plot(config, fields, movingAverageMonths,
                                      title, xLabel, yLabel, figureName,
-                                     lineStyles=lineStyles,
+                                     calendar=calendar,
+                                     lineColors=lineColors,
                                      lineWidths=lineWidths,
                                      legendText=legendText,
-                                     calendar=calendar, obsMean=obsMeltFlux,
+                                     obsMean=obsMeltFlux,
                                      obsUncertainty=obsMeltFluxUnc,
                                      obsLegend=list(obsDict.keys()))
 
@@ -331,12 +332,12 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
             figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
             fields = [timeSeries]
-            lineStyles = ['k-']
+            lineColors = ['k']
             lineWidths = [2.5]
             legendText = [mainRunName]
             if plotRef:
                 fields.append(refMeltRates.isel(nRegions=iRegion))
-                lineStyles.append('r-')
+                lineColors.append('r')
                 lineWidths.append(1.2)
                 legendText.append(refRunName)
 
@@ -354,10 +355,11 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
 
             timeseries_analysis_plot(config, fields, movingAverageMonths,
                                      title, xLabel, yLabel, figureName,
-                                     lineStyles=lineStyles,
+                                     calendar=calendar,
+                                     lineColors=lineColors,
                                      lineWidths=lineWidths,
                                      legendText=legendText,
-                                     calendar=calendar, obsMean=obsMeltRate,
+                                     obsMean=obsMeltRate,
                                      obsUncertainty=obsMeltRateUnc,
                                      obsLegend=list(obsDict.keys()),
                                      firstYearXTicks=firstYearXTicks,

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -231,7 +231,7 @@ class TimeSeriesSST(AnalysisTask):
 
             figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
-            lineStyles = ['k-']
+            lineColors = ['k']
             lineWidths = [3]
 
             fields = [SST]
@@ -240,7 +240,7 @@ class TimeSeriesSST(AnalysisTask):
             if dsRefSST is not None:
                 refSST = dsRefSST[varName].isel(nOceanRegions=regionIndex)
                 fields.append(refSST)
-                lineStyles.append('b-')
+                lineColors.append('r')
                 lineWidths.append(1.5)
                 refRunName = self.refConfig.get('runs', 'mainRunName')
                 legendText.append(refRunName)
@@ -248,7 +248,7 @@ class TimeSeriesSST(AnalysisTask):
             if preprocessedReferenceRunName != 'None':
                 SST_v0 = dsPreprocessedTimeSlice.SST
                 fields.append(SST_v0)
-                lineStyles.append('r-')
+                lineColors.append('purple')
                 lineWidths.append(1.5)
                 legendText.append(preprocessedReferenceRunName)
 
@@ -266,9 +266,10 @@ class TimeSeriesSST(AnalysisTask):
 
             timeseries_analysis_plot(config, fields, movingAveragePoints,
                                      title, xLabel, yLabel, figureName,
-                                     lineStyles=lineStyles,
+                                     calendar=calendar,
+                                     lineColors=lineColors,
                                      lineWidths=lineWidths,
-                                     legendText=legendText, calendar=calendar,
+                                     legendText=legendText,
                                      firstYearXTicks=firstYearXTicks,
                                      yearStrideXTicks=yearStrideXTicks)
 

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -10,7 +10,6 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 import xarray as xr
-import os
 
 from mpas_analysis.shared import AnalysisTask
 
@@ -399,23 +398,23 @@ class TimeSeriesSeaIce(AnalysisTask):
                 key = (hemisphere, variableName)
                 dsvalues = [plotVars[key]]
                 legendText = [mainRunName]
-                lineStyles = ['k-']
+                lineColors = ['k']
                 lineWidths = [3]
                 if compareWithObservations and key in obsLegend.keys():
                     dsvalues.append(obs[key])
                     legendText.append(obsLegend[key])
-                    lineStyles.append('b-')
+                    lineColors.append('b')
                     lineWidths.append(1.2)
                 if preprocessedReferenceRunName != 'None':
                     dsvalues.append(preprocessed[key])
                     legendText.append(preprocessedReferenceRunName)
-                    lineStyles.append('r-')
+                    lineColors.append('purple')
                     lineWidths.append(1.2)
 
                 if self.refConfig is not None:
                     dsvalues.append(plotVarsRef[key])
                     legendText.append(refRunName)
-                    lineStyles.append('g-')
+                    lineColors.append('r')
                     lineWidths.append(1.2)
 
                 if config.has_option(self.taskName, 'firstYearXTicks'):
@@ -436,11 +435,11 @@ class TimeSeriesSeaIce(AnalysisTask):
                                          title[key], xLabel,
                                          units[variableName],
                                          figureNameStd[key],
-                                         lineStyles=lineStyles,
+                                         calendar=calendar,
+                                         lineColors=lineColors,
                                          lineWidths=lineWidths,
                                          legendText=legendText,
                                          titleFontSize=titleFontSize,
-                                         calendar=calendar,
                                          firstYearXTicks=firstYearXTicks,
                                          yearStrideXTicks=yearStrideXTicks)
 
@@ -469,11 +468,10 @@ class TimeSeriesSeaIce(AnalysisTask):
                         movingAveragePoints,
                         title[key],
                         figureNamePolar[key],
-                        lineStyles=lineStyles,
+                        lineColors=lineColors,
                         lineWidths=lineWidths,
                         legendText=legendText,
-                        titleFontSize=titleFontSize,
-                        calendar=calendar)
+                        titleFontSize=titleFontSize)
 
                     filePrefix = '{}{}_{}_polar'.format(variableName,
                                                         hemisphere,

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -41,11 +41,12 @@ import cmocean
 
 
 def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
-                             fileout, lineStyles, lineWidths, legendText,
-                             calendar, maxPoints=None, titleFontSize=None,
-                             figsize=(15, 6), dpi=None, firstYearXTicks=None,
-                             yearStrideXTicks=None, maxXTicks=20,
-                             obsMean=None, obsUncertainty=None,
+                             fileout, calendar, lineColors=None,
+                             lineStyles=None, markers=None, lineWidths=None,
+                             legendText=None, maxPoints=None,
+                             titleFontSize=None, figsize=(15, 6), dpi=None,
+                             firstYearXTicks=None, yearStrideXTicks=None,
+                             maxXTicks=20, obsMean=None, obsUncertainty=None,
                              obsLegend=None, legendLocation='lower left'):
 
     """
@@ -73,13 +74,17 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
     fileout : str
         the file name to be written
 
-    lineStyles, lineWidths, legendText : list of str
-        control line style/width and corresponding legend text
-
     calendar : str
         the calendar to use for formatting the time axis
 
-    maxPoints : list of {None, int}
+    lineColors, lineStyles, markers, legendText : list of str, optional
+        control line color, style, marker, and corresponding legend
+        text.  Default is black, solid line with no marker, and no legend.
+
+    lineWidths : list of float, optional
+        control line width.  Default is 1.0.
+
+    maxPoints : list of {None, int}, optional
         the approximate maximum number of time points to use in a time series.
         This can be helpful for reducing the number of symbols plotted if
         plotting with markers.  Otherwise the markers become indistinguishable
@@ -129,6 +134,7 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
 
     minDays = []
     maxDays = []
+    plotLegend = False
     for dsIndex in range(len(dsvalues)):
         dsvalue = dsvalues[dsIndex]
         if dsvalue is None:
@@ -148,10 +154,31 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                 stride = int(round(nTime/float(maxPoints[dsIndex])))
                 mean = mean.isel(Time=slice(0, None, stride))
 
-        plt.plot(mean['Time'].values, mean.values,
-                 lineStyles[dsIndex],
-                 linewidth=lineWidths[dsIndex],
-                 label=legendText[dsIndex])
+        if legendText is None:
+            label = None
+        else:
+            label = legendText[dsIndex]
+            plotLegend = True
+        if lineColors is None:
+            color = 'k'
+        else:
+            color = lineColors[dsIndex]
+        if lineStyles is None:
+            linestyle = '-'
+        else:
+            linestyle = lineStyles[dsIndex]
+        if markers is None:
+            marker = None
+        else:
+            marker = markers[dsIndex]
+        if lineWidths is None:
+            linewidth = 1.
+        else:
+            linewidth = lineWidths[dsIndex]
+
+        plt.plot(mean['Time'].values, mean.values, color=color,
+                 linestyle=linestyle, marker=marker, linewidth=linewidth,
+                 label=label)
 
     if obsMean is not None:
         obsCount = len(obsMean)
@@ -171,7 +198,8 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                              ecolor='k',
                              capthick=2, label=obsLegend[iObs])
 
-    plt.legend(loc=legendLocation)
+    if plotLegend and len(dsvalues) > 1:
+        plt.legend(loc=legendLocation)
 
     ax = plt.gca()
 
@@ -208,8 +236,9 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
 
 
 def timeseries_analysis_plot_polar(config, dsvalues, N, title,
-                                   fileout, lineStyles, lineWidths,
-                                   legendText, titleFontSize=None,
+                                   fileout, lineColors=None, lineStyles=None,
+                                   markers=None, lineWidths=None,
+                                   legendText=None, titleFontSize=None,
                                    figsize=(15, 6), dpi=None):
 
     """
@@ -234,8 +263,12 @@ def timeseries_analysis_plot_polar(config, dsvalues, N, title,
     fileout : str
         the file name to be written
 
-    lineStyles, lineWidths, legendText : list of str
-        control line style/width and corresponding legend text
+    lineColors, lineStyles, markers, legendText : list of str, optional
+        control line color, style, marker, and corresponding legend
+        text.  Default is black, solid line with no marker, and no legend.
+
+    lineWidths : list of float, optional
+        control line width.  Default is 1.0.
 
     titleFontSize : int, optional
         the size of the title font
@@ -257,6 +290,7 @@ def timeseries_analysis_plot_polar(config, dsvalues, N, title,
 
     minDays = []
     maxDays = []
+    plotLegend = False
     for dsIndex in range(len(dsvalues)):
         dsvalue = dsvalues[dsIndex]
         if dsvalue is None:
@@ -265,11 +299,35 @@ def timeseries_analysis_plot_polar(config, dsvalues, N, title,
         mean = xr.DataArray.from_series(mean)
         minDays.append(mean.Time.min())
         maxDays.append(mean.Time.max())
-        plt.polar((mean['Time']/365.0)*np.pi*2.0, mean,
-                  lineStyles[dsIndex],
-                  linewidth=lineWidths[dsIndex],
-                  label=legendText[dsIndex])
-    plt.legend(loc='lower left')
+
+        if legendText is None:
+            label = None
+        else:
+            label = legendText[dsIndex]
+            plotLegend = True
+        if lineColors is None:
+            color = 'k'
+        else:
+            color = lineColors[dsIndex]
+        if lineStyles is None:
+            linestyle = '-'
+        else:
+            linestyle = lineStyles[dsIndex]
+        if markers is None:
+            marker = None
+        else:
+            marker = markers[dsIndex]
+        if lineWidths is None:
+            linewidth = 1.
+        else:
+            linewidth = lineWidths[dsIndex]
+
+        plt.polar((mean['Time']/365.0)*np.pi*2.0, mean, color=color,
+                  linestyle=linestyle, marker=marker, linewidth=linewidth,
+                  label=label)
+
+    if plotLegend and len(dsvalues) > 1:
+        plt.legend(loc='lower left')
 
     ax = plt.gca()
 
@@ -797,8 +855,8 @@ def plot_polar_projection_comparison(
 
 
 def plot_1D(config, xArrays, fieldArrays, errArrays,
-            lineColors, lineWidths, legendText,
-            title=None, xlabel=None, ylabel=None,
+            lineColors=None, lineStyles=None, markers=None, lineWidths=None,
+            legendText=None, title=None, xlabel=None, ylabel=None,
             fileout='plot_1D.png',
             figsize=(10, 4), dpi=None,
             xLim=None,
@@ -823,11 +881,12 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
     errArrays : list of float arrays
         error array (y errors)
 
-    lineColors, legendText : list of str
-        control line color and legend
+    lineColors, lineStyles, markers, legendText : list of str, optional
+        control line color, style, marker, and corresponding legend
+        text.  Default is black, solid line with no marker, and no legend.
 
-    lineWidths : list of int
-        control line width
+    lineWidths : list of float, optional
+        control line width.  Default is 1.0.
 
     title : str, optional
         title of plot
@@ -863,29 +922,46 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
         dpi = config.getint('plot', 'dpi')
     plt.figure(figsize=figsize, dpi=dpi)
 
+    plotLegend = False
     for dsIndex in range(len(xArrays)):
         xArray = xArrays[dsIndex]
         fieldArray = fieldArrays[dsIndex]
         errArray = errArrays[dsIndex]
         if xArray is None:
             continue
-        if errArray is None:
-            plt.plot(xArray, fieldArray,
-                     color=lineColors[dsIndex],
-                     linewidth=lineWidths[dsIndex],
-                     label=legendText[dsIndex])
+
+        if legendText is None:
+            label = None
         else:
-            plt.plot(xArray, fieldArray,
-                     color=lineColors[dsIndex],
-                     linewidth=lineWidths[dsIndex],
-                     label=legendText[dsIndex])
+            label = legendText[dsIndex]
+            plotLegend = True
+        if lineColors is None:
+            color = 'k'
+        else:
+            color = lineColors[dsIndex]
+        if markers is None:
+            marker = None
+        else:
+            marker = markers[dsIndex]
+        if lineStyles is None:
+            linestyle = '-'
+        else:
+            linestyle = lineStyles[dsIndex]
+        if lineWidths is None:
+            linewidth = 1.
+        else:
+            linewidth = lineWidths[dsIndex]
+
+        plt.plot(xArray, fieldArray, color=color, linestyle=linestyle,
+                 marker=marker, linewidth=linewidth, label=label)
+        if errArray is not None:
             plt.fill_between(xArray, fieldArray, fieldArray+errArray,
-                             facecolor=lineColors[dsIndex], alpha=0.2)
+                             facecolor=color, alpha=0.2)
             plt.fill_between(xArray, fieldArray, fieldArray-errArray,
-                             facecolor=lineColors[dsIndex], alpha=0.2)
+                             facecolor=color, alpha=0.2)
     plt.grid()
     plt.axhline(0.0, linestyle='-', color='k')  # horizontal lines
-    if dsIndex > 0:
+    if plotLegend and len(xArrays) > 1:
         plt.legend()
 
     axis_font = {'size': config.get('plot', 'axisFontSize')}

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -141,7 +141,8 @@ def build_analysis_list(config, refConfig):  # {{{
     analyses.append(ocean.MeridionalHeatTransport(config, oceanClimatolgyTask,
                                                   refConfig))
 
-    analyses.append(ocean.StreamfunctionMOC(config, oceanClimatolgyTask))
+    analyses.append(ocean.StreamfunctionMOC(config, oceanClimatolgyTask,
+                                            refConfig))
     analyses.append(ocean.IndexNino34(config, oceanIndexTask, refConfig))
 
     # Sea Ice Analyses


### PR DESCRIPTION
Line colors are now:
 * main in black
 * first obs in blue
 * second obs in green
 * ref run in red
 * v0 run in purple

To support purple as a color, line formats (e.g. 'b-') are separated
into line style, width and marker. This also allows more control.

The ability to plot a reference MOC time series has been added.