### PR TITLE
Update docs to python 3.5, simplify build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,7 +2,7 @@ name: mpas-analysis-docs
 channels:
   - conda-forge
 dependencies:
-  - python=2.7
+  - python=3.5
   - pytest
   - numpy
   - scipy

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,9 @@
 conda:
     file: docs/environment.yml
 python:
-   version: 2.7
+   version: 3.5
    setup_py_install: false
+# Build PDF
+formats:
+    - pdf
+


### PR DESCRIPTION
We're getting out-of-memory errors so trying to reduce the cost.