### PR TITLE
Add a subtask for computing region masks on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ environment with the following packages:
  * progressbar2
  * requests
  * setuptools
+ * shapely
 
 These can be installed via the conda command:
 ``` bash
 conda install -c conda-forge numpy scipy matplotlib netCDF4 xarray dask \
     bottleneck basemap lxml nco pyproj pillow cmocean progressbar2 requests \
-    setuptools
+    setuptools shapely
 ```
 
 Then, get the code from:

--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -18,3 +18,4 @@ dependencies:
   - cmocean
   - progressbar2
   - requests
+  - shapely

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -45,6 +45,7 @@ requirements:
         - requests
         - pyproj
         - setuptools
+        - shapely
 
 about:
     home:  http://gitub.com/MPAS-Dev/MPAS-Analysis

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -282,6 +282,17 @@ Plotting
    plotting.plot_xtick_format
 
 
+Regions
+-------
+.. currentmodule:: mpas_analysis.shared.regions
+
+.. autosummary::
+   :toctree: generated/
+
+   compute_region_masks_subtask.ComputeRegionMasksSubtask
+   compute_region_masks_subtask.get_feature_list
+
+
 Timekeeping
 -----------
 .. currentmodule:: mpas_analysis.shared.timekeeping

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -534,7 +534,7 @@ def purge_output(config):
               'No purge necessary.'.format(outputDirectory))
     else:
         for subdirectory in ['plots', 'logs', 'mpasClimatology', 'mapping',
-                             'timeSeries', 'html']:
+                             'timeSeries', 'html', 'mask']:
             option = '{}Subdirectory'.format(subdirectory)
             directory = build_config_full_path(
                     config=config, section='output',

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -113,6 +113,7 @@ logsSubdirectory = logs
 mpasClimatologySubdirectory = clim/mpas
 mappingSubdirectory = mapping
 timeSeriesSubdirectory = timeseries
+maskSubdirectory = masks
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
 htmlSubdirectory = html

--- a/mpas_analysis/obs/analysis_input_files
+++ b/mpas_analysis/obs/analysis_input_files
@@ -7,6 +7,7 @@ mpas_analysis/maps/map_obs_salinityArgo_1.0x1.0degree_to_0.5x0.5degree_bilinear.
 mpas_analysis/maps/map_obs_mld_1.0x1.0degree_to_0.5x0.5degree_bilinear.nc
 mpas_analysis/maps/map_obs_sst_1.0x1.0degree_to_0.5x0.5degree_bilinear.nc
 mpas_analysis/region_masks/oEC60to30v3_SingleRegionAtlanticWTransportTransects_masks.nc
+mpas_analysis/region_masks/iceShelves.geojson
 observations/Icebergs/obs.bib
 observations/Icebergs/Altiberg/Altiberg_1991-2017.nc
 observations/Icebergs/README.md

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -62,6 +62,7 @@ def generate_html(config, analyses, refConfig=None):  # {{{
                 ComponentPage.add_image(fileName, config, components,
                                         refConfig)
             except IOError:
+                print('  missing file {}'.format(fileName))
                 missingCount += 1
 
     if missingCount > 0:

--- a/mpas_analysis/shared/regions/__init__.py
+++ b/mpas_analysis/shared/regions/__init__.py
@@ -1,0 +1,2 @@
+from mpas_analysis.shared.regions.compute_region_masks_subtask \
+    import ComputeRegionMasksSubtask, get_feature_list

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -1,0 +1,262 @@
+# This software is open source software available under the BSD-3 license.
+#
+# Copyright (c) 2018 Los Alamos National Security, LLC. All rights reserved.
+# Copyright (c) 2018 Lawrence Livermore National Security, LLC. All rights
+# reserved.
+# Copyright (c) 2018 UT-Battelle, LLC. All rights reserved.
+#
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at
+# https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+import os
+import xarray as xr
+import numpy
+import shapely.geometry
+import json
+
+from mpas_analysis.shared.analysis_task import AnalysisTask
+
+from mpas_analysis.shared.io.utility import build_config_full_path, \
+    make_directories
+from mpas_analysis.shared.io import write_netcdf
+
+from mpas_analysis.shared.mpas_xarray import mpas_xarray
+
+
+def get_feature_list(config, geojsonFileName):
+    '''
+    Builds a list of features found in the geojson file
+    '''
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+    featureList = []
+    with open(geojsonFileName) as f:
+        featureData = json.load(f)
+
+        for feature in featureData['features']:
+            name = feature['properties']['name']
+            featureList.append(name)
+    return featureList
+
+
+class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
+    '''
+    An analysis tasks for computing climatologies from output from the
+    ``timeSeriesStatsMonthly`` analysis member.
+
+    Attributes
+    ----------
+    geojsonFileName : str
+        A geojson file, typically from the MPAS ``geometric_features``
+        repository, defining the shapes to be masked
+
+    outFileSuffix : str
+        The suffix for the resulting mask file
+
+    featureList : list of str
+        A list of features to include or ``None`` for all features
+
+    maskFileName : str
+        The name of the output mask file
+
+    maskExists : bool
+        Whether the mask file already exists
+
+    '''
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    def __init__(self, parentTask, geojsonFileName, outFileSuffix,
+                 featureList=None, subtaskName='computeRegionMasks'):
+        # {{{
+        '''
+        Construct the analysis task and adds it as a subtask of the
+        ``parentTask``.
+
+        Parameters
+        ----------
+        parentTask :  ``AnalysisTask``
+            The parent task, used to get the ``taskName``, ``config`` and
+            ``componentName``
+
+        geojsonFileName : str
+            A geojson file, typically from the MPAS ``geometric_features``
+            repository, defining the shapes to be masked
+
+        outFileSuffix : str
+            The suffix for the resulting mask file
+
+        featureList : list of str, optional
+            A list of features to include.  Default is all features in all
+            files
+
+        subtaskName : str, optional
+            The name of the subtask
+
+        '''
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        # call the constructor from the base class (AnalysisTask)
+        super(ComputeRegionMasksSubtask, self).__init__(
+            config=parentTask.config,
+            taskName=parentTask.taskName,
+            subtaskName=subtaskName,
+            componentName=parentTask.componentName,
+            tags=[])
+
+        self.geojsonFileName = geojsonFileName
+        self.outFileSuffix = outFileSuffix
+        self.featureList = featureList
+
+        parentTask.add_subtask(self)
+
+        # }}}
+
+    def setup_and_check(self):  # {{{
+        '''
+        Perform steps to set up the analysis and check for errors in the setup.
+
+        Raises
+        ------
+        IOError :
+            If a restart file is not available from which to read mesh
+            information or if no history files are available from which to
+            compute the climatology in the desired time range.
+        '''
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        # first, call setup_and_check from the base class (AnalysisTask),
+        # which will perform some common setup, including storing:
+        #     self.runDirectory , self.historyDirectory, self.plotsDirectory,
+        #     self.namelist, self.runStreams, self.historyStreams,
+        #     self.calendar
+        super(ComputeRegionMasksSubtask, self).setup_and_check()
+
+        try:
+            self.restartFileName = self.runStreams.readpath('restart')[0]
+        except ValueError:
+            raise IOError('No MPAS restart file found: need at least one '
+                          'restart file to perform remapping of '
+                          'climatologies.')
+
+        maskSubdirectory = build_config_full_path(self.config, 'output',
+                                                  'maskSubdirectory')
+        make_directories(maskSubdirectory)
+
+        if self.featureList is None:
+            # get a list of features for use by other tasks (e.g. to determine
+            # plot names)
+            self.featureList = get_feature_list(self.config,
+                                                self.geojsonFileName)
+
+        mpasMeshName = self.config.get('input', 'mpasMeshName')
+
+        # first, see if we have cached a mask file name in the region masks
+        # directory
+        regionMaskDirectory = build_config_full_path(self.config,
+                                                     'regions',
+                                                     'regionMaskDirectory')
+        self.maskFileName = '{}/{}_{}.nc'.format(regionMaskDirectory,
+                                                 mpasMeshName,
+                                                 self.outFileSuffix)
+
+        if os.path.exists(self.maskFileName):
+            self.maskExists = True
+        else:
+            # no cached mask file, so let's see if there's already one in the
+            # masks subfolder of the output directory
+
+            maskSubdirectory = build_config_full_path(self.config, 'output',
+                                                      'maskSubdirectory')
+            self.maskFileName = '{}/{}_{}.nc'.format(maskSubdirectory,
+                                                     mpasMeshName,
+                                                     self.outFileSuffix)
+
+            self.maskExists = os.path.exists(self.maskFileName)
+
+        # }}}
+
+    def run_task(self):  # {{{
+        '''
+        Compute the requested climatologies
+        '''
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        if self.maskExists:
+            return
+
+        self.logger.info('Creating masks file {}'.format(self.maskFileName))
+
+        with xr.open_dataset(self.restartFileName) as dsRestart:
+            dsRestart = mpas_xarray.subset_variables(dsRestart,
+                                                     ['lonCell', 'latCell'])
+            latCell = numpy.rad2deg(dsRestart.latCell.values)
+
+            # transform longitudes to [-180, 180)
+            lonCell = numpy.mod(numpy.rad2deg(dsRestart.lonCell.values) + 180.,
+                                360.) - 180.
+
+        # create shapely geometry for lonCell and latCell
+        cellPoints = [shapely.geometry.Point(x, y) for x, y in
+                      zip(lonCell, latCell)]
+
+        nCells = len(cellPoints)
+
+        masks = []
+        regionNames = []
+        nChar = 0
+        self.logger.info('  Computing masks from {}...'.format(
+                self.geojsonFileName))
+        with open(self.geojsonFileName) as f:
+            featureData = json.load(f)
+
+        for feature in featureData['features']:
+            name = feature['properties']['name']
+            if name not in self.featureList:
+                continue
+
+            self.logger.info('      {}'.format(name))
+
+            shape = shapely.geometry.shape(feature['geometry'])
+            mask = numpy.array([shape.contains(point) for point
+                                in cellPoints], dtype=bool)
+
+            nChar = max(nChar, len(name))
+
+            masks.append(mask)
+            regionNames.append(name)
+
+        # create a new data array for masks and another for mask names
+        self.logger.info('  Creating and writing masks dataset...')
+        nRegions = len(regionNames)
+        dsMasks = xr.Dataset()
+        dsMasks['masks'] = (('nRegions', 'nCells'),
+                            numpy.zeros((nRegions, nCells), dtype=bool))
+        dsMasks['regionNames'] = (('nRegions'),
+                                  numpy.zeros((nRegions),
+                                              dtype='|S{}'.format(nChar)))
+        for index in range(nRegions):
+            regionName = regionNames[index]
+            mask = masks[index]
+            dsMasks['regionCellMasks'][index, :] = mask
+            dsMasks['regionNames'][index] = regionName
+
+        write_netcdf(dsMasks, self.maskFileName)
+
+        # }}}
+
+    # }}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
The new subtask, `ComputeRegionMasksSubtask`, takes a geojson file name and an optional list of features from that file to compute masks from.  As before, a mask file can, instead, be provided in the the directory pointed to by the config option `[region]/regionMasksDirectory`.  This can either be a file created by a previous run of MPAS-Analysis or one generated from `MpasMaskCreator.x` in the MPAS-Tools repo.

I updated the `TimeSeriesAntarcticMelt` task to make use of this subtask.  This means that new meshes with land-ice cavities will not need pre-generated region masks before melt time series can be plotted.