### PR TITLE
Fix CI under python 2

### DIFF
--- a/mpas_analysis/test/test_mpas_config_parser.py
+++ b/mpas_analysis/test/test_mpas_config_parser.py
@@ -87,7 +87,8 @@ class TestMPASAnalysisConfigParser(TestCase):
                                     'key2': -12,
                                     'key3': False})
 
-        with self.assertRaisesRegex(
+        with six.assertRaisesRegex(
+                self,
                 configparser.NoOptionError,
                 "No option 'doesntexist' in section: 'Test'"):
             self.config.getExpression(str('Test'), str('doesntexist'))
@@ -113,7 +114,8 @@ class TestMPASAnalysisConfigParser(TestCase):
             self.assertEqual(self.config.getExpression('TestNumpy', testNumpy,
                                                        usenumpyfunc=True),
                              np.pi)
-        with self.assertRaisesRegex(
+        with six.assertRaisesRegex(
+                self,
                 AssertionError,
                 "'__' is not allowed in .* for `usenumpyfunc=True`"):
             self.config.getExpression('TestNumpy', 'testBadStr',

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -19,6 +19,7 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 import numpy
+import six
 
 import pytest
 from mpas_analysis.test import TestCase, loaddatadir
@@ -56,8 +57,8 @@ class TestMpasXarray(TestCase):
                                                 variableList=variableList)
         self.assertEqual(list(ds.data_vars.keys()), variableList)
 
-        with self.assertRaisesRegex(ValueError,
-                                    'Empty dataset is returned.'):
+        with six.assertRaisesRegex(self, ValueError,
+                                   'Empty dataset is returned.'):
             missingvars = ['foo', 'bar']
             ds = mpas_xarray.open_multifile_dataset(fileNames=fileName,
                                                     calendar=calendar,
@@ -128,9 +129,9 @@ class TestMpasXarray(TestCase):
              'refBottomDepth']
 
         selvals = {'refBottomDepth': 8.77999997138977}
-        with self.assertRaisesRegex(AssertionError,
-                                    'not a dimension in the dataset that '
-                                    'can be used for selection'):
+        with six.assertRaisesRegex(self, AssertionError,
+                                   'not a dimension in the dataset that '
+                                   'can be used for selection'):
             mpas_xarray.open_multifile_dataset(
                 fileNames=fileName,
                 calendar=calendar,

--- a/mpas_analysis/test/test_timekeeping.py
+++ b/mpas_analysis/test/test_timekeeping.py
@@ -20,6 +20,7 @@ from __future__ import absolute_import, division, print_function, \
 
 import pytest
 import datetime
+import six
 from mpas_analysis.shared.timekeeping.MpasRelativeDelta \
     import MpasRelativeDelta
 from mpas_analysis.test import TestCase
@@ -204,9 +205,9 @@ class TestTimekeeping(TestCase):
 
         # make sure there's an error when we try to add MpasRelativeDeltas
         # with different calendars
-        with self.assertRaisesRegex(ValueError,
-                                    'MpasRelativeDelta objects can only be '
-                                    'added if their calendars match.'):
+        with six.assertRaisesRegex(self, ValueError,
+                                   'MpasRelativeDelta objects can only be '
+                                   'added if their calendars match.'):
             delta1 = string_to_relative_delta('0000-01-00',
                                               calendar='gregorian')
             delta2 = string_to_relative_delta('0000-00-01',


### PR DESCRIPTION
This merge uses six to fix the naming incompatibility between python 2 and 3 for the function `assertRaiseRegex(p)`.  Without this fix, CI is failing under python 2.