### PR TITLE
A general clean-up pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ environment with the following packages:
 These can be installed via the conda command:
 ```
 conda install -c conda-forge numpy scipy matplotlib netCDF4 xarray dask \
-    bottleneck basemap lxml nco pyproj pillow cmocean
+    bottleneck basemap lxml nco pyproj pillow cmocean progressbar2 requests
 ```
 
 ## Download analysis input data

--- a/README.md
+++ b/README.md
@@ -146,8 +146,23 @@ the analysis, add the `--purge` flag:
 ```
 ./run_mpas_analysis --purge <config.file>
 ````
-The directory to delete is the `baseDirectory` option in the `output`
-section.
+All of the subdirectories listed in `output` will be deleted along with the
+climatology subdirectories in `oceanObservations` and `seaIceObservations`.
+
+It is a good policy to use the purge flag for most changes to the config file,
+for example, updating the start and/or end years of climatologies (and
+sometimes time series), changing the resolution of a comparison grid, renaming
+the run, changing the seasons over which climatologies are computed for a given
+task, updating the code to the latest version.
+
+Cases where it is reasonable not to purge would be, for example, changing
+options that only affect plotting (color map, ticks, ranges, font sizes, etc.),
+rerunning with a different set of tasks specified by the `generate` option
+(though this will often cause climatologies to be re-computed with new
+variables and may not save time compared with purging), generating only the
+final website with `--html_only`, and re-running after the simulation has
+progressed to extend time series (however, not recommended for changing the
+bounds on climatologies, see above).
 
 ## Running in parallel
 

--- a/docs/config/climatology.rst
+++ b/docs/config/climatology.rst
@@ -92,13 +92,13 @@ This capability is available largely for debugging purposes.
 
 Remapped data typically only makes sense if it is renormalized after remapping.
 For remapping of conserved quatntities like fluxes, renormalization would not
-be desirable but for quantities like temperature, salinity and density commonly
-used in MPAS-Anlaysis tasks, values become physically meaningless near land
-boundaries and regions without data unless renormalization is performed.  A
-threshold is needed to determine how much of a cell's area on the output grid
-must contain valid data from the input grid or mesh, below which that cell is
-considered invalid and is masked out of the destination data set.  This
-threshold is specified as a fraction::
+be desirable but for quantities like potential temperature, salinity and
+potential density commonly used in MPAS-Anlaysis tasks, values become
+physically meaningless near land boundaries and regions without data unless
+renormalization is performed.  A threshold is needed to determine how much of a
+cell's area on the output grid must contain valid data from the input grid or
+mesh, below which that cell is considered invalid and is masked out of the
+destination data set.  This threshold is specified as a fraction::
 
   renormalizationThreshold = 0.01
 

--- a/docs/config/observations.rst
+++ b/docs/config/observations.rst
@@ -23,15 +23,6 @@ folders::
   argoSubdirectory = ARGO
   schmidtkoSubdirectory = Schmidtko
 
-  # first and last year of SST observational climatology (preferably one of the
-  # two ranges given below)
-  # values for preindustrial
-  sstClimatologyStartYear = 1870
-  sstClimatologyEndYear = 1900
-  # alternative values for present day
-  #sstClimatologyStartYear = 1990
-  #sstClimatologyEndYear = 2011
-
   # interpolation order for observations. Likely values are
   #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
   interpolationMethod = bilinear
@@ -53,22 +44,6 @@ folders::
 
   # directory where sea ice observations are stored
   baseDirectory = /dir/to/seaice/observations
-  areaNH = IceArea_timeseries/iceAreaNH_climo.nc
-  areaSH = IceArea_timeseries/iceAreaSH_climo.nc
-  volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
-  volSH = none
-  concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-  concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
-  concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
-  concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
-  concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-  concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
-  concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
-  concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
-  thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
-  thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
-  thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
-  thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
   # interpolation order for observations. Likely values are
   #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -21,6 +21,9 @@ options that are most commonly modified.
    config/climatology
    config/timeSeries
    config/index
+   config/regions
+   config/plot
+   config/html
    config/observations
    config/preprocessed
    config/colormaps
@@ -28,9 +31,6 @@ options that are most commonly modified.
    config/comparison_grids
    config/moving_average
    config/time_axis_ticks
-   config/regions
-   config/plot
-   config/html
 
 
 .. _`GitHub`: https://github.com/MPAS-Dev/MPAS-Analysis/tree/develop/configs

--- a/docs/parse_table.py
+++ b/docs/parse_table.py
@@ -15,7 +15,6 @@ import re
 import os
 
 
-
 def markdown_links(data, footer):
     urlscmd = re.findall(r"\[.*?\]\n*\(.*?\)", data)
     urls = re.findall(r"\[.*?\]\n*\((.*?)\)", data)
@@ -149,10 +148,20 @@ def build_obs_pages_from_xml(xmlfile):
             if tag == 'tasks':
                 text = add_task_links(text)
             if tag == 'references':
-                # add a link to the bibtex file
-                subdirectory = entry.findall('subdirectory')[0].text.strip()
-                text = '{}\n\n[bibtex file]({}/{}/obs.bib)'.format(
-                        text, urlBase, subdirectory)
+                bibtexFound = False
+                bibtex = entry.findall('bibtex')
+                if len(bibtex) > 0:
+                    # there is a bibtex tag
+                    bibtex = bibtex[0].text.strip()
+                    if len(bibtex) > 0:
+                        # the bibtex tag is also not empty
+                        bibtexFound = True
+                if bibtexFound:
+                    # add a link to the bibtex file
+                    subdirectory = entry.findall('subdirectory')[0].text.strip()
+                    text = '{}\n\n[bibtex file]({}/{}/obs.bib)'.format(
+                            text, urlBase, subdirectory)
+
             text, footer = cleanup(text, footer)
             rst.write('{}\n\n'.format(text))
         rst.write(footer)

--- a/docs/tasks/climatologyMapSST.rst
+++ b/docs/tasks/climatologyMapSST.rst
@@ -43,28 +43,23 @@ The following configuration options are available for this task::
   # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
   comparisonGrids = ['latlon']
 
-For more details, see:
- * :ref:`config_colormaps`
- * :ref:`config_seasons`
- * :ref:`config_comparison_grids`
-
-The following configuration options relate to the observations used by this
-task::
-
-  [oceanObservations]
-  ...
   # first and last year of SST observational climatology (preferably one of the
   # two ranges given below)
   # values for preindustrial
-  sstClimatologyStartYear = 1870
-  sstClimatologyEndYear = 1900
+  obsStartYear = 1870
+  obsEndYear = 1900
   # alternative values for present day
-  #sstClimatologyStartYear = 1990
-  #sstClimatologyEndYear = 2011
+  #obsStartYear = 1990
+  #obsEndYear = 2011
 
 By default, a "preindustrial" climatology is computed for comparison with the
 model results.  For simulations covering a different time period, the range of
-years should be updated.
+years (``obsStartYear`` and ``obsEndYear``) should be updated.
+
+For details on the remaining configuration options, see:
+ * :ref:`config_colormaps`
+ * :ref:`config_seasons`
+ * :ref:`config_comparison_grids`
 
 Observations
 ------------

--- a/docs/tasks/climatologyMapSchmidtko.rst
+++ b/docs/tasks/climatologyMapSchmidtko.rst
@@ -52,7 +52,7 @@ The following configuration options are available for this task::
   # colorbarTicksDifference = numpy.linspace(-2., 2., 9)
 
   [climatologyMapSchmidtkoSalinity]
-  ## options related to plotting climatology maps of potential temperature at the
+  ## options related to plotting climatology maps of salinity at the
   ## seafloor and comparing them against data from Schmidtko et al. (2014)
 
   # colormap for model/observations
@@ -74,7 +74,7 @@ The following configuration options are available for this task::
   # colorbarTicksDifference = numpy.linspace(-0.5, 0.5, 9)
 
   [climatologyMapSchmidtkoPotentialDensity]
-  ## options related to plotting climatology maps of potential temperature at the
+  ## options related to plotting climatology maps of potential density at the
   ## seafloor and comparing them against data from Schmidtko et al. (2014)
 
   # colormap for model/observations

--- a/docs/tasks/climatologyMapSeaIceConcNH.rst
+++ b/docs/tasks/climatologyMapSeaIceConcNH.rst
@@ -54,6 +54,13 @@ The following configuration options are available for this task::
   # arrange subplots vertically?
   vertical = False
 
+  # observations files
+  concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+  concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+  concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+  concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+
+
 The option ``minimumLatitude`` determines what the southernmost latitude (in
 degrees) included in the plot will be.  The option ``referenceLongitude``
 defines which longitude will be at the bottom of the plot.
@@ -66,6 +73,12 @@ algorithms.  By altering ``observationPrefixes``, you can select only one
 The option ``vertical = True`` can be used to plot 3 panels one above another
 (resulting in a tall, thin image) rather than next to each other, the default
 (resulting in a short, wide image).
+
+The ability to modify observations files pointed to by
+``concentrationNASATeamNH_JFM``, ``concentrationNASATeamNH_JAS``,
+``concentrationBootstrapNH_JFM`` and ``concentrationBootstrapNH_JAS`` is
+provided for debugging purposes and these options
+should typically remain unchanged.
 
 For details on the remaining configration options, see:
  * :ref:`config_colormaps`

--- a/docs/tasks/climatologyMapSeaIceConcSH.rst
+++ b/docs/tasks/climatologyMapSeaIceConcSH.rst
@@ -54,6 +54,12 @@ The following configuration options are available for this task::
   # arrange subplots vertically?
   vertical = False
 
+  # observations files
+  concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+  concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+  concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+  concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
+
 The option ``minimumLatitude`` determines what the northernmost latitude (in
 degrees) included in the plot will be.  The option ``referenceLongitude``
 defines which longitude will be at the bottom of the plot.
@@ -66,6 +72,12 @@ algorithms.  By altering ``observationPrefixes``, you can select only one
 The option ``vertical = True`` can be used to plot 3 panels one above another
 (resulting in a tall, thin image) rather than next to each other, the default
 (resulting in a short, wide image).
+
+The ability to modify observations files pointed to by
+``concentrationNASATeamSH_DJF``, ``concentrationNASATeamSH_JJA``,
+``concentrationBootstrapSH_DJF`` and ``concentrationBootstrapSH_JJA`` is
+provided for debugging purposes and these options
+should typically remain unchanged.
 
 For details on the remaining configration options, see:
  * :ref:`config_colormaps`

--- a/docs/tasks/climatologyMapSeaIceThickNH.rst
+++ b/docs/tasks/climatologyMapSeaIceThickNH.rst
@@ -52,6 +52,10 @@ The following configuration options are available for this task::
   # arrange subplots vertically?
   vertical = False
 
+  # observations files
+  thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+  thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+
 The option ``minimumLatitude`` determines what the southernmost latitude (in
 degrees) included in the plot will be.  The option ``referenceLongitude``
 defines which longitude will be at the bottom of the plot.
@@ -63,6 +67,10 @@ string and is included for allowing easy code reuse with the
 The option ``vertical = True`` can be used to plot 3 panels one above another
 (resulting in a tall, thin image) rather than next to each other, the default
 (resulting in a short, wide image).
+
+The ability to modify observations files pointed to by ``thicknessNH_ON`` and
+``thicknessNH_FM`` is provided for debugging purposes and these options
+should typically remain unchanged.
 
 For details on the remaining configration options, see:
  * :ref:`config_colormaps`

--- a/docs/tasks/climatologyMapSeaIceThickSH.rst
+++ b/docs/tasks/climatologyMapSeaIceThickSH.rst
@@ -52,6 +52,10 @@ The following configuration options are available for this task::
   # arrange subplots vertically?
   vertical = False
 
+  # observations files
+  thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+  thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
+
 The option ``minimumLatitude`` determines what the northernmost latitude (in
 degrees) included in the plot will be.  The option ``referenceLongitude``
 defines which longitude will be at the bottom of the plot.
@@ -63,6 +67,10 @@ string and is included for allowing easy code reuse with the
 The option ``vertical = True`` can be used to plot 3 panels one above another
 (resulting in a tall, thin image) rather than next to each other, the default
 (resulting in a short, wide image).
+
+The ability to modify observations files pointed to by ``thicknessSH_ON`` and
+``thicknessSH_FM`` is provided for debugging purposes and these options
+should typically remain unchanged.
 
 For details on the remaining configration options, see:
  * :ref:`config_colormaps`

--- a/docs/tasks/indexNino34.rst
+++ b/docs/tasks/indexNino34.rst
@@ -27,7 +27,7 @@ The following configuration options are available for this task::
   region = nino3.4
 
   # Data source to read for comparison.  There are two options
-  # 1 - ERS SSTv4 -- Extended Reconstructed Sea Surface Temperature -- 1854 - 2016
+  # 1 - ERS_SSTv4 -- Extended Reconstructed Sea Surface Temperature -- 1854 - 2016
   # 2 - HADIsst -- Hadley Center analysis -- 1870 - 2016
   observationData = HADIsst
 
@@ -35,15 +35,9 @@ While the default is the El Ni |n~| o 3.4 region, you may select among
 ``nino3``, ``nino4``, and ``nino3.4``.  See :ref:`config_regions` for more
 information about regions in MPAS-Analyis.
 
-.. note::
-
-  A bug in ``indexNino34`` means that plot titles and other output will
-  indicate that El Ni |n~| o 3.4 was plotted regarless of which of the three
-  El Ni |n~| o regions was actually selected.
-
 By default, observations are taken from the Hadley Center analysis.  To use
 the Extended Reconstructed Sea Surface Temperature (ERS SSTv4), set
-``observationData = ERS SSTv4``.
+``observationData = ERS_SSTv4``.
 
 Observations
 ------------

--- a/docs/tasks/timeSeriesSalinityAnomaly.rst
+++ b/docs/tasks/timeSeriesSalinityAnomaly.rst
@@ -4,7 +4,7 @@ timeSeriesSalinityAnomaly
 =========================
 
 An analysis task for plotting a Hovmoller plot (time and depth axes) of the
-anomaly in ocean temperature from a reference year (usully the first year of
+anomaly in ocean salinity from a reference year (usully the first year of
 the simulation).
 
 Component and Tags::

--- a/docs/tasks/timeSeriesSeaIceAreaVol.rst
+++ b/docs/tasks/timeSeriesSeaIceAreaVol.rst
@@ -40,6 +40,12 @@ The following configuration options are available for this task::
 
   # yearStrideXTicks = 1
 
+  # observations files
+  areaNH = IceArea_timeseries/iceAreaNH_climo.nc
+  areaSH = IceArea_timeseries/iceAreaSH_climo.nc
+  volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
+  volSH = none
+
 ``compareWithObservations`` can be set to ``False`` to disable comparison with
 both sets of observations (see below).
 
@@ -48,6 +54,10 @@ The title font size can be customized with ``titleFontSize``, given in points.
 To produce polar plots (with time progressing clockwise around the origin and
 sea ice area or volume the distance from the origin) in addition to the
 typical time series with time on the x axis, set ``polarPlot = True``.
+
+The ability to modify observations files pointed to by ``areaNH``, ``areaSH``,
+``volNH`` and ``volSH`` is provided for debugging purposes and these options
+should typically remain unchanged.
 
 For details on the remaining config options, see:
  * :ref:`config_moving_average`

--- a/docs/tasks/timeSeriesTemperatureAnomaly.rst
+++ b/docs/tasks/timeSeriesTemperatureAnomaly.rst
@@ -18,7 +18,7 @@ Configuration Options
 The following configuration options are available for this task::
 
   [hovmollerTemperatureAnomaly]
-  ## options related to plotting time series of temperature vs. depth
+  ## options related to plotting time series of potential temperature vs. depth
 
   # list of regions to plot from the region list in [regions] below
   regions = ['global']

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -345,7 +345,7 @@ contourLevels = np.arange(-2.5, 2.6, 0.5)
 # yearStrideXTicks = 1
 
 [hovmollerTemperatureAnomaly]
-## options related to plotting time series of temperature vs. depth
+## options related to plotting time series of potential temperature vs. depth
 
 # list of regions to plot from the region list in [regions] below
 regions = ['global']
@@ -426,7 +426,7 @@ movingAveragePoints = 12
 # yearStrideXTicks = 1
 
 [indexNino34]
-## options related to plotting time series of the El Nino 3.4 index (or 
+## options related to plotting time series of the El Nino 3.4 index (or
 ## optionally El Nino 3 or 4 index)
 
 # Specified region for the Nino Index,'nino3', 'nino4', or 'nino3.4'
@@ -1088,7 +1088,7 @@ normArgsDifference = {'vmin': -2., 'vmax': 2.}
 # colorbarTicksDifference = numpy.linspace(-2., 2., 9)
 
 [climatologyMapSchmidtkoSalinity]
-## options related to plotting climatology maps of potential temperature at the
+## options related to plotting climatology maps of salinity at the
 ## seafloor and comparing them against data from Schmidtko et al. (2014)
 
 # colormap for model/observations
@@ -1110,7 +1110,7 @@ normArgsDifference = {'vmin': -0.5, 'vmax': 0.5}
 # colorbarTicksDifference = numpy.linspace(-0.5, 0.5, 9)
 
 [climatologyMapSchmidtkoPotentialDensity]
-## options related to plotting climatology maps of potential temperature at the
+## options related to plotting climatology maps of potential density at the
 ## seafloor and comparing them against data from Schmidtko et al. (2014)
 
 # colormap for model/observations

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -217,15 +217,6 @@ sshSubdirectory = SSH
 argoSubdirectory = ARGO
 schmidtkoSubdirectory = Schmidtko
 
-# first and last year of SST observational climatology (preferably one of the
-# two ranges given below)
-# values for preindustrial
-sstClimatologyStartYear = 1870
-sstClimatologyEndYear = 1900
-# alternative values for present day
-#sstClimatologyStartYear = 1990
-#sstClimatologyEndYear = 2011
-
 # interpolation order for observations. Likely values are
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
 interpolationMethod = bilinear
@@ -570,6 +561,15 @@ seasons =  ['JFM', 'JAS', 'ANN']
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
 comparisonGrids = ['latlon']
+
+# first and last year of SST observational climatology (preferably one of the
+# two ranges given below)
+# values for preindustrial
+obsStartYear = 1870
+obsEndYear = 1900
+# alternative values for present day
+#obsStartYear = 1990
+#obsEndYear = 2011
 
 [climatologyMapSSS]
 ## options related to plotting horizontally remapped climatologies of

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -672,9 +672,9 @@ colorbarTicksResult = numpy.linspace(-12., 12., 9)
 # colormap for differences
 colormapNameDifference = balance
 # color indices into colormapName for filled contours
-colormapIndicesDifference = numpy.array(numpy.linspace(0, 255, 10), int)
+colormapIndicesDifference = numpy.array(numpy.linspace(0, 255, 9), int)
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = numpy.linspace(-2., 2., 11)
+colorbarLevelsDifference = numpy.linspace(-2., 2., 10)
 
 # Months or seasons to plot (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -243,22 +243,6 @@ baseDirectory = /dir/to/ocean/reference
 
 # directory where sea ice observations are stored
 baseDirectory = /dir/to/seaice/observations
-areaNH = IceArea_timeseries/iceAreaNH_climo.nc
-areaSH = IceArea_timeseries/iceAreaSH_climo.nc
-volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
-volSH = none
-concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
-concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
-thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
-thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
-thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
-thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
 
 # interpolation order for observations. Likely values are
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
@@ -512,29 +496,6 @@ movingAveragePointsClimatological = 1
 
 # yearStrideXTicks = 1
 
-[timeSeriesSeaIceAreaVol]
-## options related to plotting time series of sea ice area and volume
-
-# compare to observations?
-compareWithObservations = True
-# Number of points over which to compute moving average (e.g., for monthly
-# output, movingAveragePoints=12 corresponds to a 12-month moving average
-# window)
-movingAveragePoints = 1
-# title font properties
-titleFontSize = 18
-# plot on polar plot
-polarPlot = False
-
-# An optional first year for the tick marks on the x axis. Leare commented out
-# to start at the beginning of the time series.
-
-# firstYearXTicks = 1
-
-# An optional number of years between tick marks on the x axis.  Leave
-# commented out to determine the distance between ticks automatically.
-
-# yearStrideXTicks = 1
 
 [climatologyMapSST]
 ## options related to plotting horizontally remapped climatologies of
@@ -1167,6 +1128,12 @@ observationPrefixes = ['NASATeam', 'Bootstrap']
 # arrange subplots vertically?
 vertical = False
 
+# observations files
+concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
+concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
+concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
+
 [climatologyMapSeaIceConcSH]
 ## options related to plotting horizontally remapped climatologies of
 ## sea ice concentration against reference model results and observations
@@ -1202,6 +1169,12 @@ observationPrefixes = ['NASATeam', 'Bootstrap']
 
 # arrange subplots vertically?
 vertical = False
+
+# observations files
+concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
+concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
+concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
 
 [climatologyMapSeaIceThickNH]
 ## options related to plotting horizontally remapped climatologies of
@@ -1239,6 +1212,10 @@ observationPrefixes = ['']
 # arrange subplots vertically?
 vertical = False
 
+# observations files
+thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
+thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
+
 [climatologyMapSeaIceThickSH]
 ## options related to plotting horizontally remapped climatologies of
 ## sea ice thickness against reference model results and observations
@@ -1274,6 +1251,40 @@ observationPrefixes = ['']
 
 # arrange subplots vertically?
 vertical = False
+
+# observations files
+thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
+thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
+
+[timeSeriesSeaIceAreaVol]
+## options related to plotting time series of sea ice area and volume
+
+# compare to observations?
+compareWithObservations = True
+# Number of points over which to compute moving average (e.g., for monthly
+# output, movingAveragePoints=12 corresponds to a 12-month moving average
+# window)
+movingAveragePoints = 1
+# title font properties
+titleFontSize = 18
+# plot on polar plot
+polarPlot = False
+
+# An optional first year for the tick marks on the x axis. Leare commented out
+# to start at the beginning of the time series.
+
+# firstYearXTicks = 1
+
+# An optional number of years between tick marks on the x axis.  Leave
+# commented out to determine the distance between ticks automatically.
+
+# yearStrideXTicks = 1
+
+# observations files
+areaNH = IceArea_timeseries/iceAreaNH_climo.nc
+areaSH = IceArea_timeseries/iceAreaSH_climo.nc
+volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
+volSH = none
 
 [regions]
 ## options related to ocean regions used in several analysis modules

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -201,6 +201,46 @@ endYear = 9999
 startYear = 1
 endYear = 9999
 
+[regions]
+## options related to ocean regions used in several analysis modules
+
+# list of region names (needs to be in the same order as region indices in
+# time-series stats)
+regions = ['arctic', 'equatorial', 'so', 'nino3', 'nino4', 'nino3.4', 'global']
+# list of plot titles (needs to be in the same order as region indices in
+# time-series stats)
+plotTitles = ['Arctic', 'Equatorial (15S-15N)', 'Southern Ocean', 'Nino 3',
+              'Nino 4', 'Nino 3.4', 'Global Ocean']
+
+# Directory for region mask files
+regionMaskDirectory = /path/to/masks/
+
+[plot]
+## options related to plotting that are the defaults across all analysis
+## modules
+
+# set to true if you want plots to be displayed (one by one) to the screen in
+# addition to being written out to png files
+# Note: displayToScreen = True seems to hang on Edison on large data sets,
+# so suggested use is just for debugging either locally or with small data sets
+displayToScreen = False
+
+# font size on axes
+axisFontSize = 16
+# title font properties
+titleFontSize = 20
+titleFontColor = black
+titleFontWeight = normal
+
+# the dots per inch of output figures
+dpi = 200
+
+[html]
+## options related to generating a webpage to display the analysis
+
+# generate the webpage?
+generate = True
+
 [oceanObservations]
 ## options related to ocean observations with which the results will be compared
 
@@ -1285,43 +1325,3 @@ areaNH = IceArea_timeseries/iceAreaNH_climo.nc
 areaSH = IceArea_timeseries/iceAreaSH_climo.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
 volSH = none
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# list of region names (needs to be in the same order as region indices in
-# time-series stats)
-regions = ['arctic', 'equatorial', 'so', 'nino3', 'nino4', 'nino3.4', 'global']
-# list of plot titles (needs to be in the same order as region indices in
-# time-series stats)
-plotTitles = ['Arctic', 'Equatorial (15S-15N)', 'Southern Ocean', 'Nino 3',
-              'Nino 4', 'Nino 3.4', 'Global Ocean']
-
-# Directory for region mask files
-regionMaskDirectory = /path/to/masks/
-
-[plot]
-## options related to plotting that are the defaults across all analysis
-## modules
-
-# set to true if you want plots to be displayed (one by one) to the screen in
-# addition to being written out to png files
-# Note: displayToScreen = True seems to hang on Edison on large data sets,
-# so suggested use is just for debugging either locally or with small data sets
-displayToScreen = False
-
-# font size on axes
-axisFontSize = 16
-# title font properties
-titleFontSize = 20
-titleFontColor = black
-titleFontWeight = normal
-
-# the dots per inch of output figures
-dpi = 200
-
-[html]
-## options related to generating a webpage to display the analysis
-
-# generate the webpage?
-generate = True

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -426,14 +426,15 @@ movingAveragePoints = 12
 # yearStrideXTicks = 1
 
 [indexNino34]
-## options related to plotting time series of the El Nino 3.4 index
+## options related to plotting time series of the El Nino 3.4 index (or 
+## optionally El Nino 3 or 4 index)
 
 # Specified region for the Nino Index,'nino3', 'nino4', or 'nino3.4'
 # The indexNino34 routine only accepts one value at a time
 region = nino3.4
 
 # Data source to read for comparison.  There are two options
-# 1 - ERS SSTv4 -- Extended Reconstructed Sea Surface Temperature -- 1854 - 2016
+# 1 - ERS_SSTv4 -- Extended Reconstructed Sea Surface Temperature -- 1854 - 2016
 # 2 - HADIsst -- Hadley Center analysis -- 1870 - 2016
 observationData = HADIsst
 

--- a/mpas_analysis/obs/make_obs_readme_bibtex.py
+++ b/mpas_analysis/obs/make_obs_readme_bibtex.py
@@ -96,11 +96,16 @@ def build_bibtex(xmlFile, outDir):
         except OSError:
             pass
 
-        bibtex = open('{}/obs.bib'.format(path), 'w')
-
-        text = cleanup(entry.findall('bibtex')[0].text.strip())
-        bibtex.write('{}\n'.format(text))
-        bibtex.close()
+        saved = False
+        bibtex = entry.findall('bibtex')
+        if len(bibtex) > 0:
+            text = cleanup(bibtex[0].text.strip())
+            if len(text) > 0:
+                saved = True
+                with open('{}/obs.bib'.format(path), 'w') as bibtexFile:
+                    bibtexFile.write('{}\n'.format(text))
+        if not saved:
+            print('Warning: no bibtex for {}'.format(name))
 
 
 if __name__ == "__main__":

--- a/mpas_analysis/obs/observational_datasets.xml
+++ b/mpas_analysis/obs/observational_datasets.xml
@@ -317,9 +317,9 @@
     </component>
     <description>
       This new version of the Roemmich-Gilson Argo Climatology extends the
-      analysis of Argo-only derived temperature and salinity fields through
-      2016. Several marginal seas and the Artic Oean have been added. The
-      analysis method is similar to what was descibed in the Progress In
+      analysis of Argo-only derived potential temperature and salinity fields
+      through 2016. Several marginal seas and the Artic Oean have been added.
+      The analysis method is similar to what was descibed in the Progress In
       Oceanography Roemmich and Gilson paper (2009). The only modification has
       been to scale the zonal equatorial correlation of the optimal estimation
       step, by 8 times, versus 4 times as in the 2009 paper. The additional

--- a/mpas_analysis/ocean/climatology_map_argo.py
+++ b/mpas_analysis/ocean/climatology_map_argo.py
@@ -34,8 +34,8 @@ from mpas_analysis.shared.mpas_xarray import mpas_xarray
 
 class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
     """
-    An analysis task for comparison of antarctic temperature against SOSE
-    fields
+    An analysis task for comparison of potential temperature against Argo
+    observations
     """
     # Authors
     # -------
@@ -108,7 +108,8 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
 
         if refConfig is None:
 
-            refTitleLabel = 'Roemmich-Gilson Argo Climatology: Temperature'
+            refTitleLabel = 'Roemmich-Gilson Argo Climatology: Potential ' \
+                            'Temperature'
 
             observationsDirectory = build_config_full_path(
                 config, 'oceanObservations', 'argoSubdirectory')
@@ -154,15 +155,15 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
 
                     subtask.set_plot_info(
                         outFileLabel=outFileLabel,
-                        fieldNameInTitle='Temperature',
+                        fieldNameInTitle='Potential Temperature',
                         mpasFieldName=mpasFieldName,
                         refFieldName=refFieldName,
                         refTitleLabel=refTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'$^\circ$C',
-                        imageCaption='Model temperature compared with Argo '
-                                     'observations',
-                        galleryGroup='Argo Temperature',
+                        imageCaption='Model potential temperature compared '
+                                     'with Argo observations',
+                        galleryGroup='Argo Potential Temperature',
                         groupSubtitle=None,
                         groupLink='tempArgo',
                         galleryName=galleryName)
@@ -175,8 +176,8 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
 
 class ClimatologyMapArgoSalinity(AnalysisTask):  # {{{
     """
-    An analysis task for comparison of Global Temperature against Argo
-    fields
+    An analysis task for comparison of global salinity against Argo
+    observations
     """
     # Authors
     # -------

--- a/mpas_analysis/ocean/climatology_map_schmidtko.py
+++ b/mpas_analysis/ocean/climatology_map_schmidtko.py
@@ -66,7 +66,7 @@ class ClimatologyMapSchmidtko(AnalysisTask):  # {{{
                 {'mpas': 'timeMonthly_avg_activeTracers_temperature',
                  'units': r'$^\circ$C',
                  'obs': 'botTheta',
-                 'title': 'Temperature'},
+                 'title': 'Potential Temperature'},
              'salinity':
                 {'mpas': 'timeMonthly_avg_activeTracers_salinity',
                  'units': r'PSU',

--- a/mpas_analysis/ocean/climatology_map_sose_temperature.py
+++ b/mpas_analysis/ocean/climatology_map_sose_temperature.py
@@ -147,14 +147,14 @@ class ClimatologyMapSoseTemperature(AnalysisTask):  # {{{
 
                     subtask.set_plot_info(
                         outFileLabel=outFileLabel,
-                        fieldNameInTitle='Temperature',
+                        fieldNameInTitle='Potential Temperature',
                         mpasFieldName=mpasFieldName,
                         refFieldName=refFieldName,
                         refTitleLabel=refTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'$^\circ$C',
-                        imageCaption='Temperature',
-                        galleryGroup='Temperature',
+                        imageCaption='Potential Temperature',
+                        galleryGroup='Potential Temperature',
                         groupSubtitle=None,
                         groupLink='tempSose',
                         galleryName=galleryName)

--- a/mpas_analysis/ocean/climatology_map_sst.py
+++ b/mpas_analysis/ocean/climatology_map_sst.py
@@ -65,10 +65,8 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
 
         sectionName = self.taskName
 
-        climStartYear = config.getint('oceanObservations',
-                                      'sstClimatologyStartYear')
-        climEndYear = config.getint('oceanObservations',
-                                    'sstClimatologyEndYear')
+        climStartYear = config.getint(sectionName, 'obsStartYear')
+        climEndYear = config.getint(sectionName, 'obsEndYear')
 
         # read in what seasons we want to plot
         seasons = config.getExpression(sectionName, 'seasons')
@@ -213,10 +211,9 @@ class RemapObservedSSTClimatology(RemapObservedClimatologySubtask):  # {{{
         # -------
         # Xylar Asay-Davis
 
-        climStartYear = self.config.getint('oceanObservations',
-                                           'sstClimatologyStartYear')
-        climEndYear = self.config.getint('oceanObservations',
-                                         'sstClimatologyEndYear')
+        sectionName = self.taskName
+        climStartYear = self.config.getint(sectionName, 'obsStartYear')
+        climEndYear = self.config.getint(sectionName, 'obsEndYear')
         timeStart = datetime.datetime(year=climStartYear, month=1, day=1)
         timeEnd = datetime.datetime(year=climEndYear, month=12, day=31)
 

--- a/mpas_analysis/ocean/time_series_temperature_anomaly.py
+++ b/mpas_analysis/ocean/time_series_temperature_anomaly.py
@@ -19,8 +19,8 @@ from mpas_analysis.ocean.plot_hovmoller_subtask import PlotHovmollerSubtask
 
 class TimeSeriesTemperatureAnomaly(AnalysisTask):
     """
-    Performs analysis of time series of temperature anomalies from the first
-    simulation year as a function of depth.
+    Performs analysis of time series of potential temperature anomalies from
+    a reference simulation year as a function of depth.
     """
     # Authors
     # -------
@@ -67,18 +67,18 @@ class TimeSeriesTemperatureAnomaly(AnalysisTask):
         self.add_subtask(anomalyTask)
 
         for regionName in regionNames:
-            caption = 'Trend of {} Temperature Anomaly vs depth'.format(
-                    regionName)
+            caption = 'Trend of {} Potential Temperature Anomaly vs ' \
+                      'Depth'.format(regionName)
             plotTask = PlotHovmollerSubtask(
                     parentTask=self,
                     regionName=regionName,
                     inFileName=timeSeriesFileName,
                     outFileLabel='TAnomalyZ',
-                    fieldNameInTitle='Temperature Anomaly',
+                    fieldNameInTitle='Potential Temperature Anomaly',
                     mpasFieldName=mpasFieldName,
                     unitsLabel='[$^\circ$C]',
                     sectionName=sectionName,
-                    thumbnailSuffix=u'ΔT',
+                    thumbnailSuffix=u'Δϴ',
                     imageCaption=caption,
                     galleryGroup='Trends vs Depth',
                     groupSubtitle=None,

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -116,8 +116,9 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
                        mpasFieldName):  # {{{
         config = self.config
         obsFieldName = 'seaIceConc'
+        sectionName = self.taskName
 
-        observationPrefixes = config.getExpression(self.taskName,
+        observationPrefixes = config.getExpression(sectionName,
                                                    'observationPrefixes')
         for prefix in observationPrefixes:
             for season in seasons:
@@ -125,10 +126,10 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
                     'Observations (SSM/I {})'.format(prefix)
 
                 obsFileName = build_config_full_path(
-                        config, 'seaIceObservations',
-                        'concentration{}{}_{}'.format(prefix,
-                                                      hemisphere,
-                                                      season))
+                        config=config, section='seaIceObservations',
+                        relativePathOption='concentration{}{}_{}'.format(
+                                prefix, hemisphere, season),
+                        relativePathSection=sectionName)
 
                 remapObservationsSubtask = RemapObservedConcClimatology(
                         parentTask=self, seasons=[season],

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -118,8 +118,10 @@ class ClimatologyMapSeaIceThick(AnalysisTask):  # {{{
         for season in seasons:
             if refConfig is None:
                 obsFileName = build_config_full_path(
-                        config, 'seaIceObservations',
-                        'thickness{}_{}'.format(hemisphere, season))
+                        config=config, section='seaIceObservations',
+                        relativePathOption='thickness{}_{}'.format(hemisphere,
+                                                                   season),
+                        relativePathSection=sectionName)
 
                 remapObservationsSubtask = RemapObservedThickClimatology(
                         parentTask=self, seasons=[season],

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -196,6 +196,8 @@ class TimeSeriesSeaIce(AnalysisTask):
         config = self.config
         calendar = self.calendar
 
+        sectionName = self.taskName
+
         plotTitles = {'iceArea': 'Sea-ice area',
                       'iceVolume': 'Sea-ice volume',
                       'iceThickness': 'Sea-ice mean thickness'}
@@ -205,18 +207,22 @@ class TimeSeriesSeaIce(AnalysisTask):
                  'iceThickness': '[m]'}
 
         obsFileNames = {
-            'iceArea': {'NH': build_config_full_path(config,
-                                                     'seaIceObservations',
-                                                     'areaNH'),
-                        'SH': build_config_full_path(config,
-                                                     'seaIceObservations',
-                                                     'areaSH')},
-            'iceVolume': {'NH': build_config_full_path(config,
-                                                       'seaIceObservations',
-                                                       'volNH'),
-                          'SH': build_config_full_path(config,
-                                                       'seaIceObservations',
-                                                       'volSH')}}
+            'iceArea': {'NH': build_config_full_path(
+                                  config=config, section='seaIceObservations',
+                                  relativePathOption='areaNH',
+                                  relativePathSection=sectionName),
+                        'SH': build_config_full_path(
+                                  config=config, section='seaIceObservations',
+                                  relativePathOption='areaSH',
+                                  relativePathSection=sectionName)},
+            'iceVolume': {'NH': build_config_full_path(
+                                   config=config, section='seaIceObservations',
+                                   relativePathOption='volNH',
+                                   relativePathSection=sectionName),
+                          'SH': build_config_full_path(
+                                   config=config, section='seaIceObservations',
+                                   relativePathOption='volSH',
+                                   relativePathSection=sectionName)}}
 
         # Some plotting rules
         titleFontSize = config.get('timeSeriesSeaIceAreaVol', 'titleFontSize')
@@ -417,14 +423,14 @@ class TimeSeriesSeaIce(AnalysisTask):
                     lineColors.append('r')
                     lineWidths.append(1.2)
 
-                if config.has_option(self.taskName, 'firstYearXTicks'):
-                    firstYearXTicks = config.getint(self.taskName,
+                if config.has_option(sectionName, 'firstYearXTicks'):
+                    firstYearXTicks = config.getint(sectionName,
                                                     'firstYearXTicks')
                 else:
                     firstYearXTicks = None
 
-                if config.has_option(self.taskName, 'yearStrideXTicks'):
-                    yearStrideXTicks = config.getint(self.taskName,
+                if config.has_option(sectionName, 'yearStrideXTicks'):
+                    yearStrideXTicks = config.getint(sectionName,
                                                      'yearStrideXTicks')
                 else:
                     yearStrideXTicks = None

--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -470,6 +470,35 @@ def wait_for_task(runningTasks, timeout=0.1):  # {{{
                 return analysisTask  # }}}
 
 
+def purge_output(config):
+    outputDirectory = config.get('output', 'baseDirectory')
+    if not os.path.exists(outputDirectory):
+        print('Output directory {} does not exist.\n'
+              'No purge necessary.'.format(outputDirectory))
+    else:
+        for subdirectory in ['plots', 'logs', 'mpasClimatology', 'mapping',
+                             'timeSeries', 'html']:
+            option = '{}Subdirectory'.format(subdirectory)
+            directory = build_config_full_path(
+                    config=config, section='output',
+                    relativePathOption=option)
+            if os.path.exists(directory):
+                print('Deleting contents of {}'.format(directory))
+                shutil.rmtree(directory)
+
+        for component in ['ocean', 'seaIce']:
+            for subdirectory in ['climatology', 'remappedClim']:
+                option = '{}Subdirectory'.format(subdirectory)
+                section = '{}Observations'.format(component)
+                directory = build_config_full_path(
+                        config=config, section='output',
+                        relativePathOption=option,
+                        relativePathSection=section)
+                if os.path.exists(directory):
+                    print('Deleting contents of {}'.format(directory))
+                    shutil.rmtree(directory)
+
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(
@@ -546,13 +575,7 @@ if __name__ == "__main__":
         refConfig = None
 
     if args.purge:
-        outputDirectory = config.get('output', 'baseDirectory')
-        if not os.path.exists(outputDirectory):
-            print('Output directory {} does not exist.\n'
-                  'No purge necessary.'.format(outputDirectory))
-        else:
-            print('Deleting contents of {}'.format(outputDirectory))
-            shutil.rmtree(outputDirectory)
+        purge_output(config)
 
     if args.generate:
         update_generate(config, args.generate)


### PR DESCRIPTION
This pull request includes some unrelated clean-up that has been piling up in the issues:
* fix some missing packages in the README
* Generalize indexNino34 to be labeled correctly if a user chooses `nino3` or `nino4` as regions (which never happens, but still...)
* Change temperature to potential temperature in many places (but not in task names, config options or tags, just in docs, comments, captions and titles)
* Move the obs paths/files from [oceanObservations] to [climatologyMapSST] and from [seaIceObservations] to the individual tasks
* Removed empty bibtex files from the documentation and they are also no longer generated by the script that generates the individual obs. README and bibtex files
* Moved [regions], [plots] and [html] toward the top of config.default so the order is now: general, component-specific, task-specific
* Following discussion with @darincomeau, made the `--purge` flag only delete directories known to MPAS-Analysis, not the entire output base directory.