### PR TITLE
Update example config files; fix list of mapping files

### DIFF
--- a/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -1,0 +1,151 @@
+[runs]
+## options related to the run to be analyzed and reference runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = 20180129.DECKv1b_piControl.ne30_oEC.edison
+
+# config file for a reference run to which this run will be compared.  The
+# analysis should have already been run to completion once with this config
+# file, so that the relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid.  Leave this option commented out if no
+# reference run is desired.
+# referenceRunConfigFile = /path/to/config/file
+
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 4
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /space2/asaydavis1/example_e3sm_output/20180129.DECKv1b_piControl.ne30_oEC.edison
+
+# subdirectory containing restart files
+runSubdirectory = run
+# subdirectory for ocean history files
+oceanHistorySubdirectory = archive/ocn/hist
+# subdirectory for sea ice history files
+seaIceHistorySubdirectory = archive/ice/hist
+
+# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+mpasMeshName = oEC60to30v3
+
+# Directory for mapping files (if they have been generated already). If mapping
+# files needed by the analysis are not found here, they will be generated and
+# placed in the output mappingSubdirectory
+mappingDirectory = /space2/diagnostics/mpas_analysis/maps
+
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = run/mpas-o_in
+oceanStreamsFileName = run/streams.ocean
+seaIceNamelistFileName = run/mpas-cice_in
+seaIceStreamsFileName = run/streams.cice
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+baseDirectory = /dir/to/analysis/output
+
+# provide an absolute path to put HTML in an alternative location (e.g. a web
+# portal)
+# htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
+htmlSubdirectory = html
+
+# a list of analyses to generate.  Valid names can be seen by running:
+#   ./run_mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
+#   'all' -- all analyses will be run
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      ./run_mpas_analysis --list
+#                                   to list all task names and their tags
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    ./run_mpas_analysis config.analysis --generate \
+#         all,no_ocean,all_timeSeries
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all_publicObs', 'no_landIceCavities']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 1
+# the last year over which to average climatalogies
+endYear = 10
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+startYear = 1
+endYear = 10
+
+[index]
+## options related to producing nino index.
+
+# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
+#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
+#   of years, and is a good way of insuring that all values are used.
+# For valid statistics, index times should include at least 30 years
+startYear = 1
+endYear = 10
+
+[oceanObservations]
+## options related to ocean observations with which the results will be compared
+
+# directory where ocean observations are stored
+baseDirectory = /space2/diagnostics/observations/Ocean/
+
+[seaIceObservations]
+## options related to sea ice observations with which the results will be
+## compared
+
+# directory where sea ice observations are stored
+baseDirectory = /space2/diagnostics/observations/SeaIce
+
+[regions]
+## options related to ocean regions used in several analysis modules
+
+# Directory for region mask files
+regionMaskDirectory = /space2/diagnostics/mpas_analysis/region_masks
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning
+## circulation (MOC)
+
+# Use postprocessing script to compute the MOC? You want this to be True
+# for low-resolution simulations that use GM to parameterize eddies, because
+# the online MOC analysis member currently does not include the bolus velocity
+# in its calculation, whereas the postprocessing script does.
+# NOTE: this is a temporary option that will be removed once the online
+# MOC takes into account the bolus velocity when GM is on.
+usePostprocessingScript = True

--- a/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -3,14 +3,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = 20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
-
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = None
+mainRunName = 20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
 
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -34,15 +27,15 @@ ncclimoParallelMode = bck
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /projects/ClimateEnergy_2/azamatm/E3SM_simulations/20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta/run
+baseDirectory = /lus/theta-fs0/projects/OceanClimate_2/mpeterse/20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta/run
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
-mpasMeshName = oRRS18to6v3
+mpasMeshName = oEC60to30v3wLI
 
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /projects/ccsm/acme/diagnostics_data/mapping
+mappingDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -81,14 +74,14 @@ baseDirectory = /dir/to/analysis/output
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all', 'no_landIceCavities']
+generate = ['all']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against
 ## observations and previous runs
 
 # the first year over which to average climatalogies
-startYear = 10
+startYear = 5
 # the last year over which to average climatalogies
 endYear = 10
 
@@ -99,8 +92,8 @@ endYear = 10
 # start and end years for timeseries analysis. Using out-of-bounds values
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
-startYear = 8
-endYear = 10
+startYear = 1
+endYear = 9999
 
 [index]
 ## options related to producing nino index.
@@ -116,34 +109,14 @@ endYear = 9999
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /projects/ccsm/acme/diagnostics_data/observations/Ocean
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-ninoSubdirectory = Nino
-mhtSubdirectory = MHT
-soseSubdirectory = SOSE
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /projects/ccsm/acme/diagnostics_data/reference_runs/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/observations/Ocean
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /projects/ccsm/acme/diagnostics_data/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /projects/ccsm/acme/diagnostics_data/reference_runs/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
+baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/observations/SeaIce
 
 [timeSeriesSeaIceAreaVol]
 ## options related to plotting time series of sea ice area and volume
@@ -153,7 +126,19 @@ polarPlot = False
 
 [regions]
 # Directory containing mask files for ocean basins and ice shelves
-regionMaskDirectory = /projects/ccsm/acme/diagnostics_data/region_masks
+regionMaskDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_analysis/region_masks
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning
+## circulation (MOC)
+
+# Use postprocessing script to compute the MOC? You want this to be True
+# for low-resolution simulations that use GM to parameterize eddies, because
+# the online MOC analysis member currently does not include the bolus velocity
+# in its calculation, whereas the postprocessing script does.
+# NOTE: this is a temporary option that will be removed once the online
+# MOC takes into account the bolus velocity when GM is on.
+usePostprocessingScript = True
 
 [climatologyMapSoseTemperature]
 ## options related to plotting climatology maps of Antarctic
@@ -180,3 +165,7 @@ seasons =  ['JFM', 'JAS', 'ANN']
 # list of depths in meters (positive up) at which to analyze, 'top' for the
 # sea surface, 'bot' for the sea floor
 depths = ['top', -200, -400, -600, -800, 'bot']
+
+[timeSeriesAntarcticMelt]
+# a list of ice shelves to plot
+#iceShelvesToPlot = ['Antarctica', 'Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Filchner', 'Ronne', 'Filchner-Ronne', 'Brunt_Stancomb', 'Fimbul', 'Amery', 'Totten', 'Ross_West', 'Ross_East', 'Ross', 'Getz', 'Thwaites', 'Pine_Island', 'Abbot', 'George_VI']

--- a/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
+++ b/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
@@ -3,13 +3,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = 20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = None
+mainRunName = 20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
 
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -33,15 +27,15 @@ ncclimoParallelMode = bck
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /projects/OceanClimate/mpeterse/20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta/run
+baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/azamatm/E3SM_simulations/20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta/run
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
-mpasMeshName = oEC60to30v3wLI
+mpasMeshName = oRRS18to6v3
 
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /projects/ccsm/acme/diagnostics_data/mapping
+mappingDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -80,14 +74,14 @@ baseDirectory = /dir/to/analysis/output
 # option:
 #    ./run_mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all']
+generate = ['all', 'no_landIceCavities']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against
 ## observations and previous runs
 
 # the first year over which to average climatalogies
-startYear = 5
+startYear = 10
 # the last year over which to average climatalogies
 endYear = 10
 
@@ -98,8 +92,8 @@ endYear = 10
 # start and end years for timeseries analysis. Using out-of-bounds values
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
-startYear = 1
-endYear = 9999
+startYear = 8
+endYear = 10
 
 [index]
 ## options related to producing nino index.
@@ -115,35 +109,14 @@ endYear = 9999
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /projects/ccsm/acme/diagnostics_data/observations/Ocean
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-ninoSubdirectory = Nino
-mhtSubdirectory = MHT
-meltSubdirectory = Melt
-soseSubdirectory = SOSE
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /projects/ccsm/acme/diagnostics_data/reference_runs/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/observations/Ocean
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /projects/ccsm/acme/diagnostics_data/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /projects/ccsm/acme/diagnostics_data/reference_runs/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
+baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/observations/SeaIce
 
 [timeSeriesSeaIceAreaVol]
 ## options related to plotting time series of sea ice area and volume
@@ -153,19 +126,7 @@ polarPlot = False
 
 [regions]
 # Directory containing mask files for ocean basins and ice shelves
-regionMaskDirectory = /projects/ccsm/acme/diagnostics_data/region_masks
-
-[streamfunctionMOC]
-## options related to plotting the streamfunction of the meridional overturning
-## circulation (MOC)
-
-# Use postprocessing script to compute the MOC? You want this to be True
-# for low-resolution simulations that use GM to parameterize eddies, because
-# the online MOC analysis member currently does not include the bolus velocity
-# in its calculation, whereas the postprocessing script does.
-# NOTE: this is a temporary option that will be removed once the online
-# MOC takes into account the bolus velocity when GM is on.
-usePostprocessingScript = True
+regionMaskDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_analysis/region_masks
 
 [climatologyMapSoseTemperature]
 ## options related to plotting climatology maps of Antarctic
@@ -192,7 +153,3 @@ seasons =  ['JFM', 'JAS', 'ANN']
 # list of depths in meters (positive up) at which to analyze, 'top' for the
 # sea surface, 'bot' for the sea floor
 depths = ['top', -200, -400, -600, -800, 'bot']
-
-[timeSeriesAntarcticMelt]
-# a list of ice shelves to plot
-#iceShelvesToPlot = ['Antarctica', 'Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Filchner', 'Ronne', 'Filchner-Ronne', 'Brunt_Stancomb', 'Fimbul', 'Amery', 'Totten', 'Ross_West', 'Ross_East', 'Ross', 'Getz', 'Thwaites', 'Pine_Island', 'Abbot', 'George_VI']

--- a/configs/alcf/job_script.cooley.bash
+++ b/configs/alcf/job_script.cooley.bash
@@ -1,27 +1,21 @@
 #!/bin/bash
+#COBALT -t 1:00:00
+#COBALT -n 1
+#COBALT -A ClimateEnergy_2
+#
 # Copyright (c) 2017,  Los Alamos National Security, LLC (LANS)
 # and the University Corporation for Atmospheric Research (UCAR).
 #
 # Unless noted otherwise source code is licensed under the BSD license.
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at http://mpas-dev.github.com/license.html
-#
-#COBALT -t 1:00:00
-#COBALT -n 1
-#COBALT -A OceanClimate
-#COBALT -q debug-flat-quad
 
-export OMP_NUM_THREADS=1
-
-module unload python
-module use /projects/OceanClimate/modulefiles/all
-module load e3sm-unified/1.1.2
+source /lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/base/etc/profile.d/conda.sh
+conda activate e3sm_unified_1.2.0_py2.7_nox
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed
 run_config_file="config.run_name_here"
-# prefix to run a serial job on a single node on edison
-command_prefix="aprun -N 1 -n 1"
 # change this if not submitting this script from the directory
 # containing run_mpas_analysis
 mpas_analysis_dir="."
@@ -59,20 +53,5 @@ ncclimoParallelMode = $ncclimo_mode
 
 EOF
 
-# write a batch script to prevent issues with cobalt or aprun trying to
-# symlink run_mpas_analysis
-cat <<EOF > run_mpas_analysis.bash
-#!/bin/bash
-
-module unload python
-module use /projects/OceanClimate/modulefiles/all
-module load python/anaconda-2.7-acme
-
-$mpas_analysis_dir/run_mpas_analysis \
-    $run_config_file $job_config_file
-EOF
-
-chmod u+x run_mpas_analysis.bash
-
-$command_prefix ./run_mpas_analysis.bash
+$mpas_analysis_dir/run_mpas_analysis $run_config_file $job_config_file
 

--- a/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+++ b/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
@@ -4,12 +4,6 @@
 
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = 20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = B1850C5_ne30_v0.4
 
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -30,7 +24,7 @@ mpasMeshName = oEC60to30v3
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /lcrc/group/acme/mpas_analysis/mapping
+mappingDirectory = /lcrc/group/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -110,33 +104,14 @@ endYear = 9999
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /lcrc/group/acme/mpas_analysis/observations/Ocean
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-ninoSubdirectory = Nino
-mhtSubdirectory = MHT
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /lcrc/group/acme/mpas_analysis/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /lcrc/group/acme/diagnostics/observations/Ocean
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /lcrc/group/acme/mpas_analysis/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /lcrc/group/acme/mpas_analysis/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
+baseDirectory = /lcrc/group/acme/diagnostics/observations/SeaIce
 
 [timeSeriesSeaIceAreaVol]
 ## options related to plotting time series of sea ice area and volume
@@ -148,7 +123,7 @@ polarPlot = False
 ## options related to ocean regions used in several analysis modules
 
 # Directory for region mask files
-regionMaskDirectory = /lcrc/group/acme/mpas_analysis/region_masks 
+regionMaskDirectory = /lcrc/group/acme/diagnostics/mpas_analysis/region_masks 
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/anvil/job_script.anvil.bash
+++ b/configs/anvil/job_script.anvil.bash
@@ -18,9 +18,10 @@
 
 cd $PBS_O_WORKDIR
 
+source /lcrc/soft/climate/e3sm-unified/base/etc/profile.d/conda.sh
+conda activate e3sm_unified_1.2.0_py2.7_nox
 # needed to prevent interference with acme-unified
 unset LD_LIBRARY_PATH
-soft add +e3sm-unified-1.1.2-nox
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed
@@ -63,7 +64,7 @@ EOF
 # first, perform setup only without mpirun to create the mapping files
 $mpas_analysis_dir/run_mpas_analysis --setup_only $run_config_file \
     $job_config_file
-# next, do the full run now tht we have mapping files, but this time launching
+# next, do the full run now that we have mapping files, but this time launching
 # with mpirun
 mpirun -n 1 $mpas_analysis_dir/run_mpas_analysis $run_config_file \
     $job_config_file

--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -4,12 +4,6 @@
 
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = 20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = B1850C5_ne30_v0.4
 
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -41,7 +35,7 @@ mpasMeshName = oRRS30to10v3wLI
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /global/project/projectdirs/acme/mpas_analysis/mapping
+mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -116,78 +110,17 @@ endYear = 10
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /global/project/projectdirs/acme/observations/Ocean/
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-ninoSubdirectory = Nino
-mhtSubdirectory = MHT
-meltSubdirectory = Melt
-soseSubdirectory = SOSE
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/Ocean/
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /global/project/projectdirs/acme/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory =  /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[climatologyMapSoseTemperature]
-## options related to plotting climatology maps of Antarctic
-## potential temperature at various levels, including the sea floor against
-## reference model results and SOSE reanalysis data
-
-# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
-# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['ANN']
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface, 'bot' for the sea floor
-depths = ['top', -200, -400, -600, -800, 'bot']
-
-[climatologyMapSoseSalinity]
-## options related to plotting climatology maps of Antarctic
-## salinity at various levels, including the sea floor against
-## reference model results and SOSE reanalysis data
-
-# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
-# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['ANN']
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface, 'bot' for the sea floor
-depths = ['top', -200, -400, -600, -800, 'bot']
-
-[timeSeriesSeaIceAreaVol]
-## options related to plotting time series of sea ice area and volume
-
-# plot on polar plot
-polarPlot = False
-
-[timeSeriesAntarcticMelt]
-## options related to plotting time series of melt below Antarctic ice shelves
-
-# list of ice shelves to plot or ['all'] for all 106 ice shelves and regions.
-# See "regionNames" in the ice shelf masks file in regionMaskDirectory for
-# details.
-#iceShelvesToPlot = ['Antarctica', 'Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Filchner', 'Ronne', 'Filchner-Ronne', 'Brunt_Stancomb', 'Fimbul', 'Amery', 'Totten', 'Ross_West', 'Ross_East', 'Ross', 'Getz', 'Thwaites', 'Pine_Island', 'Abbot', 'George_VI']
+baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/SeaIce
 
 [regions]
 ## options related to ocean regions used in several analysis modules
 
 # Directory for region mask files
-regionMaskDirectory = /global/project/projectdirs/acme/mpas_analysis/region_masks
+regionMaskDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/region_masks

--- a/configs/cori/job_script.cori-haswell.bash
+++ b/configs/cori/job_script.cori-haswell.bash
@@ -28,8 +28,8 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 export OMP_NUM_THREADS=1
 
 module unload python python/base
-module use /global/project/projectdirs/acme/software/modulefiles/all
-module load e3sm-unified/1.1.2
+source /global/project/projectdirs/acme/software/anaconda_envs/cori/base/etc/profile.d/conda.sh
+conda activate e3sm_unified_1.2.0_py2.7_nox
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/cori/job_script.cori-knl.bash
+++ b/configs/cori/job_script.cori-knl.bash
@@ -28,8 +28,8 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 export OMP_NUM_THREADS=1
 
 module unload python python/base
-module use /global/project/projectdirs/acme/software/modulefiles/all
-module load e3sm-unified/1.1.2
+source /global/project/projectdirs/acme/software/anaconda_envs/cori/base/etc/profile.d/conda.sh
+conda activate e3sm_unified_1.2.0_py2.7_nox
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/edison/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/edison/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -5,13 +5,6 @@
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = 20180129.DECKv1b_piControl.ne30_oEC.edison
 
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = B1850C5_ne30_v0.4
-
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
 # file, so that the relevant MPAS climatologies already exist and have been
@@ -49,7 +42,7 @@ mpasMeshName = oEC60to30v3
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /global/project/projectdirs/acme/mpas_analysis/mapping
+mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -130,45 +123,20 @@ endYear = 10
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /global/project/projectdirs/acme/observations/Ocean/
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-ninoSubdirectory = Nino
-mhtSubdirectory = MHT
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/Ocean/
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /global/project/projectdirs/acme/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory =  /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[timeSeriesSeaIceAreaVol]
-## options related to plotting time series of sea ice area and volume
-
-# plot on polar plot
-polarPlot = False
+baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/SeaIce
 
 [regions]
 ## options related to ocean regions used in several analysis modules
 
 # Directory for region mask files
-regionMaskDirectory = /global/project/projectdirs/acme/mpas_analysis/region_masks
+regionMaskDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/region_masks
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/edison/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
+++ b/configs/edison/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
@@ -5,13 +5,6 @@
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = 20180129.DECKv1b_piControl.ne30_oEC.edison
 
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = B1850C5_ne30_v0.4
-
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
 # file, so that the relevant MPAS climatologies already exist and have been
@@ -49,7 +42,7 @@ mpasMeshName = oRRS30to10v3wLI
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /global/project/projectdirs/acme/mpas_analysis/mapping
+mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -130,50 +123,17 @@ endYear = 10
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /global/project/projectdirs/acme/observations/Ocean/
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-ninoSubdirectory = Nino
-mhtSubdirectory = MHT
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/Ocean/
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /global/project/projectdirs/acme/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory =  /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[timeSeriesSeaIceAreaVol]
-## options related to plotting time series of sea ice area and volume
-
-# plot on polar plot
-polarPlot = False
-
-[timeSeriesAntarcticMelt]
-## options related to plotting time series of melt below Antarctic ice shelves
-
-# list of ice shelves to plot or ['all'] for all 106 ice shelves and regions.
-# See "regionNames" in the ice shelf masks file in regionMaskDirectory for
-# details.
-#iceShelvesToPlot = ['Antarctica', 'Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Filchner', 'Ronne', 'Filchner-Ronne', 'Brunt_Stancomb', 'Fimbul', 'Amery', 'Totten', 'Ross_West', 'Ross_East', 'Ross', 'Getz', 'Thwaites', 'Pine_Island', 'Abbot', 'George_VI']
+baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/SeaIce
 
 [regions]
 ## options related to ocean regions used in several analysis modules
 
 # Directory for region mask files
-regionMaskDirectory = /global/project/projectdirs/acme/mpas_analysis/region_masks
+regionMaskDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/region_masks

--- a/configs/edison/config.20180514.G.oQU240wLI.edison
+++ b/configs/edison/config.20180514.G.oQU240wLI.edison
@@ -4,12 +4,6 @@
 
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = 20180514.G.oQU240wLI.edison
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = B1850C5_ne30_v0.4
 
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -48,7 +42,7 @@ seaIceHistorySubdirectory = run
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /global/project/projectdirs/acme/mpas_analysis/mapping
+mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -129,45 +123,20 @@ endYear = 9999
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /global/project/projectdirs/acme/observations/Ocean/
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-ninoSubdirectory = Nino
-mhtSubdirectory = MHT
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/Ocean/
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /global/project/projectdirs/acme/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory =  /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[timeSeriesSeaIceAreaVol]
-## options related to plotting time series of sea ice area and volume
-
-# plot on polar plot
-polarPlot = False
+baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/SeaIce
 
 [regions]
 ## options related to ocean regions used in several analysis modules
 
 # Directory for region mask files
-regionMaskDirectory = /global/project/projectdirs/acme/mpas_analysis/region_masks
+regionMaskDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/region_masks
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -4,12 +4,6 @@
 
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = B_low_res_ice_shelves_1696_JWolfe_layout_Edison
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = B1850C5_ne30_v0.4
 
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -41,7 +35,7 @@ mpasMeshName = oEC60to30v3wLI
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /global/project/projectdirs/acme/mpas_analysis/mapping
+mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -120,81 +114,20 @@ endYear = 9999
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /global/project/projectdirs/acme/observations/Ocean/
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-ninoSubdirectory = Nino
-mhtSubdirectory = MHT
-meltSubdirectory = Melt
-soseSubdirectory = SOSE
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/Ocean/
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /global/project/projectdirs/acme/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory =  /global/project/projectdirs/acme/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[climatologyMapSoseTemperature]
-## options related to plotting climatology maps of Antarctic
-## potential temperature at various levels, including the sea floor against
-## reference model results and SOSE reanalysis data
-
-# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
-# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['ANN']
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface, 'bot' for the sea floor
-depths = ['top', -200, -400, -600, -800, 'bot']
-
-[climatologyMapSoseSalinity]
-## options related to plotting climatology maps of Antarctic
-## salinity at various levels, including the sea floor against
-## reference model results and SOSE reanalysis data
-
-# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
-# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['ANN']
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface, 'bot' for the sea floor
-depths = ['top', -200, -400, -600, -800, 'bot']
-
-[timeSeriesSeaIceAreaVol]
-## options related to plotting time series of sea ice area and volume
-
-# plot on polar plot
-polarPlot = False
-
-[timeSeriesAntarcticMelt]
-## options related to plotting time series of melt below Antarctic ice shelves
-
-# list of ice shelves to plot or ['all'] for all 106 ice shelves and regions.
-# See "regionNames" in the ice shelf masks file in regionMaskDirectory for
-# details.
-#iceShelvesToPlot = ['Antarctica', 'Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Filchner', 'Ronne', 'Filchner-Ronne', 'Brunt_Stancomb', 'Fimbul', 'Amery', 'Totten', 'Ross_West', 'Ross_East', 'Ross', 'Getz', 'Thwaites', 'Pine_Island', 'Abbot', 'George_VI']
+baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/SeaIce
 
 [regions]
 ## options related to ocean regions used in several analysis modules
 
 # Directory for region mask files
-regionMaskDirectory = /global/project/projectdirs/acme/mpas_analysis/region_masks
+regionMaskDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/region_masks
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/edison/job_script.edison.bash
+++ b/configs/edison/job_script.edison.bash
@@ -28,8 +28,8 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 export OMP_NUM_THREADS=1
 
 module unload python python/base
-module use /global/project/projectdirs/acme/software/modulefiles/all
-module load e3sm-unified/1.1.2
+source /global/project/projectdirs/acme/software/anaconda_envs/edison/base/etc/profile.d/conda.sh
+conda activate e3sm_unified_1.2.0_py2.7_nox
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -4,12 +4,6 @@
 
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = MPAS-SeaIce.QU60km_polar
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = B1850C5_ne30_v0.4
 
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -30,7 +24,7 @@ mpasMeshName = QU60
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-# mappingDirectory = /dir/for/mapping/files
+mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -102,31 +96,12 @@ endYear = 9999
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/observations
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/Ocean
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/observations/SeaIce
+baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/SeaIce
 
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[timeSeriesSeaIceAreaVol]
-## options related to plotting time series of sea ice area and volume
-
-# plot on polar plot
-polarPlot = False

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -4,12 +4,6 @@
 
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = MatchBoth_orig
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = B1850C5_ne30_v0.4
 
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -30,7 +24,7 @@ mpasMeshName = oEC60to30v3
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/mapping/
+mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -106,31 +100,17 @@ endYear = 9999
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/observations
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/Ocean
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
+baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/SeaIce
 
 [regions]
 ## options related to ocean regions used in several analysis modules
 
 # Directory for region mask files
-regionMaskDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/mpas_analysis/region_masks
+regionMaskDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mpas_analysis/region_masks

--- a/configs/lanl/job_script.lanl.bash
+++ b/configs/lanl/job_script.lanl.bash
@@ -22,8 +22,8 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 export OMP_NUM_THREADS=1
 
 module unload python
-module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all/
-module load e3sm-unified/1.1.2
+source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/base/etc/profile.d/conda.sh
+conda activate e3sm_unified_1.2.0_py2.7_nox
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -4,12 +4,6 @@
 
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = 20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = B1850C5_ne30_v0.4
 
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -30,7 +24,7 @@ mpasMeshName = oEC60to30v3
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mapping/
+mappingDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/mpas_analysis/mpas
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -48,7 +42,6 @@ baseDirectory = /dir/to/analysis/output
 
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
-# htmlSubdirectory = /ccs/proj/cli115/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:
@@ -111,37 +104,20 @@ endYear = 9999
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/observations
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/milena/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
+baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/observations/Ocean
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory =  /lustre/atlas/proj-shared/cli115/milena/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
+baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/observations/SeaIce
 
 [regions]
 ## options related to ocean regions used in several analysis modules
 
 # Directory for region mask files
-regionMaskDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/region_masks/
+regionMaskDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/mpas_analysis/region_masks/
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -4,12 +4,6 @@
 
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = 20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = B1850C5_ne30_v0.4
 
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -49,7 +43,7 @@ mpasMeshName = oEC60to30v3
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mapping/
+mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mpas
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
@@ -122,16 +116,6 @@ endYear = 9999
 
 # directory where ocean observations are stored
 baseDirectory = /lustre/atlas/proj-shared/cli115/observations
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/milena/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
@@ -139,13 +123,6 @@ baseDirectory = /lustre/atlas/proj-shared/cli115/milena/ACMEv0_lowres/B1850C5_ne
 
 # directory where sea ice observations are stored
 baseDirectory = /lustre/atlas/proj-shared/cli115/observations/SeaIce
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory =  /lustre/atlas/proj-shared/cli115/milena/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
 
 [regions]
 ## options related to ocean regions used in several analysis modules

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -5,13 +5,6 @@
 # mainRunName is a name that identifies the simulation being analyzed.
 mainRunName = GMPAS-IAF_oRRS18to6v3
 
-# preprocessedReferenceRunName is the name of a reference run that has been
-# preprocessed to compare against (or None to turn off comparison).  Reference
-# runs of this type would have preprocessed results because they were not
-# performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
-preprocessedReferenceRunName = None
-
 # config file for a reference run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
 # file, so that the relevant MPAS climatologies already exist and have been
@@ -30,7 +23,7 @@ mpasMeshName = oRRS18to6v3
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory
-mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mapping
+mappingDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -49,7 +42,6 @@ baseDirectory = /dir/to/analysis/output
 
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
-# htmlSubdirectory = /ccs/proj/cli115/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:
@@ -112,66 +104,17 @@ endYear = 9999
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/observations
-sstSubdirectory = SST
-sssSubdirectory = SSS
-mldSubdirectory = MLD
-ninoSubdirectory = Nino
-mhtSubdirectory = MHT
-
-[oceanReference]
-## options related to ocean reference run with which the results will be
-## compared
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /dir/to/ocean/reference
-
-[oceanPreprocessedReference]
-## options related to preprocessed ocean reference run with which the results
-## will be compared (e.g. a POP, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /dir/to/ocean/reference
+baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/observations/Ocean
 
 [seaIceObservations]
 ## options related to sea ice observations with which the results will be
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/observations/SeaIce
-areaNH = IceArea_timeseries/iceAreaNH_climo.nc
-areaSH = IceArea_timeseries/iceAreaSH_climo.nc
-volNH = PIOMAS/PIOMASvolume_monthly_climo.nc
-volSH = none
-concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concentrationNASATeamSH_JJA = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_jja.interp0.5x0.5.nc
-concentrationBootstrapNH_JFM = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jfm.interp0.5x0.5.nc
-concentrationBootstrapNH_JAS = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_NH_jas.interp0.5x0.5.nc
-concentrationBootstrapSH_DJF = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_djf.interp0.5x0.5.nc
-concentrationBootstrapSH_JJA = SSMI/Bootstrap_NSIDC0079/SSMI_Bootstrap_gridded_concentration_SH_jja.interp0.5x0.5.nc
-thicknessNH_ON = ICESat/ICESat_gridded_mean_thickness_NH_on.interp0.5x0.5.nc
-thicknessNH_FM = ICESat/ICESat_gridded_mean_thickness_NH_fm.interp0.5x0.5.nc
-thicknessSH_ON = ICESat/ICESat_gridded_mean_thickness_SH_on.interp0.5x0.5.nc
-thicknessSH_FM = ICESat/ICESat_gridded_mean_thickness_SH_fm.interp0.5x0.5.nc
-
-[seaIceReference]
-## options related to sea ice reference run with which the results will be
-## compared
-
-# directory where sea ice reference simulation results are stored
-baseDirectory = /dir/to/seaice/reference
-
-[seaIcePreprocessedReference]
-## options related to preprocessed sea ice reference run with which the results
-## will be compared (e.g. a CICE, CESM or ACME v0 run)
-
-# directory where ocean reference simulation results are stored
-baseDirectory = /dir/to/seaice/reference
+baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/observations/SeaIce
 
 [regions]
 ## options related to ocean regions used in several analysis modules
 
 # Directory for region mask files
-regionMaskDirectory = /lustre/atlas1/cli115/proj-shared/mpas_analysis/region_masks
+regionMaskDirectory = /lustre/atlas1/proj-shared/cli115/diagnostics/mpas_analysis/region_masks

--- a/configs/olcf/job_script.olcf.bash
+++ b/configs/olcf/job_script.olcf.bash
@@ -23,8 +23,8 @@
 cd $PBS_O_WORKDIR
 
 module unload python
-module use /ccs/proj/cli127/software/modulefiles/all
-module load e3sm-unified/1.1.2
+source /ccs/proj/cli900/sw/rhea/e3sm-unified/base/etc/profile.d/conda.sh
+conda activate e3sm_unified_1.2.0_py2.7_nox
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/mpas_analysis/obs/analysis_input_files
+++ b/mpas_analysis/obs/analysis_input_files
@@ -1,12 +1,11 @@
-mpas_analysis/maps/map_oEC60to30v3_TO_0.5x0.5degree_blin.nc
+mpas_analysis/maps/map_oEC60to30v3_to_0.5x0.5degree_bilinear.nc
+mpas_analysis/maps/map_oEC60to30v3_to_6000.0x6000.0km_10.0km_Antarctic_stereo_bilinear.nc
 mpas_analysis/maps/map_obs_sss_1.0x1.0degree_to_0.5x0.5degree_bilinear.nc
 mpas_analysis/maps/map_obs_zos_1.0x1.0degree_to_0.5x0.5degree_bilinear.nc
 mpas_analysis/maps/map_obs_thetaArgo_1.0x1.0degree_to_0.5x0.5degree_bilinear.nc
 mpas_analysis/maps/map_obs_salinityArgo_1.0x1.0degree_to_0.5x0.5degree_bilinear.nc
-mpas_analysis/maps/map_oRRS30to10_TO_0.5x0.5degree_blin.160412.nc
 mpas_analysis/maps/map_obs_mld_1.0x1.0degree_to_0.5x0.5degree_bilinear.nc
 mpas_analysis/maps/map_obs_sst_1.0x1.0degree_to_0.5x0.5degree_bilinear.nc
-mpas_analysis/region_masks/oRRS30to10v3_SingleRegionAtlanticWTransportTransects_masks.nc
 mpas_analysis/region_masks/oEC60to30v3_SingleRegionAtlanticWTransportTransects_masks.nc
 observations/Ocean/SST/obs.bib
 observations/Ocean/SST/MODEL.SST.HAD187001-198110.OI198111-201203.nc


### PR DESCRIPTION
The config files are now usable from cooley and theta both.

The batch script on theta is no longer useful because of the 128 node requirement.

Example config files have been updated for all machines to:
* remove preprocessed run info
* point to the new diagnostics location (for mapping files, region masks and observations)
* remove some less commonly used sections

Example job scripts have been updated to point to e3sm-unified 1.2.0

In the list of public diagnostics data to download, the names of some mapping files have been corrected while others have been removed, since we do not plan to support the RRS30to10v3 resolution in the public release.