### PR TITLE
Fix file prefix for sose climatology task with ref runs

### DIFF
--- a/mpas_analysis/ocean/climatology_map_sose.py
+++ b/mpas_analysis/ocean/climatology_map_sose.py
@@ -222,7 +222,7 @@ class ClimatologyMapSose(AnalysisTask):  # {{{
                 refTitleLabel = galleryName
 
                 refFieldName = field['mpas']
-                outFileLabel = 'temp'
+                outFileLabel = fieldPrefix
                 diffTitleLabel = 'Main - Reference'
 
             if field['3D']:


### PR DESCRIPTION
The file prefix was 'temp' for all variable before the fix, which meant tasks where overwriting each other's images and the resulting web page didn't make sense.