### PR TITLE
Break the MOC into several subtasks

### DIFF
--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -43,6 +43,8 @@ from mpas_analysis.shared.io.utility import build_config_full_path, \
 from mpas_analysis.shared.html import generate_html
 
 from mpas_analysis.shared import AnalysisTask
+from mpas_analysis.shared.analysis_task import \
+    update_time_bounds_from_file_names
 
 from mpas_analysis.shared.plot.plotting import _register_custom_colormaps, \
     _plot_color_gradients
@@ -54,6 +56,26 @@ from mpas_analysis.shared.climatology import MpasClimatologyTask, \
 from mpas_analysis.shared.time_series import MpasTimeSeriesTask
 
 from mpas_analysis.shared.io.download import download_files
+
+
+def update_time_bounds_in_config(config):  # {{{
+    """
+    Updates the start and end year (and associated full date) for
+    climatologies, time series and climate indices based on the files that are
+    actually available.
+
+    Parameters
+    ----------
+    config : ``MpasAnalysisConfigParser`` object
+        contains config options
+
+    """
+    # By updating the bounds for each component, we should end up with the
+    # more constrained time bounds if any component has less output than others
+    for componentName in ['ocean', 'seaIce']:
+        for section in ['climatology', 'timeSeries', 'index']:
+            update_time_bounds_from_file_names(config, section, componentName)
+    # }}}
 
 
 def build_analysis_list(config, refConfig):  # {{{
@@ -662,6 +684,8 @@ def main():
     logsDirectory = build_config_full_path(config, 'output',
                                            'logsSubdirectory')
     make_directories(logsDirectory)
+
+    update_time_bounds_in_config(config)
 
     analyses = build_analysis_list(config, refConfig)
     analyses = determine_analyses_to_generate(analyses)

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -548,44 +548,6 @@ usePostprocessingScript = False
 # Supported options are Atlantic and IndoPacific
 regionNames = ['Atlantic']
 
-# Minium value of latitudinal extent for MOC streamfunction plot
-latBinMinGlobal = -80.
-latBinMinAtlantic = -35.
-latBinMinIndoPacific = -80.
-
-# Maximum value of latitudinal extent for MOC streamfunction plot
-latBinMaxGlobal = 80.
-latBinMaxAtlantic = 70.
-latBinMaxIndoPacific = 70.
-
-# Size of latitude bins over which MOC streamfunction is integrated
-# (this is only relevant for the postprocessing MOC script)
-latBinSizeGlobal = 1.
-latBinSizeAtlantic = 0.5
-latBinSizeIndoPacific = 0.5
-
-# colormap for model results
-colormapNameGlobal = RdYlBu_r
-colormapNameAtlantic = RdYlBu_r
-colormapNameIndoPacific = RdYlBu_r
-# whether the colormap is indexed or continuous
-colormapTypeGlobal = indexed
-colormapTypeAtlantic = indexed
-colormapTypeIndoPacific = indexed
-# colormap indices for contour color
-colormapIndicesGlobal = [0, 40, 80, 110, 140, 170, 200, 230, 255]
-colormapIndicesAtlantic = [0, 40, 80, 110, 140, 170, 200, 230, 255]
-colormapIndicesIndoPacific = [0, 40, 80, 110, 140, 170, 200, 230, 255]
-# colorbar levels/values for contour boundaries
-colorbarLevelsGlobal = [-20, -10, -5, -2, 2, 5, 10, 20, 30, 40]
-colorbarLevelsAtlantic = [-10, -5, -2, 0, 5, 8, 10, 14, 18, 22]
-colorbarLevelsIndoPacific = [-10, -5, -2, 0, 5, 8, 10, 14, 18, 22]
-# contour line levels (use [] for automatic contour selection, 'none' for no
-# contour lines)
-contourLevelsGlobal = np.arange(-25.1, 35.1, 10)
-contourLevelsAtlantic = np.arange(-8, 20.1, 2)
-contourLevelsIndoPacific = np.arange(-8, 20.1, 2)
-
 # Number of points over which to compute moving average for
 # MOC timeseries (e.g., for monthly output, movingAveragePoints=12
 # corresponds to a 12-month moving average window)
@@ -604,6 +566,114 @@ movingAveragePointsClimatological = 1
 # commented out to determine the distance between ticks automatically.
 
 # yearStrideXTicks = 1
+
+[streamfunctionMOCGlobal]
+## options related to plotting the Global MOC
+
+# Minium value of latitudinal extent for MOC streamfunction plot
+latBinMin = -80.
+# Maximum value of latitudinal extent for MOC streamfunction plot
+latBinMax = 80.
+# Size of latitude bins over which MOC streamfunction is integrated
+# (this is only relevant for the postprocessing MOC script)
+latBinSize = 1.
+
+# colormap for model results
+colormapNameResult = RdYlBu_r
+# whether the colormap is indexed or continuous
+colormapTypeResult = indexed
+# colormap indices for contour color
+colormapIndicesResult = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+# colorbar levels/values for contour boundaries
+colorbarLevelsResult = [-20, -10, -5, -2, 2, 5, 10, 20, 30, 40]
+# contour line levels (use [] for automatic contour selection, 'none' for no
+# contour lines)
+contourLevelsResult = np.arange(-25.1, 35.1, 10)
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = indexed
+# colormap indices for contour color
+# color indices into colormapName for filled contours
+colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsDifference = [-5, -3, -2, -1, -0.1, 0, 0.1, 1, 2, 3, 5]
+# contour line levels (use [] for automatic contour selection, 'none' for no
+# contour lines)
+contourLevelsDifference = np.arange(-5., 6., 2.)
+
+[streamfunctionMOCAtlantic]
+## options related to plotting the Global MOC
+
+# Minium value of latitudinal extent for MOC streamfunction plot
+latBinMin = -35.
+# Maximum value of latitudinal extent for MOC streamfunction plot
+latBinMax = 70.
+# Size of latitude bins over which MOC streamfunction is integrated
+# (this is only relevant for the postprocessing MOC script)
+latBinSize = 0.5
+
+# colormap for model results
+colormapNameResult = RdYlBu_r
+# whether the colormap is indexed or continuous
+colormapTypeResult = indexed
+# colormap indices for contour color
+colormapIndicesResult = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+# colorbar levels/values for contour boundaries
+colorbarLevelsResult = [-10, -5, -2, 0, 5, 8, 10, 14, 18, 22]
+# contour line levels (use [] for automatic contour selection, 'none' for no
+# contour lines)
+contourLevelsResult = np.arange(-8, 20.1, 2)
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = indexed
+# colormap indices for contour color
+# color indices into colormapName for filled contours
+colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsDifference = [-5, -3, -2, -1, -0.1, 0, 0.1, 1, 2, 3, 5]
+# contour line levels (use [] for automatic contour selection, 'none' for no
+# contour lines)
+contourLevelsDifference = np.arange(-5., 6., 2.)
+
+[streamfunctionMOCIndoPacific]
+## options related to plotting the Global MOC
+
+# Minium value of latitudinal extent for MOC streamfunction plot
+latBinMin = -80.
+# Maximum value of latitudinal extent for MOC streamfunction plot
+latBinMax = 70.
+# Size of latitude bins over which MOC streamfunction is integrated
+# (this is only relevant for the postprocessing MOC script)
+latBinSize = 0.5
+
+# colormap for model results
+colormapNameResult = RdYlBu_r
+# whether the colormap is indexed or continuous
+colormapTypeResult = indexed
+# colormap indices for contour color
+colormapIndicesResult = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+# colorbar levels/values for contour boundaries
+colorbarLevelsResult = [-10, -5, -2, 0, 5, 8, 10, 14, 18, 22]
+# contour line levels (use [] for automatic contour selection, 'none' for no
+# contour lines)
+contourLevelsResult = np.arange(-8, 20.1, 2)
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = indexed
+# colormap indices for contour color
+# color indices into colormapName for filled contours
+colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsDifference = [-5, -3, -2, -1, -0.1, 0, 0.1, 1, 2, 3, 5]
+# contour line levels (use [] for automatic contour selection, 'none' for no
+# contour lines)
+contourLevelsDifference = np.arange(-5., 6., 2.)
 
 
 [climatologyMapSST]

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -126,12 +126,13 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
 
         self.sectionName = 'streamfunctionMOC'
 
-        self.usePostprocessing = config.getExpression(self.sectionName,
-                                                      'usePostprocessingScript')
+        self.usePostprocessing = config.getExpression(
+                self.sectionName, 'usePostprocessingScript')
 
         if not self.usePostprocessing and self.mocAnalysisMemberEnabled:
-            self.variableList = ['timeMonthly_avg_mocStreamvalLatAndDepth',
-                                 'timeMonthly_avg_mocStreamvalLatAndDepthRegion']
+            self.variableList = \
+                ['timeMonthly_avg_mocStreamvalLatAndDepth',
+                 'timeMonthly_avg_mocStreamvalLatAndDepthRegion']
         else:
             self.variableList = ['timeMonthly_avg_normalVelocity',
                                  'timeMonthly_avg_vertVelocityTop']
@@ -219,9 +220,9 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
             z = self.moc[region]
             # Subset lat range
             minLat = config.getExpression(self.sectionName,
-                                         'latBinMin{}'.format(region))
+                                          'latBinMin{}'.format(region))
             maxLat = config.getExpression(self.sectionName,
-                                         'latBinMax{}'.format(region))
+                                          'latBinMax{}'.format(region))
             indLat = np.logical_and(x >= minLat, x <= maxLat)
             x = x[indLat]
             z = z[:, indLat]
@@ -417,8 +418,10 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
 
             # rename some variables for convenience
             annualClimatology = annualClimatology.rename(
-                {'timeMonthly_avg_mocStreamvalLatAndDepth': 'avgMocStreamfunGlobal',
-                 'timeMonthly_avg_mocStreamvalLatAndDepthRegion': 'avgMocStreamfunRegional'})
+                {'timeMonthly_avg_mocStreamvalLatAndDepth':
+                    'avgMocStreamfunGlobal',
+                 'timeMonthly_avg_mocStreamvalLatAndDepthRegion':
+                     'avgMocStreamfunRegional'})
 
             # Create dictionary for MOC climatology (NB: need this form
             # in order to convert it to xarray dataset later in the script)
@@ -432,7 +435,8 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
                 else:
                     # hard-wire region=0 (Atlantic) for now
                     indRegion = 0
-                    mocTop = annualClimatology.avgMocStreamfunRegional[indRegion, :, :].values
+                    mocVar = annualClimatology.avgMocStreamfunRegional
+                    mocTop = mocVar[indRegion, :, :].values
                 # Store computed MOC to dictionary
                 self.lat[region] = binBoundaryMocStreamfunction
                 self.moc[region] = mocTop
@@ -485,7 +489,8 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
         '''compute MOC time series from analysis member'''
 
         # Compute and plot time series of Atlantic MOC at 26.5N (RAPID array)
-        self.logger.info('\n  Compute Atlantic MOC time series from analysis member...')
+        self.logger.info('\n  Compute Atlantic MOC time series from analysis '
+                         'member...')
         self.logger.info('   Load data...')
 
         outputDirectory = build_config_full_path(self.config, 'output',
@@ -587,7 +592,8 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
 
             # hard-wire region=0 (Atlantic) for now
             indRegion = 0
-            mocTop = dsLocal.timeMonthly_avg_mocStreamvalLatAndDepthRegion[indRegion, :, :].values
+            mocVar = dsLocal.timeMonthly_avg_mocStreamvalLatAndDepthRegion
+            mocTop = mocVar[indRegion, :, :].values
             mocRegion[timeIndex] = np.amax(mocTop[:, indlat26])
 
         description = 'Max MOC Atlantic streamfunction nearest to RAPID ' \

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -822,8 +822,9 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
                          'member...')
         self.logger.info('   Load data...')
 
-        outputDirectory = build_config_full_path(self.config, 'output',
-                                                 'timeseriesSubdirectory')
+        outputDirectory = '{}/moc/'.format(
+                build_config_full_path(self.config, 'output',
+                                       'timeseriesSubdirectory'))
         try:
             os.makedirs(outputDirectory)
         except OSError:

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -210,7 +210,6 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
                           '{}.'.format(streamName, self.startDate,
                                        self.endDate))
 
-        self._update_climatology_bounds()
         self.symlinkDirectory = self._create_symlinks()
 
         with xarray.open_dataset(self.inputFiles[0]) as ds:
@@ -313,60 +312,6 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         return get_unmasked_mpas_climatology_file_name(self.config, season,
                                                        self.componentName)
 
-        # }}}
-
-    def _update_climatology_bounds(self):  # {{{
-        """
-        Update the start and end years and dates for climatologies based on the
-        years actually available in the list of files.
-        """
-        # Authors
-        # -------
-        # Xylar Asay-Davis
-
-        config = self.config
-
-        requestedStartYear = self.startYear
-        requestedEndYear = self.endYear
-
-        fileNames = sorted(self.inputFiles)
-        years, months = get_files_year_month(fileNames,
-                                             self.historyStreams,
-                                             'timeSeriesStatsMonthlyOutput')
-
-        # search for the start of the first full year
-        firstIndex = 0
-        while(firstIndex < len(years) and months[firstIndex] != 1):
-            firstIndex += 1
-        startYear = years[firstIndex]
-
-        # search for the end of the last full year
-        lastIndex = len(years)-1
-        while(lastIndex >= 0 and months[lastIndex] != 12):
-            lastIndex -= 1
-        endYear = years[lastIndex]
-
-        startDate = '{:04d}-01-01_00:00:00'.format(startYear)
-        endDate = '{:04d}-12-31_23:59:59'.format(endYear)
-
-        if startYear != requestedStartYear or endYear != requestedEndYear:
-            print("Warning: climatology start and/or end year different from "
-                  "requested\n"
-                  "requestd: {:04d}-{:04d}\n"
-                  "actual:   {:04d}-{:04d}\n".format(requestedStartYear,
-                                                     requestedEndYear,
-                                                     startYear,
-                                                     endYear))
-
-            config.set('climatology', 'startYear', str(startYear))
-            config.set('climatology', 'startDate', startDate)
-            config.set('climatology', 'endYear', str(endYear))
-            config.set('climatology', 'endDate', endDate)
-
-        self.startDate = startDate
-        self.endDate = endDate
-        self.startYear = startYear
-        self.endYear = endYear
         # }}}
 
     def _create_symlinks(self):  # {{{

--- a/mpas_analysis/shared/climatology/ref_year_mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/ref_year_mpas_climatology_task.py
@@ -12,11 +12,8 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-import sys
-if sys.version_info[0] == 3:
-    from io import StringIO
-else:
-    from io import BytesIO as StringIO
+from six import StringIO
+
 from mpas_analysis.configuration import MpasAnalysisConfigParser
 
 from mpas_analysis.shared.climatology import MpasClimatologyTask

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -185,8 +185,6 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
             raise IOError('No files were found in stream {} between {} and '
                           '{}.'.format(streamName, startDate, endDate))
 
-        self._update_time_series_bounds_from_file_names()
-
         self.runMessage = '\nComputing MPAS time series from first year ' \
                           'plus files:\n' \
                           '    {} through\n    {}'.format(
@@ -232,65 +230,6 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         self.logger.info(self.runMessage)
 
         self._compute_time_series_with_ncrcat()
-
-        # }}}
-
-    def _update_time_series_bounds_from_file_names(self):  # {{{
-        """
-        Update the start and end years and dates for time series based on the
-        years actually available in the list of files.
-        """
-        # Authors
-        # -------
-        # Xylar Asay-Davis
-
-        config = self.config
-        section = self.section
-
-        requestedStartYear = config.getint(section, 'startYear')
-        requestedEndYear = config.getint(section, 'endYear')
-
-        fileNames = sorted(self.inputFiles)
-        years, months = get_files_year_month(fileNames,
-                                             self.historyStreams,
-                                             'timeSeriesStatsMonthlyOutput')
-
-        # search for the start of the first full year
-        firstIndex = 0
-        while(firstIndex < len(years) and months[firstIndex] != 1):
-            firstIndex += 1
-        startYear = years[firstIndex]
-
-        # search for the end of the last full year
-        lastIndex = len(years)-1
-        while(lastIndex >= 0 and months[lastIndex] != 12):
-            lastIndex -= 1
-        endYear = years[lastIndex]
-
-        if startYear != requestedStartYear or endYear != requestedEndYear:
-            print("Warning: {} start and/or end year different from "
-                  "requested\n"
-                  "requestd: {:04d}-{:04d}\n"
-                  "actual:   {:04d}-{:04d}\n".format(section,
-                                                     requestedStartYear,
-                                                     requestedEndYear,
-                                                     startYear,
-                                                     endYear))
-            config.set(section, 'startYear', str(startYear))
-            config.set(section, 'endYear', str(endYear))
-
-            startDate = '{:04d}-01-01_00:00:00'.format(startYear)
-            config.set(section, 'startDate', startDate)
-            endDate = '{:04d}-12-31_23:59:59'.format(endYear)
-            config.set(section, 'endDate', endDate)
-        else:
-            startDate = config.get(section, 'startDate')
-            endDate = config.get(section, 'endDate')
-
-        self.startDate = startDate
-        self.endDate = endDate
-        self.startYear = startYear
-        self.endYear = endYear
 
         # }}}
 

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -27,6 +27,8 @@ from mpas_analysis.configuration import MpasAnalysisConfigParser
 from mpas_analysis.shared.climatology import MpasClimatologyTask, \
     RemapMpasClimatologySubtask
 from mpas_analysis.shared import AnalysisTask
+from mpas_analysis.shared.analysis_task import \
+    update_time_bounds_from_file_names
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories
 
@@ -132,7 +134,7 @@ class TestMpasClimatologyTask(TestCase):
         startDate = '{:04d}-01-01_00:00:00'.format(startYear)
         endDate = '{:04d}-12-31_23:59:59'.format(endYear)
 
-        mpasClimatologyTask._update_climatology_bounds()
+        update_time_bounds_from_file_names(config, 'climatology', 'ocean')
         mpasClimatologyTask._create_symlinks()
 
         assert(mpasClimatologyTask.startYear == startYear)
@@ -152,7 +154,7 @@ class TestMpasClimatologyTask(TestCase):
         config.set('climatology', 'startDate', startDate)
         config.set('climatology', 'endDate', endDate)
 
-        mpasClimatologyTask._update_climatology_bounds()
+        update_time_bounds_from_file_names(config, 'climatology', 'ocean')
         mpasClimatologyTask._create_symlinks()
 
         startYear = 2


### PR DESCRIPTION
The subtasks are:
* `ComputeMOCClimatologySubtask` - computes the MOC climatology and stores it to a file
* `PlotMOCClimatologySubtask` - plots the MOC climatology, possibly as a 3-panel plot vs. the climatology from a reference run
* `ComputeMOCTimeSeriesSubtask` - several subtasks that each compute one year of the MOC time series and store the results to a file
* `CombineMOCTimeSeriesSubtask` - combines the results from each `ComputeMOCTimeSeriesSubtask` into a single time series file.
* `PlotMOCTimeSeriesSubtask` - plots the MOC time series, possibly along with the time series from a reference run.

To support breaking the MOC time series computation into multiple tasks, it was necessary to update time bounds (based on what files are actually available) *before* analysis tasks are created.  This allows analysis tasks to use the time bounds to create subtasks.  Without this fix, the MOC main task might create 9999 subtasks to try to process the MOC (which is possible but isn't pretty).

closes #349