### PR TITLE
Update MHT legend text with Trenberth reference

### DIFF
--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -283,7 +283,8 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
 
             lineColors.extend(['b', 'g'])
             lineWidths.extend([1.2, 1.2])
-            legendText.extend(['NCEP', 'ECMWF'])
+            legendText.extend(['Trenberth and Caron - NCEP',
+                               'Trenberth and Caron - ECMWF'])
             xArrays.extend([xObs, xObs])
             fieldArrays.extend([ncepGlobal, ecmwfGlobal])
             errArrays.extend([ncepErrGlobal, ecmwfErrGlobal])


### PR DESCRIPTION
Quick change in MHT legend text for the observation part. It is confusing to me to just have ECMWF and NCEP in there.
This addresse #372.