### PR TITLE
Fix error reporting on tasks

### DIFF
--- a/run_mpas_analysis
+++ b/run_mpas_analysis
@@ -415,7 +415,7 @@ def run_analysis(config, analyses):  # {{{
 
         progress.update(totalTaskCount-unfinishedCount)
 
-        if unfinishedCount <= 0:
+        if unfinishedCount <= 0 and len(runningTasks.keys()) == 0:
             # we're done
             break
 


### PR DESCRIPTION
Make sure all tasks in the `runningTasks` dictionary have been processed before finishing the tasks loop.  All tasks may be finished (either successfully or not) but we still need to loop through the tasks that have not been popped from `runningTasks` to report errors.