### PR TITLE
Update all multifile datasets to use ncrcat

### DIFF
--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -13,7 +13,7 @@ from mpas_analysis.shared import AnalysisTask
 
 from mpas_analysis.shared.plot.plotting import timeseries_analysis_plot
 
-from mpas_analysis.shared.generalized_reader import open_multifile_dataset
+from mpas_analysis.shared.time_series import combine_time_series_with_ncrcat
 from mpas_analysis.shared.io import open_mpas_dataset
 
 from mpas_analysis.shared.timekeeping.utility import date_to_days, \
@@ -200,11 +200,16 @@ class TimeSeriesSST(AnalysisTask):
                              'run...')
             inFilesPreprocessed = '{}/SST.{}.year*.nc'.format(
                 preprocessedInputDirectory, preprocessedReferenceRunName)
-            dsPreprocessed = open_multifile_dataset(
-                fileNames=inFilesPreprocessed,
-                calendar=calendar,
-                config=config,
-                timeVariableName='xtime')
+
+            outFolder = '{}/preprocessed'.format(outputDirectory)
+            make_directories(outFolder)
+            outFileName = '{}/sst.nc'.format(outFolder)
+
+            combine_time_series_with_ncrcat(inFilesPreprocessed,
+                                            outFileName, logger=self.logger)
+            dsPreprocessed = open_mpas_dataset(fileName=outFileName,
+                                               calendar=calendar,
+                                               timeVariableNames='xtime')
             yearEndPreprocessed = days_to_datetime(dsPreprocessed.Time.max(),
                                                    calendar=calendar).year
             if yearStart <= yearEndPreprocessed:

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -24,7 +24,7 @@ from mpas_analysis.shared.timekeeping.utility import date_to_days, \
 from mpas_analysis.shared.timekeeping.MpasRelativeDelta import \
     MpasRelativeDelta
 
-from mpas_analysis.shared.generalized_reader import open_multifile_dataset
+from mpas_analysis.shared.time_series import combine_time_series_with_ncrcat
 from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
 from mpas_analysis.shared.mpas_xarray.mpas_xarray import subset_variables
 
@@ -260,25 +260,6 @@ class TimeSeriesSeaIce(AnalysisTask):
         timeEnd = date_to_days(year=yearEnd, month=12, day=31,
                                calendar=calendar)
 
-        if preprocessedReferenceRunName != 'None':
-            inFilesPreprocessed = '{}/icevol.{}.year*.nc'.format(
-                preprocessedReferenceDirectory, preprocessedReferenceRunName)
-            dsPreprocessed = open_multifile_dataset(
-                fileNames=inFilesPreprocessed,
-                calendar=calendar,
-                config=config,
-                timeVariableName='xtime')
-            preprocessedYearEnd = days_to_datetime(dsPreprocessed.Time.max(),
-                                                   calendar=calendar).year
-            if yearStart <= preprocessedYearEnd:
-                dsPreprocessedTimeSlice = \
-                    dsPreprocessed.sel(Time=slice(timeStart, timeEnd))
-            else:
-                self.logger.warning('Preprocessed time series ends before the '
-                                    'timeSeries startYear and will not be '
-                                    'plotted.')
-                preprocessedReferenceRunName = 'None'
-
         if self.refConfig is not None:
 
             dsTimeSeriesRef = {}
@@ -349,22 +330,31 @@ class TimeSeriesSeaIce(AnalysisTask):
                     key = (hemisphere, variableName)
 
             if compareWithObservations:
-                dsObs = open_multifile_dataset(
-                    fileNames=obsFileNames['iceArea'][hemisphere],
-                    calendar=calendar,
-                    config=config,
-                    timeVariableName='xtime')
+
+                outFolder = '{}/obs'.format(outputDirectory)
+                make_directories(outFolder)
+                outFileName = '{}/iceArea{}.nc'.format(outFolder, hemisphere)
+
+                combine_time_series_with_ncrcat(
+                    obsFileNames['iceArea'][hemisphere],
+                    outFileName, logger=self.logger)
+                dsObs = open_mpas_dataset(fileName=outFileName,
+                                          calendar=calendar,
+                                          timeVariableNames='xtime')
                 key = (hemisphere, 'iceArea')
                 obs[key] = self._replicate_cycle(plotVars[key], dsObs.IceArea,
                                                  calendar)
 
                 key = (hemisphere, 'iceVolume')
                 if hemisphere == 'NH':
-                    dsObs = open_multifile_dataset(
-                        fileNames=obsFileNames['iceVolume'][hemisphere],
-                        calendar=calendar,
-                        config=config,
-                        timeVariableName='xtime')
+                    outFileName = '{}/iceVolume{}.nc'.format(outFolder,
+                                                             hemisphere)
+                    combine_time_series_with_ncrcat(
+                        obsFileNames['iceVolume'][hemisphere],
+                        outFileName, logger=self.logger)
+                    dsObs = open_mpas_dataset(fileName=outFileName,
+                                              calendar=calendar,
+                                              timeVariableNames='xtime')
                     obs[key] = self._replicate_cycle(plotVars[key],
                                                      dsObs.IceVol,
                                                      calendar)
@@ -372,14 +362,20 @@ class TimeSeriesSeaIce(AnalysisTask):
                     obs[key] = None
 
             if preprocessedReferenceRunName != 'None':
+                outFolder = '{}/preprocessed'.format(outputDirectory)
+                make_directories(outFolder)
                 inFilesPreprocessed = '{}/icearea.{}.year*.nc'.format(
                     preprocessedReferenceDirectory,
                     preprocessedReferenceRunName)
-                dsPreprocessed = open_multifile_dataset(
-                    fileNames=inFilesPreprocessed,
-                    calendar=calendar,
-                    config=config,
-                    timeVariableName='xtime')
+
+                outFileName = '{}/iceArea{}.nc'.format(outFolder, hemisphere)
+
+                combine_time_series_with_ncrcat(inFilesPreprocessed,
+                                                outFileName,
+                                                logger=self.logger)
+                dsPreprocessed = open_mpas_dataset(fileName=outFileName,
+                                                   calendar=calendar,
+                                                   timeVariableNames='xtime')
                 dsPreprocessedTimeSlice = dsPreprocessed.sel(
                     Time=slice(timeStart, timeEnd))
                 key = (hemisphere, 'iceArea')
@@ -389,11 +385,14 @@ class TimeSeriesSeaIce(AnalysisTask):
                 inFilesPreprocessed = '{}/icevol.{}.year*.nc'.format(
                     preprocessedReferenceDirectory,
                     preprocessedReferenceRunName)
-                dsPreprocessed = open_multifile_dataset(
-                    fileNames=inFilesPreprocessed,
-                    calendar=calendar,
-                    config=config,
-                    timeVariableName='xtime')
+                outFileName = '{}/iceVolume{}.nc'.format(outFolder, hemisphere)
+
+                combine_time_series_with_ncrcat(inFilesPreprocessed,
+                                                outFileName,
+                                                logger=self.logger)
+                dsPreprocessed = open_mpas_dataset(fileName=outFileName,
+                                                   calendar=calendar,
+                                                   timeVariableNames='xtime')
                 dsPreprocessedTimeSlice = dsPreprocessed.sel(
                     Time=slice(timeStart, timeEnd))
                 key = (hemisphere, 'iceVolume')

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -260,6 +260,32 @@ class TimeSeriesSeaIce(AnalysisTask):
         timeEnd = date_to_days(year=yearEnd, month=12, day=31,
                                calendar=calendar)
 
+        if preprocessedReferenceRunName != 'None':
+            # determine if we're beyond the end of the preprocessed data
+            # (and go ahead and cache the data set while we're checking)
+            outFolder = '{}/preprocessed'.format(outputDirectory)
+            make_directories(outFolder)
+            inFilesPreprocessed = '{}/icevol.{}.year*.nc'.format(
+                preprocessedReferenceDirectory, preprocessedReferenceRunName)
+            outFileName = '{}/iceVolume.nc'.format(outFolder)
+
+            combine_time_series_with_ncrcat(inFilesPreprocessed,
+                                            outFileName,
+                                            logger=self.logger)
+            dsPreprocessed = open_mpas_dataset(fileName=outFileName,
+                                               calendar=calendar,
+                                               timeVariableNames='xtime')
+            preprocessedYearEnd = days_to_datetime(dsPreprocessed.Time.max(),
+                                                   calendar=calendar).year
+            if yearStart <= preprocessedYearEnd:
+                dsPreprocessedTimeSlice = \
+                    dsPreprocessed.sel(Time=slice(timeStart, timeEnd))
+            else:
+                self.logger.warning('Preprocessed time series ends before the '
+                                    'timeSeries startYear and will not be '
+                                    'plotted.')
+                preprocessedReferenceRunName = 'None'
+
         if self.refConfig is not None:
 
             dsTimeSeriesRef = {}
@@ -363,12 +389,11 @@ class TimeSeriesSeaIce(AnalysisTask):
 
             if preprocessedReferenceRunName != 'None':
                 outFolder = '{}/preprocessed'.format(outputDirectory)
-                make_directories(outFolder)
                 inFilesPreprocessed = '{}/icearea.{}.year*.nc'.format(
                     preprocessedReferenceDirectory,
                     preprocessedReferenceRunName)
 
-                outFileName = '{}/iceArea{}.nc'.format(outFolder, hemisphere)
+                outFileName = '{}/iceArea.nc'.format(outFolder)
 
                 combine_time_series_with_ncrcat(inFilesPreprocessed,
                                                 outFileName,
@@ -385,7 +410,7 @@ class TimeSeriesSeaIce(AnalysisTask):
                 inFilesPreprocessed = '{}/icevol.{}.year*.nc'.format(
                     preprocessedReferenceDirectory,
                     preprocessedReferenceRunName)
-                outFileName = '{}/iceVolume{}.nc'.format(outFolder, hemisphere)
+                outFileName = '{}/iceVolume.nc'.format(outFolder)
 
                 combine_time_series_with_ncrcat(inFilesPreprocessed,
                                                 outFileName,

--- a/mpas_analysis/shared/time_series/__init__.py
+++ b/mpas_analysis/shared/time_series/__init__.py
@@ -1,4 +1,5 @@
-from mpas_analysis.shared.time_series.time_series import cache_time_series
+from mpas_analysis.shared.time_series.time_series import cache_time_series, \
+    combine_time_series_with_ncrcat
 from mpas_analysis.shared.time_series.mpas_time_series_task import \
     MpasTimeSeriesTask
 


### PR DESCRIPTION
Some obs. and preprocessed datasets were being opened with `xarray.open_mfdataset()` function (via the the "generalized reader" in MPAS-Analysis), which sometimes led to "too many open files" errors.