### PR TITLE
Disable HDF5 locking in example job scripts

### DIFF
--- a/configs/alcf/job_script.cooley.bash
+++ b/configs/alcf/job_script.cooley.bash
@@ -13,8 +13,9 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
 
-source /lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/base/etc/profile.d/conda.sh
-conda activate e3sm_unified_1.2.0_py2.7_nox
+module use /lus/theta-fs0/projects/ccsm/acme/tools/modulefiles
+module load e3sm-unified/1.2.0
+export HDF5_USE_FILE_LOCKING=FALSE
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/anvil/job_script.anvil.bash
+++ b/configs/anvil/job_script.anvil.bash
@@ -23,8 +23,10 @@ cd $PBS_O_WORKDIR
 
 source /lcrc/soft/climate/e3sm-unified/base/etc/profile.d/conda.sh
 conda activate e3sm_unified_1.2.0_py2.7_nox
+export HDF5_USE_FILE_LOCKING=FALSE
 # needed to prevent interference with acme-unified
 unset LD_LIBRARY_PATH
+
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/cori/job_script.cori-haswell.bash
+++ b/configs/cori/job_script.cori-haswell.bash
@@ -30,9 +30,10 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 
 export OMP_NUM_THREADS=1
 
-module unload python python/base
-source /global/project/projectdirs/acme/software/anaconda_envs/cori/base/etc/profile.d/conda.sh
-conda activate e3sm_unified_1.2.0_py2.7_nox
+module unload python python/base e3sm-unified
+module use /global/project/projectdirs/acme/software/modulefiles/all
+module load e3sm-unified/1.2.0
+export HDF5_USE_FILE_LOCKING=FALSE
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/cori/job_script.cori-knl.bash
+++ b/configs/cori/job_script.cori-knl.bash
@@ -30,9 +30,10 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 
 export OMP_NUM_THREADS=1
 
-module unload python python/base
-source /global/project/projectdirs/acme/software/anaconda_envs/cori/base/etc/profile.d/conda.sh
-conda activate e3sm_unified_1.2.0_py2.7_nox
+module unload python python/base e3sm-unified
+module use /global/project/projectdirs/acme/software/modulefiles/all
+module load e3sm-unified/1.2.0
+export HDF5_USE_FILE_LOCKING=FALSE
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/edison/job_script.edison.bash
+++ b/configs/edison/job_script.edison.bash
@@ -30,9 +30,10 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 
 export OMP_NUM_THREADS=1
 
-module unload python python/base
-source /global/project/projectdirs/acme/software/anaconda_envs/edison/base/etc/profile.d/conda.sh
-conda activate e3sm_unified_1.2.0_py2.7_nox
+module unload python python/base e3sm-unified
+module use /global/project/projectdirs/acme/software/modulefiles/all
+module load e3sm-unified/1.2.0
+export HDF5_USE_FILE_LOCKING=FALSE
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/job_script.default.bash
+++ b/configs/job_script.default.bash
@@ -10,6 +10,8 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
 
+export HDF5_USE_FILE_LOCKING=FALSE
+
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed
 run_config_file="config.run_name_here"

--- a/configs/lanl/job_script.lanl.bash
+++ b/configs/lanl/job_script.lanl.bash
@@ -24,9 +24,10 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 
 export OMP_NUM_THREADS=1
 
-module unload python
-source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/base/etc/profile.d/conda.sh
-conda activate e3sm_unified_1.2.0_py2.7_nox
+module unload python e3sm-unified
+module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all
+module load e3sm-unified/1.2.0
+export HDF5_USE_FILE_LOCKING=FALSE
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/olcf/job_script.olcf.bash
+++ b/configs/olcf/job_script.olcf.bash
@@ -25,9 +25,10 @@
 
 cd $PBS_O_WORKDIR
 
-module unload python
-source /ccs/proj/cli900/sw/rhea/e3sm-unified/base/etc/profile.d/conda.sh
-conda activate e3sm_unified_1.2.0_py2.7_nox
+module unload python e3sm-unified
+module use /ccs/proj/cli900/sw/rhea/modulefiles/all
+module load e3sm-unified/1.2.0
+export HDF5_USE_FILE_LOCKING=FALSE
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed


### PR DESCRIPTION
This seems to be necessary to prevent an issue with HDF5 files being locked (e.g. by `ncclimo`).  

This merge also updates the way E3SM-Unified is loaded in the job scripts to use modules instead of sourcing a setup file.  The module approach for loading the conda environment doesn't allow the use of conda commands but all other functionality of the environment seems to work as expected.