### PR TITLE
Add a publicObs tag to all tasks with obs. on public server

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ for more details.
 
 ## Running the analysis
 
-  1. Create and empty config file (say `config.myrun`) or copy one of the
-     example files in the `configs` directory.
-  2. Copy and modify any config options you want to change from
-     `mpas_analysis/config.default` into your new config file.
+  1. Create and empty config file (say `config.myrun`), copy `config.example`,
+     or copy one of the example files in the `configs` directory.
+  2. Either modify config options in your new file or copy and modify config
+     options from `mpas_analysis/config.default`.
 
      **Requirements for custom config files:**
      * At minimum you should set `baseDirectory` under `[output]` to the folder
@@ -71,11 +71,10 @@ for more details.
        updated correctly.
      * Any options you copy into the config file **must** include the
        appropriate section header (e.g. '[run]' or '[output]')
-     * The entire `mpas_analysis/config.default` does not need to be used.
+     * You do not need to copy all options from `mpas_analysis/config.default`.
        This file will automatically be used for any options you do not include
        in your custom config file.
-     * Given the automatic sourcing of `mpas_analysis/config.default` you
-       should **not** alter that file directly.
+     * You should **not** modify `mpas_analysis/config.default` directly.
   3. run: `./run_mpas_analysis config.myrun`.  This will read the configuraiton
      first from `mpas_analysis/config.default` and then replace that
      configuraiton with any changes from from `config.myrun`

--- a/config.example
+++ b/config.example
@@ -1,0 +1,201 @@
+## This file contains the most common config options that a user might want
+## to customize.  The values are the same as in mpas_analysis/config.default,
+## the default config file, which has all possible configuration options.
+## Usage:
+##  1. Copy this file to a new name for a specific run (say config.myrun).
+##  2. Modify any config options you want to change in your new config file.
+##     At a minimum, you need to specify:
+##       * [runs]/mainRunName -- A name for the run to be included plot titles
+##                               and legends
+##       * [input]/baseDirectory -- The directory for the simulation results
+##                                  to analyze
+##       * [input]/mpasMeshName -- The name of the MPAS ocean/sea ice mesh
+##       * [output]/baseDirectory -- The directory for the analysis results
+##       * [oceanObservations]/baseDirectory -- The directory for the analysis
+##                                              ocean observations
+##       * [seaIceObservations]/baseDirectory -- The directory for the analysis
+##                                               sea ice observations
+##       * [regions]/regionMaskDirectory -- a directory containing MOC and
+##                                          ice shelf region masks
+##  3. run: ./run_mpas_analysis config.myrun.  This will read the configuraiton
+##     first from config.default and then replace that configuraiton with any
+##     changes from from config.myrun
+##  4. If you want to run a subset of the analysis, you can either set the
+##     generate option under [output] in your config file or use the
+##     --generate flag on the command line.  See the comments for 'generate'
+##     in the '[output]' section below for more details on this option.
+
+
+[runs]
+## options related to the run to be analyzed and reference runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = runName
+
+# preprocessedReferenceRunName is the name of a reference run that has been
+# preprocessed to compare against (or None to turn off comparison).  Reference
+# runs of this type would have preprocessed results because they were not
+# performed with MPAS components (so they cannot be easily ingested by
+# MPAS-Analysis)
+preprocessedReferenceRunName = None
+
+# config file for a reference run to which this run will be compared.  The
+# analysis should have already been run to completion once with this config
+# file, so that the relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid.  Leave this option commented out if no
+# reference run is desired.
+# referenceRunConfigFile = /path/to/config/file
+
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 1
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = serial
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /dir/for/model/output
+
+# Note: an absolute path can be supplied for any of these subdirectories.
+# A relative path is assumed to be relative to baseDirectory.
+# By default, results are assumed to be directly in baseDirectory,
+# i.e. <baseDirecory>/./
+
+# subdirectory containing restart files
+runSubdirectory = .
+# subdirectory for ocean history files
+oceanHistorySubdirectory = .
+# subdirectory for sea ice history files
+seaIceHistorySubdirectory = .
+
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = mpaso_in
+oceanStreamsFileName = streams.ocean
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
+
+# names of ocean and sea ice meshes (e.g. oEC60to30, oQU240, oRRS30to10, etc.)
+mpasMeshName = mesh
+
+# Directory for mapping files (if they have been generated already). If mapping
+# files needed by the analysis are not found here, they will be generated and
+# placed in the output mappingSubdirectory
+# mappingDirectory = /dir/for/mapping/files
+
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+# NOTE: This directory path must be specific to each test case.
+baseDirectory = /dir/for/analysis/output
+
+# subdirectories within baseDirectory for analysis output
+scratchSubdirectory = scratch
+plotsSubdirectory = plots
+logsSubdirectory = logs
+mpasClimatologySubdirectory = clim/mpas
+mappingSubdirectory = mapping
+timeSeriesSubdirectory = timeseries
+# provide an absolute path to put HTML in an alternative location (e.g. a web
+# portal)
+htmlSubdirectory = html
+
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
+#   'all' -- all analyses will be run
+#   'all_publicObs' -- all analyses for which observations are availabe on the
+#                      public server (the default)
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    ./run_mpas_analysis config.analysis --generate \
+#         only_ocean,no_timeSeries,timeSeriesSST
+generate = ['all_publicObs']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 11
+# the last year over which to average climatalogies
+endYear = 20
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+startYear = 1
+endYear = 9999
+
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 9999
+
+[oceanObservations]
+## options related to ocean observations with which the results will be compared
+
+# directory where ocean observations are stored
+baseDirectory = /dir/to/ocean/observations
+
+[oceanPreprocessedReference]
+## options related to preprocessed ocean reference run with which the results
+## will be compared (e.g. a POP, CESM or ACME v0 run)
+
+# directory where ocean reference simulation results are stored
+baseDirectory = /dir/to/ocean/reference
+
+[seaIceObservations]
+## options related to sea ice observations with which the results will be
+## compared
+
+# directory where sea ice observations are stored
+baseDirectory = /dir/to/seaice/observations
+
+[seaIcePreprocessedReference]
+## options related to preprocessed sea ice reference run with which the results
+## will be compared (e.g. a CICE, CESM or ACME v0 run)
+
+# directory where ocean reference simulation results are stored
+baseDirectory = /dir/to/seaice/reference
+
+[regions]
+## options related to ocean regions used in several analysis modules
+
+# Directory for region mask files
+regionMaskDirectory = /path/to/masks/

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -5,7 +5,7 @@
 ##     example files in the configs directory.
 ##  2. Copy and modify any config options you want to change from this file into
 ##     into your new config file. Make sure they have the right section name
-##     (e.g. [run] or [output]). If nothing esle, you will need to set
+##     (e.g. [run] or [output]). If nothing else, you will need to set
 ##     baseDirectory under [output] to the folder where output should be stored.
 ##  3. run: ./run_mpas_analysis config.myrun.  This will read the configuraiton
 ##     first from this file and then replace that configuraiton with any
@@ -126,6 +126,8 @@ htmlSubdirectory = html
 # Shortcuts exist to generate (or not generate) several types of analysis.
 # These include:
 #   'all' -- all analyses will be run
+#   'all_publicObs' -- all analyses for which observations are availabe on the
+#                      public server (the default)
 #   'all_<tag>' -- all analysis with a particular tag will be run
 #   'all_<component>' -- all analyses from a given component (either 'ocean'
 #                        or 'seaIce') will be run
@@ -143,7 +145,7 @@ htmlSubdirectory = html
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         only_ocean,no_timeSeries,timeSeriesSST
-generate = ['all']
+generate = ['all_publicObs']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/mpas_analysis/ocean/climatology_map_argo.py
+++ b/mpas_analysis/ocean/climatology_map_argo.py
@@ -66,7 +66,8 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
         super(ClimatologyMapArgoTemperature, self).__init__(
                 config=config, taskName='climatologyMapArgoTemperature',
                 componentName='ocean',
-                tags=['climatology', 'horizontalMap', 'argo', fieldName])
+                tags=['climatology', 'horizontalMap', 'argo', fieldName,
+                      'publicObs'])
 
         sectionName = self.taskName
 

--- a/mpas_analysis/ocean/climatology_map_mld.py
+++ b/mpas_analysis/ocean/climatology_map_mld.py
@@ -60,7 +60,7 @@ class ClimatologyMapMLD(AnalysisTask):  # {{{
         super(ClimatologyMapMLD, self).__init__(
                 config=config, taskName='climatologyMapMLD',
                 componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName])
+                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         sectionName = self.taskName
 

--- a/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
+++ b/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
@@ -59,7 +59,7 @@ class ClimatologyMapOHCAnomaly(AnalysisTask):  # {{{
         super(ClimatologyMapOHCAnomaly, self).__init__(
                 config=config, taskName='climatologyMapOHCAnomaly',
                 componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName])
+                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         sectionName = self.taskName
 

--- a/mpas_analysis/ocean/climatology_map_ssh.py
+++ b/mpas_analysis/ocean/climatology_map_ssh.py
@@ -59,7 +59,7 @@ class ClimatologyMapSSH(AnalysisTask):  # {{{
         super(ClimatologyMapSSH, self).__init__(
                 config=config, taskName='climatologyMapSSH',
                 componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName])
+                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         mpasFieldName = 'timeMonthly_avg_pressureAdjustedSSH'
 

--- a/mpas_analysis/ocean/climatology_map_sss.py
+++ b/mpas_analysis/ocean/climatology_map_sss.py
@@ -58,7 +58,7 @@ class ClimatologyMapSSS(AnalysisTask):  # {{{
         super(ClimatologyMapSSS, self).__init__(
                 config=config, taskName='climatologyMapSSS',
                 componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName])
+                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         mpasFieldName = 'timeMonthly_avg_activeTracers_salinity'
         iselValues = {'nVertLevels': 0}

--- a/mpas_analysis/ocean/climatology_map_sst.py
+++ b/mpas_analysis/ocean/climatology_map_sst.py
@@ -58,7 +58,7 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
         super(ClimatologyMapSST, self).__init__(
                 config=config, taskName='climatologyMapSST',
                 componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName])
+                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         mpasFieldName = 'timeMonthly_avg_activeTracers_temperature'
         iselValues = {'nVertLevels': 0}

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -76,7 +76,7 @@ class IndexNino34(AnalysisTask):  # {{{
             config=config,
             taskName='indexNino34',
             componentName='ocean',
-            tags=['timeSeries', 'index', 'nino'])
+            tags=['timeSeries', 'index', 'nino', 'publicObs'])
 
         self.mpasTimeSeriesTask = mpasTimeSeriesTask
         self.refConfig = refConfig

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -64,7 +64,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             config=config,
             taskName='meridionalHeatTransport',
             componentName='ocean',
-            tags=['climatology'])
+            tags=['climatology', 'publicObs'])
 
         self.mpasClimatologyTask = mpasClimatologyTask
         self.run_after(mpasClimatologyTask)

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -73,7 +73,8 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
             config=config,
             taskName='streamfunctionMOC',
             componentName='ocean',
-            tags=['streamfunction', 'moc', 'climatology', 'timeSeries'])
+            tags=['streamfunction', 'moc', 'climatology', 'timeSeries',
+                  'publicObs'])
 
         self.mpasClimatologyTask = mpasClimatologyTask
         self.run_after(mpasClimatologyTask)

--- a/mpas_analysis/ocean/time_series_ohc_anomaly.py
+++ b/mpas_analysis/ocean/time_series_ohc_anomaly.py
@@ -54,7 +54,7 @@ class TimeSeriesOHCAnomaly(AnalysisTask):
             config=config,
             taskName='timeSeriesOHCAnomaly',
             componentName='ocean',
-            tags=['timeSeries', 'ohc'])
+            tags=['timeSeries', 'ohc', 'publicObs'])
 
         sectionName = 'timeSeriesOHCAnomaly'
         regionNames = config.getExpression(sectionName, 'regions')

--- a/mpas_analysis/ocean/time_series_salinity_anomaly.py
+++ b/mpas_analysis/ocean/time_series_salinity_anomaly.py
@@ -47,7 +47,7 @@ class TimeSeriesSalinityAnomaly(AnalysisTask):
             config=config,
             taskName='timeSeriesSalinityAnomaly',
             componentName='ocean',
-            tags=['timeSeries', 'salinity'])
+            tags=['timeSeries', 'salinity', 'publicObs'])
 
         sectionName = 'hovmollerSalinityAnomaly'
         regionNames = config.getExpression(sectionName, 'regions')

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -67,7 +67,7 @@ class TimeSeriesSST(AnalysisTask):
             config=config,
             taskName='timeSeriesSST',
             componentName='ocean',
-            tags=['timeSeries', 'sst'])
+            tags=['timeSeries', 'sst', 'publicObs'])
 
         self.mpasTimeSeriesTask = mpasTimeSeriesTask
         self.refConfig = refConfig

--- a/mpas_analysis/ocean/time_series_temperature_anomaly.py
+++ b/mpas_analysis/ocean/time_series_temperature_anomaly.py
@@ -47,7 +47,7 @@ class TimeSeriesTemperatureAnomaly(AnalysisTask):
             config=config,
             taskName='timeSeriesTemperatureAnomaly',
             componentName='ocean',
-            tags=['timeSeries', 'temperature'])
+            tags=['timeSeries', 'temperature', 'publicObs'])
 
         sectionName = 'hovmollerTemperatureAnomaly'
         regionNames = config.getExpression(sectionName, 'regions')

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -63,7 +63,7 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
         super(ClimatologyMapSeaIceConc, self).__init__(
                 config=config, taskName=taskName,
                 componentName='seaIce',
-                tags=['climatology', 'horizontalMap', fieldName])
+                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         mpasFieldName = 'timeMonthly_avg_iceAreaCell'
         iselValues = None

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -63,7 +63,8 @@ class ClimatologyMapSeaIceThick(AnalysisTask):  # {{{
         super(ClimatologyMapSeaIceThick, self).__init__(
                 config=config, taskName=taskName,
                 componentName='seaIce',
-                tags=['climatology', 'horizontalMap', fieldName])
+                tags=['climatology', 'horizontalMap', fieldName,
+                      'publicObs'])
 
         mpasFieldName = 'timeMonthly_avg_iceVolumeCell'
         iselValues = None

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -75,7 +75,7 @@ class TimeSeriesSeaIce(AnalysisTask):
             config=config,
             taskName='timeSeriesSeaIceAreaVol',
             componentName='seaIce',
-            tags=['timeSeries'])
+            tags=['timeSeries', 'publicObs'])
 
         self.mpasTimeSeriesTask = mpasTimeSeriesTask
         self.refConfig = refConfig


### PR DESCRIPTION
The new default is to generate only the tasks with this tag:
```
generate = ['all_publicObs']
```

Any tasks without observations are also given the `publicObs` tag because they will run successfully if someone only has the publicly available observations.

This merge also adds an example config file at the top level with the most common options that a user would want to change.

The README.md has also been updated to clarify creating a custom config file, including mentioning the new example config file.