### PR TITLE
Switch scripts that download obs. data to use "requests" package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ environment with the following packages:
  * pyproj
  * pillow
  * cmocean
+ * progressbar2
+ * requests
 
 These can be installed via the conda command:
 ```
@@ -60,7 +62,7 @@ two subdirectories:
   standard resolution MPAS meshes
 * `observations`, which includes the pre-processed observations listed in the
   [Observations table](http://mpas-analysis.readthedocs.io/en/latest/observations.html)
-  and used to evaluate the model results 
+  and used to evaluate the model results
 
 ## List Analysis
 

--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -16,3 +16,5 @@ dependencies:
   - pyproj
   - pillow
   - cmocean
+  - progressbar2
+  - requests

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -37,6 +37,8 @@ requirements:
         - nco >=4.7.0
         - pillow
         - cmocean
+        - progressbar2
+        - requests
 
 about:
     home:  http://gitub.com/MPAS-Dev/MPAS-Analysis

--- a/download_analysis_data.py
+++ b/download_analysis_data.py
@@ -25,80 +25,8 @@ from __future__ import absolute_import, division, print_function, \
 import os
 import argparse
 import pkg_resources
-import requests
-import progressbar
 
-
-# From https://stackoverflow.com/a/1094933/7728169
-def sizeof_fmt(num, suffix='B'):
-    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
-        if abs(num) < 1024.0:
-            return "%3.1f%s%s" % (num, unit, suffix)
-        num /= 1024.0
-    return "%.1f%s%s" % (num, 'Yi', suffix)
-
-
-def download_analysis_files(outDir):
-    urlBase = 'https://web.lcrc.anl.gov/public/e3sm/diagnostics'
-    analysisFileList = pkg_resources.resource_string(
-            'mpas_analysis', 'obs/analysis_input_files').decode('utf-8')
-
-    for fileName in analysisFileList.split('\n'):
-        outFileName = '{}/{}'.format(outDir, fileName)
-        # outFileName contains full path, so we need to make the relevant
-        # subdirectories if they do not exist already
-        directory = os.path.dirname(outFileName)
-        try:
-            os.makedirs(directory)
-        except OSError:
-            pass
-
-        url = '{}/{}'.format(urlBase, fileName)
-        try:
-            response = requests.get(url, stream=True)
-            totalSize = response.headers.get('content-length')
-        except requests.exceptions.RequestException:
-            print('  {} could not be reached!'.format(fileName))
-            continue
-
-        if totalSize is None:
-            # no content length header
-            if not os.path.exists(outFileName):
-                with open(outFileName, 'wb') as f:
-                    print('Downloading {}...'.format(fileName))
-                    try:
-                        f.write(response.content)
-                    except requests.exceptions.RequestException:
-                        print('  {} failed!'.format(fileName))
-                    else:
-                        print('  {} done.'.format(fileName))
-        else:
-            # we can do the download in chunks and use a progress bar, yay!
-
-            totalSize = int(totalSize)
-            if os.path.exists(outFileName) and \
-                    totalSize == os.path.getsize(outFileName):
-                # we already have the file, so just continue
-                continue
-
-            print('Downloading {} ({})...'.format(fileName,
-                                                  sizeof_fmt(totalSize)))
-            widgets = [progressbar.Percentage(), ' ', progressbar.Bar(),
-                       ' ', progressbar.ETA()]
-            bar = progressbar.ProgressBar(widgets=widgets,
-                                          maxval=totalSize).start()
-            size = 0
-            with open(outFileName, 'wb') as f:
-                try:
-                    for data in response.iter_content(chunk_size=4096):
-                        size += len(data)
-                        f.write(data)
-                        bar.update(size)
-                    bar.finish()
-                except requests.exceptions.RequestException:
-                    print('  {} failed!'.format(fileName))
-                else:
-                    print('  {} done.'.format(fileName))
+from mpas_analysis.shared.io.download import download_files
 
 
 if __name__ == "__main__":
@@ -115,4 +43,10 @@ if __name__ == "__main__":
     except OSError:
         pass
 
-    download_analysis_files(args.outDir)
+    urlBase = 'https://web.lcrc.anl.gov/public/e3sm/diagnostics'
+    analysisFileList = pkg_resources.resource_string(
+            'mpas_analysis', 'obs/analysis_input_files').decode('utf-8')
+
+    # remove any empty strings from the list
+    analysisFileList = list(filter(None, analysisFileList.split('\n')))
+    download_files(analysisFileList, urlBase, args.outDir)

--- a/download_analysis_data.py
+++ b/download_analysis_data.py
@@ -16,31 +16,26 @@ observations data, MPAS mapping files and MPAS regional mask files
 # Authors
 # -------
 # Milena Veneziani
+# Xylar Asay-Davis
 
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 
 import os
-import threading
 import argparse
 import pkg_resources
-try:
-    # python 3
-    from queue import Queue
-except ImportError:
-    # python 2
-    from Queue import Queue
+import requests
+import progressbar
 
 
-try:
-    # python 3
-    from urllib.request import urlretrieve
-    from urllib.error import HTTPError
-except ImportError:
-    # python 2
-    from urllib import urlretrieve
-    from urllib2 import HTTPError
+# From https://stackoverflow.com/a/1094933/7728169
+def sizeof_fmt(num, suffix='B'):
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yi', suffix)
 
 
 def download_analysis_files(outDir):
@@ -48,27 +43,7 @@ def download_analysis_files(outDir):
     analysisFileList = pkg_resources.resource_string(
             'mpas_analysis', 'obs/analysis_input_files').decode('utf-8')
 
-    fileList = []
     for fileName in analysisFileList.split('\n'):
-        fileList.append((urlBase, fileName))
-
-    queue = Queue()
-    # Set up some threads to fetch the data
-    threadCount = 2
-    for index in range(threadCount):
-        worker = threading.Thread(target=download_worker,
-                                  args=(queue, outDir))
-        worker.setDaemon(True)
-        worker.start()
-
-    for fileData in fileList:
-        queue.put(fileData)
-    queue.join()
-
-
-def download_worker(queue, outDir):
-    while True:
-        urlBase, fileName = queue.get()
         outFileName = '{}/{}'.format(outDir, fileName)
         # outFileName contains full path, so we need to make the relevant
         # subdirectories if they do not exist already
@@ -78,15 +53,52 @@ def download_worker(queue, outDir):
         except OSError:
             pass
 
-        if not os.path.exists(outFileName):
-            print('Downloading {}...'.format(fileName))
-            try:
-                urlretrieve('{}/{}'.format(urlBase, fileName), outFileName)
-            except HTTPError:
-                print('  {} failed!'.format(fileName))
-            else:
-                print('  {} done.'.format(fileName))
-        queue.task_done()
+        url = '{}/{}'.format(urlBase, fileName)
+        try:
+            response = requests.get(url, stream=True)
+            totalSize = response.headers.get('content-length')
+        except requests.exceptions.RequestException:
+            print('  {} could not be reached!'.format(fileName))
+            continue
+
+        if totalSize is None:
+            # no content length header
+            if not os.path.exists(outFileName):
+                with open(outFileName, 'wb') as f:
+                    print('Downloading {}...'.format(fileName))
+                    try:
+                        f.write(response.content)
+                    except requests.exceptions.RequestException:
+                        print('  {} failed!'.format(fileName))
+                    else:
+                        print('  {} done.'.format(fileName))
+        else:
+            # we can do the download in chunks and use a progress bar, yay!
+
+            totalSize = int(totalSize)
+            if os.path.exists(outFileName) and \
+                    totalSize == os.path.getsize(outFileName):
+                # we already have the file, so just continue
+                continue
+
+            print('Downloading {} ({})...'.format(fileName,
+                                                  sizeof_fmt(totalSize)))
+            widgets = [progressbar.Percentage(), ' ', progressbar.Bar(),
+                       ' ', progressbar.ETA()]
+            bar = progressbar.ProgressBar(widgets=widgets,
+                                          maxval=totalSize).start()
+            size = 0
+            with open(outFileName, 'wb') as f:
+                try:
+                    for data in response.iter_content(chunk_size=4096):
+                        size += len(data)
+                        f.write(data)
+                        bar.update(size)
+                    bar.finish()
+                except requests.exceptions.RequestException:
+                    print('  {} failed!'.format(fileName))
+                else:
+                    print('  {} done.'.format(fileName))
 
 
 if __name__ == "__main__":

--- a/mpas_analysis/shared/io/download.py
+++ b/mpas_analysis/shared/io/download.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
+# and the University Corporation for Atmospheric Research (UCAR).
+#
+# Unless noted otherwise source code is licensed under the BSD license.
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at http://mpas-dev.github.com/license.html
+#
+
+"""
+Utilities for downloading files
+"""
+# Authors
+# -------
+# Milena Veneziani
+# Xylar Asay-Davis
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+
+import os
+import requests
+import progressbar
+
+
+# From https://stackoverflow.com/a/1094933/7728169
+def sizeof_fmt(num, suffix='B'):
+    '''
+    Covert a number of bytes to a human-readable file size
+    '''
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+        if abs(num) < 1024.0:
+            return "%3.1f%s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f%s%s" % (num, 'Yi', suffix)
+
+
+def download_files(fileList, urlBase, outDir):
+    '''
+    Download a list of files from a URL to a directory
+    '''
+    # Authors
+    # -------
+    # Milena Veneziani
+    # Xylar Asay-Davis
+
+    for fileName in fileList:
+        outFileName = '{}/{}'.format(outDir, fileName)
+        # outFileName contains full path, so we need to make the relevant
+        # subdirectories if they do not exist already
+        directory = os.path.dirname(outFileName)
+        try:
+            os.makedirs(directory)
+        except OSError:
+            pass
+
+        url = '{}/{}'.format(urlBase, fileName)
+        try:
+            response = requests.get(url, stream=True)
+            totalSize = response.headers.get('content-length')
+        except requests.exceptions.RequestException:
+            print('  {} could not be reached!'.format(fileName))
+            continue
+
+        if totalSize is None:
+            # no content length header
+            if not os.path.exists(outFileName):
+                with open(outFileName, 'wb') as f:
+                    print('Downloading {}...'.format(fileName))
+                    try:
+                        f.write(response.content)
+                    except requests.exceptions.RequestException:
+                        print('  {} failed!'.format(fileName))
+                    else:
+                        print('  {} done.'.format(fileName))
+        else:
+            # we can do the download in chunks and use a progress bar, yay!
+
+            totalSize = int(totalSize)
+            if os.path.exists(outFileName) and \
+                    totalSize == os.path.getsize(outFileName):
+                # we already have the file, so just continue
+                continue
+
+            print('Downloading {} ({})...'.format(fileName,
+                                                  sizeof_fmt(totalSize)))
+            widgets = [progressbar.Percentage(), ' ', progressbar.Bar(),
+                       ' ', progressbar.ETA()]
+            bar = progressbar.ProgressBar(widgets=widgets,
+                                          maxval=totalSize).start()
+            size = 0
+            with open(outFileName, 'wb') as f:
+                try:
+                    for data in response.iter_content(chunk_size=4096):
+                        size += len(data)
+                        f.write(data)
+                        bar.update(size)
+                    bar.finish()
+                except requests.exceptions.RequestException:
+                    print('  {} failed!'.format(fileName))
+                else:
+                    print('  {} done.'.format(fileName))

--- a/preprocess_observations/preprocess_Schmidtko_data.py
+++ b/preprocess_observations/preprocess_Schmidtko_data.py
@@ -26,14 +26,7 @@ import argparse
 import pandas
 import gsw
 
-try:
-    # python 3
-    from urllib.request import urlretrieve
-    from urllib.error import HTTPError
-except ImportError:
-    # python 2
-    from urllib import urlretrieve
-    from urllib2 import HTTPError
+from mpas_analysis.shared.io.download import download_files
 
 from mpas_analysis.shared.interpolation import Remapper
 from mpas_analysis.shared.grid import LatLonGridDescriptor
@@ -42,21 +35,6 @@ from mpas_analysis.shared.climatology.comparison_descriptors \
 from mpas_analysis.configuration \
     import MpasAnalysisConfigParser
 from mpas_analysis.shared.io import write_netcdf
-
-
-def download_file(outDir):
-    # dowload the desired file
-    urlBase = 'https://www.geomar.de/fileadmin/personal/fb1/po/sschmidtko/'
-    fileName = 'Antarctic_shelf_data.txt'
-    outFileName = '{}/{}'.format(outDir, fileName)
-    if not os.path.exists(outFileName):
-        print('Downloading {}...'.format(fileName))
-        try:
-            urlretrieve('{}/{}'.format(urlBase, fileName), outFileName)
-        except HTTPError:
-            print('  {} failed!'.format(fileName))
-        else:
-            print('  {} done.'.format(fileName))
 
 
 def text_to_netcdf(inDir, outDir):
@@ -200,10 +178,11 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-i", "--inDir", dest="inDir", required=True,
-                        help="Directory where SOSE files should be downloaded")
+                        help="Directory where intermediate files used in "
+                             "processing should be downloaded")
     parser.add_argument("-o", "--outDir", dest="outDir", required=True,
-                        help="Directory where MPAS-Analysis observation are"
-                             "stored")
+                        help="Directory where final preprocessed observation "
+                             "are stored")
     args = parser.parse_args()
 
     try:
@@ -216,6 +195,9 @@ if __name__ == "__main__":
     except OSError:
         pass
 
-    download_file(args.inDir)
+    urlBase = 'https://www.geomar.de/fileadmin/personal/fb1/po/sschmidtko/'
+    fileName = 'Antarctic_shelf_data.txt'
+
+    download_files([fileName], urlBase, args.inDir)
     text_to_netcdf(args.inDir, args.inDir)
     remap(args.inDir, args.outDir)

--- a/setup.py
+++ b/setup.py
@@ -50,5 +50,6 @@ setup(name='mpas_analysis',
                     'mpas_analysis.obs': ['analysis_input_files', 'observational_datasets.xml']},
       install_requires=['numpy', 'scipy', 'matplotlib', 'netCDF4', 'xarray',
                         'dask', 'bottleneck', 'basemap', 'lxml', 'nco',
-                        ' pyproj', 'pillow', 'cmocean'],
+                        'pyproj', 'pillow', 'cmocean', 'progressbar2',
+                        'requests'],
       scripts=['run_mpas_analysis', 'download_analysis_data.py'])


### PR DESCRIPTION
This allows a nice progress bar and should avoid an error seen with urllib.

The script also now checks if the file is already there *and* if it has the right size.  If not, it will be downloaded.

To support the progress bar, it is necessary to no longer use threading, since one cannot easily do separate progress bars for separate threads.