### PR TITLE
Transect contour plots

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1159,7 +1159,7 @@ normArgsDifference = {'vmin': -0.3, 'vmax': 0.3}
 # latitude or longitude based on which has more steps in the same direction.
 # Use 'fewestDirectionChanges' to automatically determine whether to display
 # latitude or longitude based on which has fewer changes in direction.
-upperXAxes = both
+upperXAxes = greatestExtent
 
 # The approximate number of ticks to use on the upper x axis or axes
 numUpperTicks = 8
@@ -1178,7 +1178,7 @@ upperXAxisTickLabelPrecision = 2
 # the selection of contours governed by the contourLevels parameters in
 # config sections for specific types of transects);  if False the model field
 # will be displayed as a heatmap (possibly also with contours)
-compareAsContoursOnSinglePlot = True
+compareAsContoursOnSinglePlot = False
 
 # the line style to use for contours on heatmaps and for
 # contours of the model field on contour comparison plots

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1190,7 +1190,7 @@ contourLineColor = black
 
 # the line style to use for contours of the reference field
 # on contour comparison plots
-comparisonContourLineStyle = dashed
+comparisonContourLineStyle = solid
 
 # the line color to use for contours of the reference field
 # on contour comparison plots

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -368,7 +368,7 @@ colormapName = balance
 colormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colorbar levels/values for contour boundaries
 colorbarLevels = [-2.4, -0.8, -0.4, -0.2, 0, 0.2, 0.4, 0.8, 2.4]
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevels = np.arange(-2.5, 2.6, 0.5)
 
 # An optional first year for the tick marks on the x axis. Leave commented out
@@ -398,7 +398,7 @@ colormapName = balance
 colormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
 colorbarLevels = [-1, -0.5, -0.2, -0.05, 0, 0.05, 0.2, 0.5, 1]
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevels = np.arange(-1.0, 1.26, 0.25)
 
 # An optional first year for the tick marks on the x axis. Leave commented out
@@ -429,7 +429,7 @@ colormapName = balance
 colormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
 colorbarLevels = [-0.1, -0.02, -0.003, -0.001, 0, 0.001, 0.003, 0.02, 0.1]
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevels = np.arange(-0.1, 0.11, 0.02)
 
 # An optional first year for the tick marks on the x axis. Leave commented out
@@ -491,7 +491,7 @@ colormapName = balance
 colormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colorbar levels/values for contour boundaries
 colorbarLevels = [-0.1, -0.05, -0.02, -0.01, -0.005, 0, 0.005, 0.01, 0.02, 0.05, 0.1]
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevels = [-0.1, -0.01, 0.01, 0.1]
 
 # latitude and depth limits
@@ -553,7 +553,7 @@ colormapIndicesIndoPacific = [0, 40, 80, 110, 140, 170, 200, 230, 255]
 colorbarLevelsGlobal = [-20, -10, -5, -2, 2, 5, 10, 20, 30, 40]
 colorbarLevelsAtlantic = [-10, -5, -2, 0, 5, 8, 10, 14, 18, 22]
 colorbarLevelsIndoPacific = [-10, -5, -2, 0, 5, 8, 10, 14, 18, 22]
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevelsGlobal = np.arange(-25.1, 35.1, 10)
 contourLevelsAtlantic = np.arange(-8, 20.1, 2)
 contourLevelsIndoPacific = np.arange(-8, 20.1, 2)
@@ -679,7 +679,7 @@ colorbarLevelsResult = numpy.arange(-240., 130., 10.)
 # colormap levels/values for ticks (defaults to same as levels)
 colorbarTicksResult = numpy.arange(-240., 160., 40.)
 
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevelsResult = numpy.arange(-240., 130., 10.)
 # contour line thickness
 contourThicknessResult = 0.25
@@ -1159,7 +1159,7 @@ normArgsDifference = {'vmin': -0.3, 'vmax': 0.3}
 # latitude or longitude based on which has more steps in the same direction.
 # Use 'fewestDirectionChanges' to automatically determine whether to display
 # latitude or longitude based on which has fewer changes in direction.
-upperXAxes = greatestExtent
+upperXAxes = both
 
 # The approximate number of ticks to use on the upper x axis or axes
 numUpperTicks = 8
@@ -1169,6 +1169,41 @@ numUpperTicks = 8
 # with numUpperTicks) to avoid problems with overlapping numbers along the
 # upper axis.
 upperXAxisTickLabelPrecision = 2
+
+# Whether or not to compare fields on transects by displaying their contours
+# on a single pane plot.  If True, this will be done;  if False, the fields
+# and their difference will be displayed using a three panel plot.  If there
+# is no reference field for comparison, then the model field will be displayed
+# in a single pane plot using contours only if this variable is True (with
+# the selection of contours governed by the contourLevels parameters in
+# config sections for specific types of transects);  if False the model field
+# will be displayed as a heatmap (possibly also with contours)
+compareAsContoursOnSinglePlot = True
+
+# the line style to use for contours on heatmaps and for
+# contours of the model field on contour comparison plots
+contourLineStyle = solid
+
+# the line color to use for contours on heatmaps and for
+# contours of the model field on contour comparison plots
+contourLineColor = black
+
+# the line style to use for contours of the reference field
+# on contour comparison plots
+comparisonContourLineStyle = dashed
+
+# the line color to use for contours of the reference field
+# on contour comparison plots
+comparisonContourLineColor = red
+
+# whether or not to label contours on transect heatmaps
+labelContoursOnHeatmaps = False
+
+# whether or not to label contours on contour comparison plots
+labelContoursOnContourComparisonPlots = True
+
+# the precision to use for contour labels
+contourLabelPrecision = 1
 
 
 [woceTransects]
@@ -1216,7 +1251,7 @@ normArgsResult = {'vmin': 0.0, 'vmax': 18.0}
 #colorbarLevelsResult = [0, 1, 2, 3, 4, 6, 8, 10, 14, 18]
 # place the ticks automatically by default
 # colorbarTicksResult = numpy.linspace(0.0, 18.0, 9)
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevelsResult = np.arange(1.0, 18.0, 2.0)
 
 # colormap for differences
@@ -1231,9 +1266,8 @@ normArgsDifference = {'vmin': -2.0, 'vmax': 2.0}
 #colorbarLevelsDifference = [-2, -1.5, -1.25, -1, -0.2, 0, 0.2, 1, 1.25, 1.5, 2]
 # place the ticks automatically by default
 # colorbarTicksDifference = numpy.linspace(-2.0, 2.0, 9)
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevelsDifference = np.arange(-1.8, 2.0, 0.4)
-
 
 
 [woceSalinityTransects]
@@ -1251,7 +1285,7 @@ normArgsResult = {'vmin': 33.0, 'vmax': 36.0}
 #colorbarLevelsResult = [33, 34, 34.25, 34.5, 34.6, 34.7, 34.8, 34.9, 35, 36]
 # place the ticks automatically by default
 # colorbarTicksResult = numpy.linspace(33.0, 36.0, 9)
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevelsResult = np.arange(33.3, 36.0, 0.3)
 
 # colormap for differences
@@ -1266,7 +1300,7 @@ normArgsDifference = {'vmin': -1.0, 'vmax': 1.0}
 #colorbarLevelsDifference = [-1, -0.5, -0.2, -0.05, -0.02, 0,  0.02, 0.05, 0.2, 0.5, 1]
 # place the ticks automatically by default
 # colorbarTicksDifference = numpy.linspace(-1.0, 1.0, 9)
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevelsDifference = np.arange(-0.9, 1.0, 0.4)
 
 
@@ -1352,6 +1386,8 @@ normTypeResult = linear
 normArgsResult = {'vmin': -2., 'vmax': 30.}
 # place the ticks automatically by default
 # colorbarTicksResult = numpy.linspace(-2., 2., 9)
+# contour line levels (use [] for automatic contour selection)
+contourLevelsResult = []
 
 # colormap for differences
 colormapNameDifference = balance
@@ -1361,6 +1397,8 @@ normTypeDifference = linear
 normArgsDifference = {'vmin': -2., 'vmax': 2.}
 # place the ticks automatically by default
 # colorbarTicksDifference = numpy.linspace(-2., 2., 9)
+# contour line levels (use [] for automatic contour selection)
+contourLevelsDifference = []
 
 
 [geojsonSalinityTransects]
@@ -1374,6 +1412,8 @@ normTypeResult = linear
 normArgsResult = {'vmin': 30, 'vmax': 39.0}
 # place the ticks automatically by default
 # colorbarTicksResult = numpy.linspace(34.2, 35.2, 9)
+# contour line levels (use [] for automatic contour selection)
+contourLevelsResult = []
 
 # colormap for differences
 colormapNameDifference = balance
@@ -1383,6 +1423,8 @@ normTypeDifference = linear
 normArgsDifference = {'vmin': -0.5, 'vmax': 0.5}
 # place the ticks automatically by default
 # colorbarTicksDifference = numpy.linspace(-0.5, 0.5, 9)
+# contour line levels (use [] for automatic contour selection)
+contourLevelsDifference = []
 
 
 [geojsonPotentialDensityTransects]
@@ -1396,6 +1438,8 @@ normTypeResult = linear
 normArgsResult = {'vmin': 1026.5, 'vmax': 1028.}
 # place the ticks automatically by default
 # colorbarTicksResult = numpy.linspace(1026., 1028., 9)
+# contour line levels (use [] for automatic contour selection)
+contourLevelsResult = []
 
 # colormap for differences
 colormapNameDifference = balance
@@ -1405,6 +1449,8 @@ normTypeDifference = linear
 normArgsDifference = {'vmin': -0.3, 'vmax': 0.3}
 # place the ticks automatically by default
 # colorbarTicksDifference = numpy.linspace(-0.3, 0.3, 9)
+# contour line levels (use [] for automatic contour selection)
+contourLevelsDifference = []
 
 
 [geojsonZonalVelocityTransects]
@@ -1419,6 +1465,8 @@ normTypeResult = linear
 normArgsResult = {'vmin': -0.2, 'vmax': 0.2}
 # determine the ticks automatically by default, uncomment to specify
 # colorbarTicksResult = numpy.linspace(-0.2, 0.2, 9)
+# contour line levels (use [] for automatic contour selection)
+contourLevelsResult = []
 
 # colormap for differences
 colormapNameDifference = balance
@@ -1428,6 +1476,8 @@ normTypeDifference = linear
 normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
 # determine the ticks automatically by default, uncomment to specify
 # colorbarTicksDifference = numpy.linspace(-0.2, 0.2, 9)
+# contour line levels (use [] for automatic contour selection)
+contourLevelsDifference = []
 
 
 [geojsonMeridionalVelocityTransects]
@@ -1442,6 +1492,8 @@ normTypeResult = linear
 normArgsResult = {'vmin': -0.2, 'vmax': 0.2}
 # determine the ticks automatically by default, uncomment to specify
 # colorbarTicksResult = numpy.linspace(-0.2, 0.2, 9)
+# contour line levels (use [] for automatic contour selection)
+contourLevelsResult = []
 
 # colormap for differences
 colormapNameDifference = balance
@@ -1451,6 +1503,8 @@ normTypeDifference = linear
 normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
 # determine the ticks automatically by default, uncomment to specify
 # colorbarTicksDifference = numpy.linspace(-0.2, 0.2, 9)
+# contour line levels (use [] for automatic contour selection)
+contourLevelsDifference = []
 
 
 [soseTransects]
@@ -1512,7 +1566,7 @@ normArgsResult = {'vmin': 0.0, 'vmax': 6.0}
 #colorbarLevelsResult = [0, 0.25, 0.5, 0.75, 1, 2, 3, 4, 5, 6]
 # place the ticks automatically by default
 # colorbarTicksResult = numpy.linspace(0.0, 6.0, 9)
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevelsResult = np.arange(0.5, 6.0, 1.0)
 
 # colormap for differences
@@ -1527,7 +1581,7 @@ normArgsDifference = {'vmin': -2.0, 'vmax': 2.0}
 #colorbarLevelsDifference = [-2, -1.5, -1.25, -1, -0.2, 0, 0.2, 1, 1.25, 1.5, 2]
 # place the ticks automatically by default
 # colorbarTicksDifference = numpy.linspace(-2.0, 2.0, 9)
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevelsDifference = np.arange(-1.8, 2.0, 0.4)
 
 
@@ -1546,7 +1600,7 @@ normArgsResult = {'vmin': 34.0, 'vmax': 35.0}
 #colorbarLevelsResult = [34, 34.3, 34.5, 34.65, 34.675, 34.7, 34.725, 34.75, 34.8, 35]
 # place the ticks automatically by default
 # colorbarTicksResult = numpy.linspace(34.0, 35.0, 9)
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevelsResult = np.arange(34.1, 35.0, 0.1)
 
 # colormap for differences
@@ -1561,7 +1615,7 @@ normArgsDifference = {'vmin': -0.5, 'vmax': 0.5}
 #colorbarLevelsDifference = [-0.5, -0.2, -0.1, -0.05, -0.02, 0,  0.02, 0.05, 0.1, 0.2, 0.5]
 # place the ticks automatically by default
 # colorbarTicksDifference = numpy.linspace(-0.5, 0.5, 9)
-# contour line levels
+# contour line levels (use [] for automatic contour selection)
 contourLevelsDifference = numpy.linspace(-0.6, 0.6, 9)
 
 
@@ -1576,6 +1630,7 @@ normTypeResult = linear
 normArgsResult = {'vmin': 1026.5, 'vmax': 1028.}
 # place the ticks automatically by default
 # colorbarTicksResult = numpy.linspace(1026., 1028., 9)
+# contour line levels (use [] for automatic contour selection)
 contourLevelsResult = numpy.linspace(1026.5, 1028., 7)
 
 # colormap for differences
@@ -1586,6 +1641,7 @@ normTypeDifference = linear
 normArgsDifference = {'vmin': -0.3, 'vmax': 0.3}
 # place the ticks automatically by default
 # colorbarTicksDifference = numpy.linspace(-0.3, 0.3, 9)
+# contour line levels (use [] for automatic contour selection)
 contourLevelsDifference = numpy.linspace(-0.3, 0.3, 9)
 
 
@@ -1601,6 +1657,7 @@ normTypeResult = linear
 normArgsResult = {'vmin': -0.2, 'vmax': 0.2}
 # determine the ticks automatically by default, uncomment to specify
 # colorbarTicksResult = numpy.linspace(-0.2, 0.2, 9)
+# contour line levels (use [] for automatic contour selection)
 contourLevelsResult = numpy.linspace(-0.2, 0.2, 9)
 
 # colormap for differences
@@ -1611,6 +1668,7 @@ normTypeDifference = linear
 normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
 # determine the ticks automatically by default, uncomment to specify
 # colorbarTicksDifference = numpy.linspace(-0.2, 0.2, 9)
+# contour line levels (use [] for automatic contour selection)
 contourLevelsDifference = numpy.linspace(-0.2, 0.2, 9)
 
 
@@ -1626,6 +1684,7 @@ normTypeResult = linear
 normArgsResult = {'vmin': -0.2, 'vmax': 0.2}
 # determine the ticks automatically by default, uncomment to specify
 # colorbarTicksResult = numpy.linspace(-0.2, 0.2, 9)
+# contour line levels (use [] for automatic contour selection)
 contourLevelsResult = numpy.linspace(-0.2, 0.2, 9)
 
 # colormap for differences
@@ -1636,6 +1695,7 @@ normTypeDifference = linear
 normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
 # determine the ticks automatically by default, uncomment to specify
 # colorbarTicksDifference = numpy.linspace(-0.2, 0.2, 9)
+# contour line levels (use [] for automatic contour selection)
 contourLevelsDifference = numpy.linspace(-0.2, 0.2, 9)
 
 
@@ -1651,6 +1711,7 @@ normTypeResult = linear
 normArgsResult = {'vmin': 0, 'vmax': 0.2}
 # determine the ticks automatically by default, uncomment to specify
 # colorbarTicksResult = numpy.linspace(0, 0.2, 9)
+# contour line levels (use [] for automatic contour selection)
 contourLevelsResult = numpy.linspace(0, 0.2, 9)
 
 # colormap for differences
@@ -1661,6 +1722,7 @@ normTypeDifference = linear
 normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
 # determine the ticks automatically by default, uncomment to specify
 # colorbarTicksDifference = numpy.linspace(-0.2, 0.2, 9)
+# contour line levels (use [] for automatic contour selection)
 contourLevelsDifference = numpy.linspace(-0.2, 0.2, 9)
 
 

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -22,7 +22,8 @@ from __future__ import absolute_import, division, print_function, \
 import xarray as xr
 import numpy
 
-from mpas_analysis.shared.plot.plotting import plot_vertical_section_comparison
+from mpas_analysis.shared.plot.plotting import \
+    plot_vertical_section, plot_vertical_section_comparison
 
 from mpas_analysis.shared import AnalysisTask
 
@@ -453,32 +454,66 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             raise ValueError('invalid option for upperXAxes')
 
 
-        # construct a three-panel comparison plot for the transect
+        # get the parameters determining what type of plot to use,
+        # what line styles and line colors to use, and whether and how
+        # to label contours
 
-        plot_vertical_section_comparison(config,
-                                         x,
-                                         z,
-                                         modelOutput,
-                                         refOutput,
-                                         bias,
-                                         outFileName,
-                                         configSectionName,
-                                         cbarLabel=self.unitsLabel,
-                                         xlabel=xLabel,
-                                         ylabel=yLabel,
-                                         title=title,
-                                         modelTitle='{}'.format(mainRunName),
-                                         refTitle=self.refTitleLabel,
-                                         diffTitle=self.diffTitleLabel,
-                                         secondXAxisData=self.secondXAxisData,
-                                         secondXAxisLabel=self.secondXAxisLabel,
-                                         thirdXAxisData=self.thirdXAxisData,
-                                         thirdXAxisLabel=self.thirdXAxisLabel,
-                                         numUpperTicks=numUpperTicks,
-                                         upperXAxisTickLabelPrecision=
-                                             upperXAxisTickLabelPrecision,
-                                         invertYAxis=False,
-                                         backgroundColor='#918167')
+        compareAsContours = config.getboolean('transects',
+                                              'compareAsContoursOnSinglePlot')
+
+        contourLineStyle = config.get('transects', 'contourLineStyle')
+        contourLineColor = config.get('transects', 'contourLineColor')
+        comparisonContourLineStyle = config.get('transects',
+                                                'comparisonContourLineStyle')
+        comparisonContourLineColor = config.get('transects',
+                                                'comparisonContourLineColor')
+
+        if compareAsContours:
+            labelContours = config.getboolean('transects',
+                                    'labelContoursOnContourComparisonPlots')
+        else:
+            labelContours = config.getboolean('transects',
+                                              'labelContoursOnHeatmaps')
+        
+        contourLabelPrecision = config.getint('transects',
+                                              'contourLabelPrecision')
+
+
+        # construct a three-panel comparison plot for the transect, or a
+        # single-panel contour comparison plot if compareAsContours is True
+        
+        plot_vertical_section_comparison(
+            config,
+            x,
+            z,
+            modelOutput,
+            refOutput,
+            bias,
+            outFileName,
+            configSectionName,
+            cbarLabel=self.unitsLabel,
+            xlabel=xLabel,
+            ylabel=yLabel,
+            title=title,
+            modelTitle='{}'.format(mainRunName),
+            refTitle=self.refTitleLabel,
+            diffTitle=self.diffTitleLabel,
+            secondXAxisData=self.secondXAxisData,
+            secondXAxisLabel=self.secondXAxisLabel,
+            thirdXAxisData=self.thirdXAxisData,
+            thirdXAxisLabel=self.thirdXAxisLabel,
+            numUpperTicks=numUpperTicks,
+            upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
+            invertYAxis=False,
+            backgroundColor='#918167',
+            compareAsContours=compareAsContours,
+            lineStyle=contourLineStyle,
+            lineColor=contourLineColor,
+            comparisonContourLineStyle=comparisonContourLineStyle,
+            comparisonContourLineColor=comparisonContourLineColor,
+            labelContours=labelContours,
+            contourLabelPrecision=contourLabelPrecision
+            )
 
         caption = '{} {}'.format(season, self.imageCaption)
         write_image_xml(


### PR DESCRIPTION
Added the ability to compare the model and reference fields on transects by plotting the contours of both fields on a single plot (as an alternative to the default mode of plotting the model and reference fields and their difference as heatmaps on a three panel plot).

New parameters in the [transects] section of config.default control which comparison mode (three panel plot or contour comparison plot) is used, what the line style and line color of contours are (controlled separately for the contours on heatmaps or of the model field on contour comparison plots vs. the contours of the reference field on contour comparison plots), whether to label the contours, and what precision to use for the contour labels.

These parameters can later be moved to the config.default section for specific types of transects if more granularity of control is desired.

Note that the new option to label contours also applied to the optional contours on heatmaps (controlled by a separate parameter in the [transects] section of config.default).

The ability to use zero, one, or two upper x axes -- recently implemented for heatmap transect plots -- also applies to the contour comparison plots.

A legend below the contour comparison plot indicates which contours are for the model and which are for the reference field.  If contour labels are used, the colorbar label string (typically containing the units of the field) is parenthetically appended to the legend entries.  If contour comparison plot mode is enabled and there is no comparison field, just contours of the model field are plotted.  In this case, the colorbar label string (units) is parenthetically appended to the plot title, as no legend is used.

The following galleries show some sample contour comparison plots for a few different combinations of parameters:

http://portal.nersc.gov/project/acme/streletz/1_contourComparisonPlot_no_upper_axis_contour_labels_html/ocean/index.html#woce

http://portal.nersc.gov/project/acme/streletz/2_contourComparisonPlot_greatestExtent_upper_axis_no_contour_labels_html/ocean/#woce

http://portal.nersc.gov/project/acme/streletz/3_contourComparisonPlot_both_upper_axes_contour_labels_html/ocean/#woce

Note that this PR mostly (but not entirely addresses issue #230, Add Drake Passage PD plotting).  The type of plot requested there is provided by this PR.  In order create such a plot for the Drake Passage, all that is needed is to create a GeoJSON file for the Drake Passage transect).

