### PR TITLE
Allow main vs. ref comparision to use a cached main in addition to a cached ref analysis run

### DIFF
--- a/config.example
+++ b/config.example
@@ -47,6 +47,13 @@ preprocessedReferenceRunName = None
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 ## options related to executing parallel tasks
 

--- a/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -12,6 +12,13 @@ mainRunName = 20180129.DECKv1b_piControl.ne30_oEC.edison
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 ## options related to executing parallel tasks
 

--- a/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -12,6 +12,13 @@ mainRunName = 20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 ## options related to executing parallel tasks
 

--- a/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
+++ b/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
@@ -12,6 +12,13 @@ mainRunName = 20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 ## options related to executing parallel tasks
 

--- a/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+++ b/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
@@ -12,6 +12,13 @@ mainRunName = 20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [input]
 ## options related to reading in the results to be analyzed
 

--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -12,6 +12,13 @@ mainRunName = 20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 ## options related to executing parallel tasks
 

--- a/configs/edison/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/edison/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -12,6 +12,13 @@ mainRunName = 20180129.DECKv1b_piControl.ne30_oEC.edison
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 ## options related to executing parallel tasks
 

--- a/configs/edison/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
+++ b/configs/edison/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
@@ -12,6 +12,13 @@ mainRunName = 20180129.DECKv1b_piControl.ne30_oEC.edison
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 ## options related to executing parallel tasks
 

--- a/configs/edison/config.20180514.G.oQU240wLI.edison
+++ b/configs/edison/config.20180514.G.oQU240wLI.edison
@@ -12,6 +12,13 @@ mainRunName = 20180514.G.oQU240wLI.edison
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 ## options related to executing parallel tasks
 

--- a/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -12,6 +12,13 @@ mainRunName = B_low_res_ice_shelves_1696_JWolfe_layout_Edison
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 ## options related to executing parallel tasks
 

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -12,6 +12,13 @@ mainRunName = MPAS-SeaIce.QU60km_polar
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [input]
 ## options related to reading in the results to be analyzed
 

--- a/configs/lanl/config.BGCphaeo4.testrun
+++ b/configs/lanl/config.BGCphaeo4.testrun
@@ -18,6 +18,14 @@ preprocessedReferenceRunName = B1850C5_ne30_v0.4
 # remapped to the comparison grid.  Leave this option commented out if no
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
+
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 parallelTaskCount = 6
 ncclimoParallelMode = bck

--- a/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
+++ b/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
@@ -18,6 +18,14 @@ preprocessedReferenceRunName = B1850C5_ne30_v0.4
 # remapped to the comparison grid.  Leave this option commented out if no
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
+
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [execute]
 parallelTaskCount = 6
 ncclimoParallelMode = bck

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -12,6 +12,13 @@ mainRunName = MatchBoth_orig
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [input]
 ## options related to reading in the results to be analyzed
 

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -12,6 +12,13 @@ mainRunName = 20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [input]
 ## options related to reading in the results to be analyzed
 

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -12,6 +12,13 @@ mainRunName = 20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [input]
 ## options related to reading in the results to be analyzed
 

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -12,6 +12,13 @@ mainRunName = GMPAS-IAF_oRRS18to6v3
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 [input]
 ## options related to reading in the results to be analyzed
 

--- a/docs/config/runs.rst
+++ b/docs/config/runs.rst
@@ -28,6 +28,13 @@ of a reference E3SM v1 or standalone MPAS run (if any)::
   # reference run is desired.
   # referenceRunConfigFile = /path/to/config/file
 
+  # config file for a main run on which the analysis was already run to
+  # completion.  The relevant MPAS climatologies already exist and have been
+  # remapped to the comparison grid and time series have been extracted.
+  # Leave this option commented out if the analysis for the main run should be
+  # performed.
+  # mainRunConfigFile = /path/to/config/file
+
 The name of the "main" run (as opposed to a reference run, if any) can be any
 identifier that will be used in figure titles, legends, web pages and file
 names to identify this run.  It does not need to be the name of the simulation
@@ -53,8 +60,8 @@ disabled by commenting out the configuration option::
 To specify a reference run, first run MPAS analysis on the reference run.  Be
 sure that:
 
-  * the start and endy year for climatologies is covered by the simulation
-    output.
+  * the start and end year for climatologies, time series and climate indices
+    is covered by the simulation output.
   * most configuration options for the reference run are the same as for the
     main run.  The exceptions are contents of the ``[run]``, ``[input]`` and
     ``[output]`` sections.  The range of years for climatologies can be
@@ -65,4 +72,35 @@ uncommenting ``referenceRunConfigFile`` and specifying the path to the
 configuration file use in this analysis, e.g.::
 
   referenceRunConfigFile = config.reference_run
+
+If analysis has already been run on the "main" run in a "main vs ref"
+comparison, some time can be saved in performing the comparison
+(particularly for higher resolution output, for which a lot of the
+computation time goes into computing climatologies and extracting time
+series).  By default, this feature is disabled by commenting out the
+configuration option::
+
+  # mainRunConfigFile = /path/to/config/file
+
+To specify a main run, first run MPAS analysis on the main run.  The
+"comparison" config file should be nearly identical to the "main" config
+file except that:
+
+  * The output ``baseDirectory`` should be different.
+  * the start and end year for climatologies, time series and climate indices
+    must be the actual range used if output data was not available to span
+    the requested range in the "main" run.
+
+All configuration information for the "main" run in the "main vs ref"
+comparison is taken from the "comparsion" config file, not the "main" config.
+Only the output directories and subdirectories for climatologies, time series,
+mapping files and mask files (if these latter 2 were generated on the fly)
+will be taken from the "main" config file.  Symbolic links will be made to
+these directories so the comparison analysis run can reuse this data.
+Specify the path to the configuration file use in "main" analysis by
+uncommenting the option and providing a relative or absolute path to the
+config file::
+
+  mainRunConfigFile = config.main_run
+
 

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -37,6 +37,13 @@ preprocessedReferenceRunName = None
 # reference run is desired.
 # referenceRunConfigFile = /path/to/config/file
 
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
 
 [execute]
 ## options related to executing parallel tasks

--- a/mpas_analysis/ocean/plot_climatology_map_subtask.py
+++ b/mpas_analysis/ocean/plot_climatology_map_subtask.py
@@ -393,14 +393,19 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
             remappedRefClimatology = None
 
         if remappedRefClimatology is not None and depth is not None:
-            if str(depth) not in remappedRefClimatology.depthSlice.values:
+            depthIndex = -1
+            for index, depthSlice in enumerate(
+                    remappedRefClimatology.depthSlice.values):
+                if depthSlice.decode("utf-8") == str(depth):
+                    depthIndex = index
+            if depthIndex == -1:
                 raise KeyError('The climatology you are attempting to perform '
-                               'depth slices of was originally created\n'
+                               'depth slices of was originally created'
                                'without depth {}. You will need to delete and '
                                'regenerate the climatology'.format(depth))
 
-            remappedRefClimatology = remappedRefClimatology.sel(
-                depthSlice=str(depth), drop=True)
+            remappedRefClimatology = remappedRefClimatology.isel(
+                depthSlice=depthIndex, drop=True)
 
         if self.removeMean:
             if remappedRefClimatology is None:


### PR DESCRIPTION
Adds a config option `mainRunConfigFile`.  By pointing to a config file for analysis that has already run
(from which only the output directory and subdirectories are used), the climatologies, time series, mapping files and masks can be reused rather than needlessly recomputing them.

This merge also fixes a string vs. byte issue that occurs when indexing depths in Argo and SOSE climatology maps.  An error occurs when trying to reuse depth data (possibly only in python 3) because byte strings don't compare correctly with unicode strings.

closes #345 