### PR TITLE
Rename ref --> control in reference to second panel of 3-panel plots

### DIFF
--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -99,7 +99,7 @@ class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
 
         if refConfig is None:
 
-            refTitleLabel = \
+            controlTitleLabel = \
                 'Observations (Rignot et al, 2013)'
 
             observationsDirectory = build_config_full_path(
@@ -108,13 +108,13 @@ class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
             obsFileName = \
                 '{}/Rignot_2013_melt_rates_6000.0x6000.0km_10.0km_' \
                 'Antarctic_stereo.nc'.format(observationsDirectory)
-            refFieldName = 'meltRate'
+            controlFieldName = 'meltRate'
             outFileLabel = 'meltRignot'
             galleryName = 'Observations: Rignot et al. (2013)'
 
             remapObservationsSubtask = RemapObservedAntarcticMeltClimatology(
                     parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
+                    outFilePrefix=controlFieldName,
                     comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             diffTitleLabel = 'Model - Observations'
@@ -123,9 +123,9 @@ class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
             remapObservationsSubtask = None
             refRunName = refConfig.get('runs', 'mainRunName')
             galleryName = None
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
 
-            refFieldName = mpasFieldName
+            controlFieldName = mpasFieldName
             outFileLabel = 'melt'
             diffTitleLabel = 'Main - Reference'
 
@@ -142,8 +142,8 @@ class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
                         outFileLabel=outFileLabel,
                         fieldNameInTitle='Melt Rate',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'm a$^{-1}$',
                         imageCaption='Antarctic Melt Rate',

--- a/mpas_analysis/ocean/climatology_map_argo.py
+++ b/mpas_analysis/ocean/climatology_map_argo.py
@@ -111,7 +111,7 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
 
         if refConfig is None:
 
-            refTitleLabel = 'Roemmich-Gilson Argo Climatology: Potential ' \
+            controlTitleLabel = 'Roemmich-Gilson Argo Climatology: Potential ' \
                             'Temperature'
 
             observationsDirectory = build_config_full_path(
@@ -120,15 +120,15 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
             obsFileName = \
                 '{}/ArgoClimatology_TS.nc'.format(
                         observationsDirectory)
-            refFieldName = 'theta'
+            controlFieldName = 'theta'
             outFileLabel = 'tempArgo'
             galleryName = 'Roemmich-Gilson Climatology: Argo'
             diffTitleLabel = 'Model - Argo'
 
             remapObservationsSubtask = RemapArgoClimatology(
                     parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix='{}Argo'.format(refFieldName),
-                    fieldName=refFieldName,
+                    outFilePrefix='{}Argo'.format(controlFieldName),
+                    fieldName=controlFieldName,
                     depths=depths,
                     comparisonGridNames=comparisonGridNames)
 
@@ -138,9 +138,9 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
             remapObservationsSubtask = None
             refRunName = refConfig.get('runs', 'mainRunName')
             galleryName = 'Ref: {}'.format(refRunName)
-            refTitleLabel = galleryName
+            controlTitleLabel = galleryName
 
-            refFieldName = mpasFieldName
+            controlFieldName = mpasFieldName
             outFileLabel = 'temp'
             diffTitleLabel = 'Main - Reference'
 
@@ -160,8 +160,8 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
                         outFileLabel=outFileLabel,
                         fieldNameInTitle='Potential Temperature',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'$\degree$C',
                         imageCaption='Model potential temperature compared '
@@ -252,7 +252,7 @@ class ClimatologyMapArgoSalinity(AnalysisTask):  # {{{
 
         if refConfig is None:
 
-            refTitleLabel = 'Roemmich-Gilson Argo Climatology: Salinity'
+            controlTitleLabel = 'Roemmich-Gilson Argo Climatology: Salinity'
 
             observationsDirectory = build_config_full_path(
                 config, 'oceanObservations', 'argoSubdirectory')
@@ -260,15 +260,15 @@ class ClimatologyMapArgoSalinity(AnalysisTask):  # {{{
             obsFileName = \
                 '{}/ArgoClimatology_TS.nc'.format(
                         observationsDirectory)
-            refFieldName = 'salinity'
+            controlFieldName = 'salinity'
             outFileLabel = 'salinArgo'
             galleryName = 'Roemmich-Gilson Climatology: Argo'
             diffTitleLabel = 'Model - Argo'
 
             remapObservationsSubtask = RemapArgoClimatology(
                     parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix='{}Argo'.format(refFieldName),
-                    fieldName=refFieldName,
+                    outFilePrefix='{}Argo'.format(controlFieldName),
+                    fieldName=controlFieldName,
                     depths=depths,
                     comparisonGridNames=comparisonGridNames)
 
@@ -278,9 +278,9 @@ class ClimatologyMapArgoSalinity(AnalysisTask):  # {{{
             remapObservationsSubtask = None
             refRunName = refConfig.get('runs', 'mainRunName')
             galleryName = None
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
 
-            refFieldName = mpasFieldName
+            controlFieldName = mpasFieldName
             outFileLabel = 'salin'
             diffTitleLabel = 'Main - Reference'
 
@@ -300,8 +300,8 @@ class ClimatologyMapArgoSalinity(AnalysisTask):  # {{{
                         outFileLabel=outFileLabel,
                         fieldNameInTitle='Salinity',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'PSU',
                         imageCaption='Model Salinity compared with Argo '

--- a/mpas_analysis/ocean/climatology_map_bgc.py
+++ b/mpas_analysis/ocean/climatology_map_bgc.py
@@ -116,10 +116,10 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
                 subtaskName='remapMpasClimatology_{}'.format(fieldName))
 
             if refConfig is None:
-                refTitleLabel = 'Observations'
+                controlTitleLabel = 'Observations'
                 preindustrial = config.getboolean(sectionName, 'preindustrial')
                 if preindustrial and 'DIC' in fieldName:
-                    refTitleLabel += ' (Preindustrial)'
+                    controlTitleLabel += ' (Preindustrial)'
 
                 observationsDirectory = build_config_full_path(
                     config, 'oceanObservations',
@@ -140,7 +140,7 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
 
                 observationsLabel = config.get(fieldSectionName,
                                                'observationsLabel')
-                refFieldName = fieldName
+                controlFieldName = fieldName
                 outFileLabel = fieldName + observationsLabel
 
                 galleryLabel = config.get(fieldSectionName, 'galleryLabel')
@@ -149,7 +149,7 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
 
                 remapObservationsSubtask = RemapObservedBGCClimatology(
                     parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
+                    outFilePrefix=controlFieldName,
                     comparisonGridNames=comparisonGridNames,
                     subtaskName='remapObservations_{}'.format(fieldName))
                 self.add_subtask(remapObservationsSubtask)
@@ -166,9 +166,9 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
                 remapObservationsSubtask = None
                 refRunName = refConfig.get('runs', 'mainRunName')
                 galleryName = None
-                refTitleLabel = 'Ref: {}'.format(refRunName)
+                controlTitleLabel = 'Ref: {}'.format(refRunName)
 
-                refFieldName = mpasFieldName
+                controlFieldName = mpasFieldName
                 outFileLabel = fieldName
                 diffTitleLabel = 'Main - Reference'
 
@@ -185,8 +185,8 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
                         outFileLabel=outFileLabel,
                         fieldNameInTitle=fieldName,
                         mpasFieldName=plotField,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         unitsLabel=units,
                         imageCaption='Mean ' + fieldName,
                         galleryGroup='Sea Surface Biogeochemistry',

--- a/mpas_analysis/ocean/climatology_map_eke.py
+++ b/mpas_analysis/ocean/climatology_map_eke.py
@@ -106,7 +106,7 @@ class ClimatologyMapEKE(AnalysisTask):  # {{{
         # to compare to observations:
         if refConfig is None:
 
-            refTitleLabel = \
+            controlTitleLabel = \
                 'Observations (Surface EKE from Drifter Data)'
 
             observationsDirectory = build_config_full_path(
@@ -116,13 +116,13 @@ class ClimatologyMapEKE(AnalysisTask):  # {{{
             obsFileName = \
                 "{}/drifter_variance.nc".format(
                     observationsDirectory)
-            refFieldName = 'eke'
+            controlFieldName = 'eke'
             outFileLabel = 'ekeDRIFTER'
             galleryName = 'Observations: EKE from Drifters'
 
             remapObservationsSubtask = RemapObservedEKEClimatology(
                 parentTask=self, seasons=seasons, fileName=obsFileName,
-                outFilePrefix=refFieldName,
+                outFilePrefix=controlFieldName,
                 comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             diffTitleLabel = 'Model - Observations'
@@ -132,9 +132,9 @@ class ClimatologyMapEKE(AnalysisTask):  # {{{
             remapObservationsSubtask = None
             refRunName = refConfig.get('runs', 'mainRunName')
             galleryName = None
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
 
-            refFieldName = mpasFieldName
+            controlFieldName = mpasFieldName
             outFileLabel = 'eke'
             diffTitleLabel = 'Main - Reference'
 
@@ -151,8 +151,8 @@ class ClimatologyMapEKE(AnalysisTask):  # {{{
                     outFileLabel=outFileLabel,
                     fieldNameInTitle='EKE',
                     mpasFieldName=mpasFieldName,
-                    refFieldName=refFieldName,
-                    refTitleLabel=refTitleLabel,
+                    controlFieldName=controlFieldName,
+                    controlTitleLabel=controlTitleLabel,
                     diffTitleLabel=diffTitleLabel,
                     unitsLabel=r'cm$^2$/s$^2$',
                     imageCaption='Mean Surface Eddy Kinetic Energy',

--- a/mpas_analysis/ocean/climatology_map_mld.py
+++ b/mpas_analysis/ocean/climatology_map_mld.py
@@ -104,16 +104,16 @@ class ClimatologyMapMLD(AnalysisTask):  # {{{
             obsFileName = "{}/holtetalley_mld_climatology.nc".format(
                     observationsDirectory)
 
-            refFieldName = 'mld'
+            controlFieldName = 'mld'
             outFileLabel = 'mldHolteTalleyARGO'
 
             remapObservationsSubtask = RemapObservedMLDClimatology(
                     parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
+                    outFilePrefix=controlFieldName,
                     comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             galleryName = 'Observations: Holte-Talley ARGO'
-            refTitleLabel = \
+            controlTitleLabel = \
                 'Observations (HolteTalley density threshold MLD)'
             diffTitleLabel = 'Model - Observations'
 
@@ -121,9 +121,9 @@ class ClimatologyMapMLD(AnalysisTask):  # {{{
             remapObservationsSubtask = None
             refRunName = refConfig.get('runs', 'mainRunName')
             galleryName = None
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
 
-            refFieldName = mpasFieldName
+            controlFieldName = mpasFieldName
             outFileLabel = 'mld'
             diffTitleLabel = 'Main - Reference'
 
@@ -140,8 +140,8 @@ class ClimatologyMapMLD(AnalysisTask):  # {{{
                         outFileLabel=outFileLabel,
                         fieldNameInTitle='MLD',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'm',
                         imageCaption='Mean Mixed-Layer Depth',

--- a/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
+++ b/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
@@ -108,14 +108,14 @@ class ClimatologyMapOHCAnomaly(AnalysisTask):  # {{{
             outFileLabel = 'deltaOHC_{}'.format(depthRangeString)
             remapObservationsSubtask = None
             if refConfig is None:
-                refTitleLabel = None
-                refFieldName = None
+                controlTitleLabel = None
+                controlFieldName = None
                 diffTitleLabel = 'Model - Observations'
 
             else:
                 refRunName = refConfig.get('runs', 'mainRunName')
-                refTitleLabel = 'Ref: {}'.format(refRunName)
-                refFieldName = mpasFieldName
+                controlTitleLabel = 'Ref: {}'.format(refRunName)
+                controlFieldName = mpasFieldName
                 diffTitleLabel = 'Main - Reference'
 
             for comparisonGridName in comparisonGridNames:
@@ -134,8 +134,8 @@ class ClimatologyMapOHCAnomaly(AnalysisTask):  # {{{
                             fieldNameInTitle=r'$\Delta$OHC over {}'.format(
                                     depthRangeString),
                             mpasFieldName=mpasFieldName,
-                            refFieldName=refFieldName,
-                            refTitleLabel=refTitleLabel,
+                            controlFieldName=controlFieldName,
+                            controlTitleLabel=controlTitleLabel,
                             diffTitleLabel=diffTitleLabel,
                             unitsLabel=r'GJ m$^{-2}$',
                             imageCaption='Anomaly in Ocean Heat Content over '

--- a/mpas_analysis/ocean/climatology_map_schmidtko.py
+++ b/mpas_analysis/ocean/climatology_map_schmidtko.py
@@ -121,12 +121,12 @@ class ClimatologyMapSchmidtko(AnalysisTask):  # {{{
             comparisonGridNames=comparisonGridNames)
 
         if refConfig is None:
-            refTitleLabel = 'Observations: Schmidtko et al. (2014)'
+            controlTitleLabel = 'Observations: Schmidtko et al. (2014)'
             diffTitleLabel = 'Model - Observations'
-            groupSubtitle = refTitleLabel
+            groupSubtitle = controlTitleLabel
         else:
             refRunName = refConfig.get('runs', 'mainRunName')
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
             diffTitleLabel = 'Main - Reference'
             groupSubtitle = None
 
@@ -134,13 +134,13 @@ class ClimatologyMapSchmidtko(AnalysisTask):  # {{{
             fieldPrefix = field['prefix']
             upperFieldPrefix = fieldPrefix[0].upper() + fieldPrefix[1:]
             if refConfig is None:
-                refFieldName = field['obs']
+                controlFieldName = field['obs']
                 outFileLabel = '{}Schmidtko'.format(fieldPrefix)
 
                 remapObservationsSubtask = RemapSchmidtko(
                         parentTask=self, seasons=seasons, fileName=obsFileName,
                         outFilePrefix='{}Schmidtko'.format(fieldPrefix),
-                        fieldName=refFieldName,
+                        fieldName=controlFieldName,
                         comparisonGridNames=comparisonGridNames,
                         subtaskName='remapObservations{}'.format(
                                 upperFieldPrefix))
@@ -151,7 +151,7 @@ class ClimatologyMapSchmidtko(AnalysisTask):  # {{{
                 remapObservationsSubtask = None
                 refRunName = refConfig.get('runs', 'mainRunName')
 
-                refFieldName = field['mpas']
+                controlFieldName = field['mpas']
                 outFileLabel = '{}Bottom'.format(fieldPrefix)
                 diffTitleLabel = 'Main - Reference'
 
@@ -173,8 +173,8 @@ class ClimatologyMapSchmidtko(AnalysisTask):  # {{{
                         outFileLabel=outFileLabel,
                         fieldNameInTitle=field['title'],
                         mpasFieldName=field['mpas'],
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=field['units'],
                         imageCaption=field['title'],

--- a/mpas_analysis/ocean/climatology_map_sose.py
+++ b/mpas_analysis/ocean/climatology_map_sose.py
@@ -191,7 +191,7 @@ class ClimatologyMapSose(AnalysisTask):  # {{{
 
             if refConfig is None:
 
-                refTitleLabel = 'State Estimate (SOSE)'
+                controlTitleLabel = 'State Estimate (SOSE)'
 
                 observationsDirectory = build_config_full_path(
                     config, 'oceanObservations', 'soseSubdirectory')
@@ -200,15 +200,15 @@ class ClimatologyMapSose(AnalysisTask):  # {{{
                     '{}/SOSE_2005-2010_monthly_{}_6000.0x' \
                     '6000.0km_10.0km_Antarctic_stereo.nc'.format(
                             observationsDirectory, field['obsFilePrefix'])
-                refFieldName = field['obsFieldName']
+                controlFieldName = field['obsFieldName']
                 outFileLabel = '{}SOSE'.format(fieldPrefix)
                 galleryName = 'State Estimate: SOSE'
                 diffTitleLabel = 'Model - State Estimate'
 
                 remapObsSubtask = RemapSoseClimatology(
                         parentTask=self, seasons=seasons, fileName=obsFileName,
-                        outFilePrefix='{}SOSE'.format(refFieldName),
-                        fieldName=refFieldName,
+                        outFilePrefix='{}SOSE'.format(controlFieldName),
+                        fieldName=controlFieldName,
                         botFieldName=field['obsBotFieldName'],
                         depths=fieldDepths,
                         comparisonGridNames=comparisonGridNames,
@@ -221,9 +221,9 @@ class ClimatologyMapSose(AnalysisTask):  # {{{
                 remapObsSubtask = None
                 refRunName = refConfig.get('runs', 'mainRunName')
                 galleryName = 'Ref: {}'.format(refRunName)
-                refTitleLabel = galleryName
+                controlTitleLabel = galleryName
 
-                refFieldName = field['mpas']
+                controlFieldName = field['mpas']
                 outFileLabel = fieldPrefix
                 diffTitleLabel = 'Main - Reference'
 
@@ -257,8 +257,8 @@ class ClimatologyMapSose(AnalysisTask):  # {{{
                             outFileLabel=outFileLabel,
                             fieldNameInTitle=field['titleName'],
                             mpasFieldName=field['mpas'],
-                            refFieldName=refFieldName,
-                            refTitleLabel=refTitleLabel,
+                            controlFieldName=controlFieldName,
+                            controlTitleLabel=controlTitleLabel,
                             diffTitleLabel=diffTitleLabel,
                             unitsLabel=field['units'],
                             imageCaption=field['titleName'],

--- a/mpas_analysis/ocean/climatology_map_ssh.py
+++ b/mpas_analysis/ocean/climatology_map_ssh.py
@@ -97,7 +97,7 @@ class ClimatologyMapSSH(AnalysisTask):  # {{{
 
         if refConfig is None:
 
-            refTitleLabel = 'Observations (AVISO Dynamic ' \
+            controlTitleLabel = 'Observations (AVISO Dynamic ' \
                 'Topography, 1993-2010)'
 
             observationsDirectory = build_config_full_path(
@@ -107,13 +107,13 @@ class ClimatologyMapSSH(AnalysisTask):  # {{{
             obsFileName = \
                 "{}/zos_AVISO_L4_199210-201012.nc".format(
                     observationsDirectory)
-            refFieldName = 'zos'
+            controlFieldName = 'zos'
             outFileLabel = 'sshAVISO'
             galleryName = 'Observations: AVISO'
 
             remapObservationsSubtask = RemapObservedSSHClimatology(
                     parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
+                    outFilePrefix=controlFieldName,
                     comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             diffTitleLabel = 'Model - Observations'
@@ -122,9 +122,9 @@ class ClimatologyMapSSH(AnalysisTask):  # {{{
             remapObservationsSubtask = None
             refRunName = refConfig.get('runs', 'mainRunName')
             galleryName = None
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
 
-            refFieldName = mpasFieldName
+            controlFieldName = mpasFieldName
             outFileLabel = 'ssh'
             diffTitleLabel = 'Main - Reference'
 
@@ -141,8 +141,8 @@ class ClimatologyMapSSH(AnalysisTask):  # {{{
                         outFileLabel=outFileLabel,
                         fieldNameInTitle='Zero-mean SSH',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'cm',
                         imageCaption='Mean Sea Surface Height',

--- a/mpas_analysis/ocean/climatology_map_sss.py
+++ b/mpas_analysis/ocean/climatology_map_sss.py
@@ -95,7 +95,7 @@ class ClimatologyMapSSS(AnalysisTask):  # {{{
 
         if refConfig is None:
 
-            refTitleLabel = \
+            controlTitleLabel = \
                 'Observations (Aquarius, 2011-2014)'
 
             observationsDirectory = build_config_full_path(
@@ -105,13 +105,13 @@ class ClimatologyMapSSS(AnalysisTask):  # {{{
             obsFileName = \
                 "{}/Aquarius_V3_SSS_Monthly.nc".format(
                     observationsDirectory)
-            refFieldName = 'sss'
+            controlFieldName = 'sss'
             outFileLabel = 'sssAquarius'
             galleryName = 'Observations: Aquarius'
 
             remapObservationsSubtask = RemapObservedSSSClimatology(
                     parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
+                    outFilePrefix=controlFieldName,
                     comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             diffTitleLabel = 'Model - Observations'
@@ -120,9 +120,9 @@ class ClimatologyMapSSS(AnalysisTask):  # {{{
             remapObservationsSubtask = None
             refRunName = refConfig.get('runs', 'mainRunName')
             galleryName = None
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
 
-            refFieldName = mpasFieldName
+            controlFieldName = mpasFieldName
             outFileLabel = 'sss'
             diffTitleLabel = 'Main - Reference'
 
@@ -139,8 +139,8 @@ class ClimatologyMapSSS(AnalysisTask):  # {{{
                         outFileLabel=outFileLabel,
                         fieldNameInTitle='SSS',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'PSU',
                         imageCaption='Mean Sea Surface Salinity',

--- a/mpas_analysis/ocean/climatology_map_sst.py
+++ b/mpas_analysis/ocean/climatology_map_sst.py
@@ -102,7 +102,7 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
             else:
                 period = 'present-day'
 
-            refTitleLabel = \
+            controlTitleLabel = \
                 'Observations (Hadley/OI, {} {:04d}-{:04d})'.format(
                         period, climStartYear, climEndYear)
 
@@ -113,13 +113,13 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
             obsFileName = \
                 "{}/MODEL.SST.HAD187001-198110.OI198111-201203.nc".format(
                     observationsDirectory)
-            refFieldName = 'sst'
+            controlFieldName = 'sst'
             outFileLabel = 'sstHADOI'
             galleryName = 'Observations: Hadley-NOAA-OI'
 
             remapObservationsSubtask = RemapObservedSSTClimatology(
                     parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
+                    outFilePrefix=controlFieldName,
                     comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             diffTitleLabel = 'Model - Observations'
@@ -128,9 +128,9 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
             remapObservationsSubtask = None
             refRunName = refConfig.get('runs', 'mainRunName')
             galleryName = None
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
 
-            refFieldName = mpasFieldName
+            controlFieldName = mpasFieldName
             outFileLabel = 'sst'
             diffTitleLabel = 'Main - Reference'
 
@@ -147,8 +147,8 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
                         outFileLabel=outFileLabel,
                         fieldNameInTitle='SST',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'$^o$C',
                         imageCaption='Mean Sea Surface Temperature',

--- a/mpas_analysis/ocean/geojson_transects.py
+++ b/mpas_analysis/ocean/geojson_transects.py
@@ -118,13 +118,13 @@ class GeojsonTransects(AnalysisTask):  # {{{
         plotObs = False
         if refConfig is None:
 
-            refTitleLabel = None
+            controlTitleLabel = None
 
             diffTitleLabel = None
 
         else:
             refRunName = refConfig.get('runs', 'mainRunName')
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
 
             diffTitleLabel = 'Main - Reference'
 
@@ -134,9 +134,9 @@ class GeojsonTransects(AnalysisTask):  # {{{
                 for season in seasons:
                     outFileLabel = fieldPrefix
                     if refConfig is None:
-                        refFieldName = None
+                        controlFieldName = None
                     else:
-                        refFieldName = field['mpas']
+                        controlFieldName = field['mpas']
 
                     fieldPrefixUpper = fieldPrefix[0].upper() + fieldPrefix[1:]
                     fieldNameInTytle = '{} from {}'.format(
@@ -153,8 +153,8 @@ class GeojsonTransects(AnalysisTask):  # {{{
                             outFileLabel=outFileLabel,
                             fieldNameInTitle=fieldNameInTytle,
                             mpasFieldName=field['mpas'],
-                            refFieldName=refFieldName,
-                            refTitleLabel=refTitleLabel,
+                            controlFieldName=controlFieldName,
+                            controlTitleLabel=controlTitleLabel,
                             diffTitleLabel=diffTitleLabel,
                             unitsLabel=field['units'],
                             imageCaption=fieldNameInTytle,

--- a/mpas_analysis/ocean/plot_climatology_map_subtask.py
+++ b/mpas_analysis/ocean/plot_climatology_map_subtask.py
@@ -200,7 +200,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
         # }}}
 
     def set_plot_info(self, outFileLabel, fieldNameInTitle, mpasFieldName,
-                      refFieldName, refTitleLabel, unitsLabel,
+                      controlFieldName, controlTitleLabel, unitsLabel,
                       imageCaption, galleryGroup, groupSubtitle, groupLink,
                       galleryName, diffTitleLabel='Model - Observations',
                       configSectionName=None):
@@ -219,11 +219,11 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
         mpasFieldName : str
             The name of the variable in the MPAS timeSeriesStatsMonthly output
 
-        refFieldName : str
+        controlFieldName : str
             The name of the variable to use from the observations or reference
             file
 
-        refTitleLabel : str
+        controlTitleLabel : str
             the title of the observations or reference subplot
 
         unitsLabel : str
@@ -260,8 +260,8 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
         self.outFileLabel = outFileLabel
         self.fieldNameInTitle = fieldNameInTitle
         self.mpasFieldName = mpasFieldName
-        self.refFieldName = refFieldName
-        self.refTitleLabel = refTitleLabel
+        self.controlFieldName = controlFieldName
+        self.controlTitleLabel = controlTitleLabel
         self.diffTitleLabel = diffTitleLabel
         self.unitsLabel = unitsLabel
 
@@ -386,8 +386,8 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
             refStartYear = self.refConfig.getint('climatology', 'startYear')
             refEndYear = self.refConfig.getint('climatology', 'endYear')
             if refStartYear != self.startYear or refEndYear != self.endYear:
-                self.refTitleLabel = '{}\n(years {:04d}-{:04d})'.format(
-                    self.refTitleLabel, refStartYear, refEndYear)
+                self.controlTitleLabel = '{}\n(years {:04d}-{:04d})'.format(
+                    self.controlTitleLabel, refStartYear, refEndYear)
 
         else:
             remappedRefClimatology = None
@@ -409,15 +409,15 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
                     remappedModelClimatology[self.mpasFieldName].mean()
             else:
                 masked = remappedModelClimatology[self.mpasFieldName].where(
-                    remappedRefClimatology[self.refFieldName].notnull())
+                    remappedRefClimatology[self.controlFieldName].notnull())
                 remappedModelClimatology[self.mpasFieldName] = \
                     remappedModelClimatology[self.mpasFieldName] - \
                     masked.mean()
 
-                masked = remappedRefClimatology[self.refFieldName].where(
+                masked = remappedRefClimatology[self.controlFieldName].where(
                     remappedModelClimatology[self.mpasFieldName].notnull())
-                remappedRefClimatology[self.refFieldName] = \
-                    remappedRefClimatology[self.refFieldName] - \
+                remappedRefClimatology[self.controlFieldName] = \
+                    remappedRefClimatology[self.controlFieldName] - \
                     masked.mean()
 
         if self.comparisonGridName == 'latlon':
@@ -446,13 +446,13 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
         lonTarg, latTarg = np.meshgrid(lon, lat)
 
         if remappedRefClimatology is None:
-            refOutput = None
+            controlOutput = None
             bias = None
         else:
-            refOutput = nans_to_numpy_mask(
-                remappedRefClimatology[self.refFieldName].values)
+            controlOutput = nans_to_numpy_mask(
+                remappedRefClimatology[self.controlFieldName].values)
 
-            bias = modelOutput - refOutput
+            bias = modelOutput - controlOutput
 
         filePrefix = self.filePrefix
         outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
@@ -463,13 +463,13 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
                                lonTarg,
                                latTarg,
                                modelOutput,
-                               refOutput,
+                               controlOutput,
                                bias,
                                configSectionName,
                                fileout=outFileName,
                                title=title,
                                modelTitle='{}'.format(mainRunName),
-                               refTitle=self.refTitleLabel,
+                               controlTitle=self.controlTitleLabel,
                                diffTitle=self.diffTitleLabel,
                                cbarlabel=self.unitsLabel)
 
@@ -509,13 +509,13 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
             remappedModelClimatology[self.mpasFieldName].values)
 
         if remappedRefClimatology is None:
-            refOutput = None
+            controlOutput = None
             bias = None
         else:
-            refOutput = nans_to_numpy_mask(
-                remappedRefClimatology[self.refFieldName].values)
+            controlOutput = nans_to_numpy_mask(
+                remappedRefClimatology[self.controlFieldName].values)
 
-            bias = modelOutput - refOutput
+            bias = modelOutput - controlOutput
 
         x = interp_extrap_corner(remappedModelClimatology['x'].values)
         y = interp_extrap_corner(remappedModelClimatology['y'].values)
@@ -532,13 +532,13 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
             y,
             self.landMask,
             modelOutput,
-            refOutput,
+            controlOutput,
             bias,
             fileout=outFileName,
             colorMapSectionName=configSectionName,
             title=title,
             modelTitle='{}'.format(mainRunName),
-            refTitle=self.refTitleLabel,
+            controlTitle=self.controlTitleLabel,
             diffTitle=self.diffTitleLabel,
             cbarlabel=self.unitsLabel)
 

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -164,7 +164,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         # }}}
 
     def set_plot_info(self, outFileLabel, fieldNameInTitle, mpasFieldName,
-                      refFieldName, refTitleLabel, unitsLabel,
+                      controlFieldName, controlTitleLabel, unitsLabel,
                       imageCaption, galleryGroup, groupSubtitle, groupLink,
                       galleryName, configSectionName,
                       diffTitleLabel='Model - Observations'):
@@ -183,11 +183,11 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         mpasFieldName : str
             The name of the variable in the MPAS timeSeriesStatsMonthly output
 
-        refFieldName : str
+        controlFieldName : str
             The name of the variable to use from the observations or reference
             file
 
-        refTitleLabel : str
+        controlTitleLabel : str
             the title of the observations or reference subplot
 
         unitsLabel : str
@@ -223,8 +223,8 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         self.outFileLabel = outFileLabel
         self.fieldNameInTitle = fieldNameInTitle
         self.mpasFieldName = mpasFieldName
-        self.refFieldName = refFieldName
-        self.refTitleLabel = refTitleLabel
+        self.controlFieldName = controlFieldName
+        self.controlTitleLabel = controlTitleLabel
         self.diffTitleLabel = diffTitleLabel
         self.unitsLabel = unitsLabel
 
@@ -331,8 +331,8 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             refStartYear = self.refConfig.getint('climatology', 'startYear')
             refEndYear = self.refConfig.getint('climatology', 'endYear')
             if refStartYear != self.startYear or refEndYear != self.endYear:
-                self.refTitleLabel = '{}\n(years {:04d}-{:04d})'.format(
-                        self.refTitleLabel, refStartYear, refEndYear)
+                self.controlTitleLabel = '{}\n(years {:04d}-{:04d})'.format(
+                        self.controlTitleLabel, refStartYear, refEndYear)
 
         else:
             remappedRefClimatology = None
@@ -382,17 +382,17 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         modelOutput = modelOutput.transpose()
 
         if remappedRefClimatology is None:
-            refOutput = None
+            controlOutput = None
             bias = None
         else:
-            refOutput = remappedRefClimatology[self.refFieldName]
-            dims = refOutput.dims
-            refOutput = nans_to_numpy_mask(refOutput.values)
+            controlOutput = remappedRefClimatology[self.controlFieldName]
+            dims = controlOutput.dims
+            controlOutput = nans_to_numpy_mask(controlOutput.values)
             if dims[1] != 'nPoints':
                 assert(dims[0] == 'nPoints')
-                refOutput = refOutput.transpose()
+                controlOutput = controlOutput.transpose()
 
-            bias = modelOutput - refOutput
+            bias = modelOutput - controlOutput
 
         filePrefix = self.filePrefix
         outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
@@ -483,7 +483,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             x,
             z,
             modelOutput,
-            refOutput,
+            controlOutput,
             bias,
             outFileName,
             configSectionName,
@@ -492,7 +492,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             ylabel=yLabel,
             title=title,
             modelTitle='{}'.format(mainRunName),
-            refTitle=self.refTitleLabel,
+            controlTitle=self.controlTitleLabel,
             diffTitle=self.diffTitleLabel,
             secondXAxisData=self.secondXAxisData,
             secondXAxisLabel=self.secondXAxisLabel,

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -23,7 +23,7 @@ import xarray as xr
 import numpy
 
 from mpas_analysis.shared.plot.plotting import \
-    plot_vertical_section, plot_vertical_section_comparison
+    plot_vertical_section_comparison
 
 from mpas_analysis.shared import AnalysisTask
 
@@ -400,10 +400,8 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
                 self.fieldNameInTitle, season, self.startYear,
                 self.endYear)
 
-
         xLabel = 'Distance [km]'
         yLabel = 'Depth [m]'
-
 
         # define the axis labels and the data to use for the upper
         # x axis or axes, if such additional axes have been requested
@@ -453,7 +451,6 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         else:
             raise ValueError('invalid option for upperXAxes')
 
-
         # get the parameters determining what type of plot to use,
         # what line styles and line colors to use, and whether and how
         # to label contours
@@ -469,19 +466,18 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
                                                 'comparisonContourLineColor')
 
         if compareAsContours:
-            labelContours = config.getboolean('transects',
-                                    'labelContoursOnContourComparisonPlots')
+            labelContours = config.getboolean(
+                    'transects', 'labelContoursOnContourComparisonPlots')
         else:
             labelContours = config.getboolean('transects',
                                               'labelContoursOnHeatmaps')
-        
+
         contourLabelPrecision = config.getint('transects',
                                               'contourLabelPrecision')
 
-
         # construct a three-panel comparison plot for the transect, or a
         # single-panel contour comparison plot if compareAsContours is True
-        
+
         plot_vertical_section_comparison(
             config,
             x,
@@ -571,16 +567,18 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         lon_jump = numpy.where(
             numpy.logical_or(lon_diff > 180, lon_diff < -180), True, False)
 
-        if numpy.all(lon_jump == False):  # transect does not cross
-                                          # periodic boundary
+        if numpy.all(numpy.logical_not(lon_jump)):
+            # transect does not cross periodic boundary
 
             lon_extent = numpy.max(lon) - numpy.min(lon)
 
-        else:  # transect crosses periodic boundary at least once, so min and
-               # max cannot be used to calculate the longitudinal extent
+        else:
+            # transect crosses periodic boundary at least once, so min and
+            # max cannot be used to calculate the longitudinal extent
 
-            # calculate the indices at which the transect crosses the right-hand
-            # periodic boundary and enters the leftmost region of the domain
+            # calculate the indices at which the transect crosses the
+            # right-hand periodic boundary and enters the leftmost region of
+            # the domain
             lon_r = numpy.sort(numpy.nonzero(lon_diff < -180)[0] + 1)
 
             # calculate the indices at which the transect crosses the left-hand

--- a/mpas_analysis/ocean/sose_transects.py
+++ b/mpas_analysis/ocean/sose_transects.py
@@ -158,13 +158,13 @@ class SoseTransects(AnalysisTask):  # {{{
         plotObs = refConfig is None
         if plotObs:
 
-            refTitleLabel = 'State Estimate (SOSE)'
+            controlTitleLabel = 'State Estimate (SOSE)'
 
             diffTitleLabel = 'Model - State Estimate'
 
         else:
             refRunName = refConfig.get('runs', 'mainRunName')
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
 
             diffTitleLabel = 'Main - Reference'
 
@@ -177,9 +177,9 @@ class SoseTransects(AnalysisTask):  # {{{
                 for season in seasons:
                     outFileLabel = 'SOSE_{}_'.format(fieldPrefix)
                     if plotObs:
-                        refFieldName = field['obsFieldName']
+                        controlFieldName = field['obsFieldName']
                     else:
-                        refFieldName = field['mpas']
+                        controlFieldName = field['mpas']
 
                     fieldNameInTytle = r'{} at {}$\degree$ Longitude'.format(
                             field['titleName'], lon)
@@ -194,8 +194,8 @@ class SoseTransects(AnalysisTask):  # {{{
                             outFileLabel=outFileLabel,
                             fieldNameInTitle=fieldNameInTytle,
                             mpasFieldName=field['mpas'],
-                            refFieldName=refFieldName,
-                            refTitleLabel=refTitleLabel,
+                            controlFieldName=controlFieldName,
+                            controlTitleLabel=controlTitleLabel,
                             diffTitleLabel=diffTitleLabel,
                             unitsLabel=field['units'],
                             imageCaption='{} {}'.format(fieldNameInTytle,

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -597,11 +597,11 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
         depth, lat, moc = self._load_moc(config)
 
         if self.refConfig is None:
-            refTitle = None
+            controlTitle = None
             diffTitle = None
         else:
             refDepth, refLat, refMOC = self._load_moc(self.refConfig)
-            refTitle = self.refConfig.get('runs', 'mainRunName')
+            controlTitle = self.refConfig.get('runs', 'mainRunName')
             diffTitle = 'Main - Reference'
 
         # **** Plot MOC ****
@@ -633,7 +633,7 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
             x = x[indLat]
             regionMOC = regionMOC[:, indLat]
             if self.refConfig is None:
-                refRegionMOC = None
+                controlRegionMOC = None
                 diff = None
             else:
                 # the coords of the ref MOC won't necessarily match this MOC
@@ -645,22 +645,22 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
                     temp[zIndex, :] = np.interp(
                             x, refLat[region], refMOC[region][zIndex, :],
                             left=np.nan, right=np.nan)
-                refRegionMOC = np.zeros((nz, nx))
+                controlRegionMOC = np.zeros((nz, nx))
                 for xIndex in range(nx):
-                    refRegionMOC[:, xIndex] = np.interp(
+                    controlRegionMOC[:, xIndex] = np.interp(
                             depth, refDepth, temp[:, xIndex],
                             left=np.nan, right=np.nan)
 
-                diff = regionMOC - refRegionMOC
+                diff = regionMOC - controlRegionMOC
 
             plot_vertical_section_comparison(
-                    config, x, z, regionMOC, refRegionMOC, diff,
+                    config, x, z, regionMOC, controlRegionMOC, diff,
                     fileout=figureName,
                     colorMapSectionName='streamfunctionMOC{}'.format(region),
                     cbarLabel=colorbarLabel,
                     title=title,
                     modelTitle=mainRunName,
-                    refTitle=refTitle,
+                    controlTitle=controlTitle,
                     diffTitle=diffTitle,
                     xlabel=xLabel,
                     ylabel=yLabel,

--- a/mpas_analysis/ocean/woce_transects.py
+++ b/mpas_analysis/ocean/woce_transects.py
@@ -121,13 +121,13 @@ class WoceTransects(AnalysisTask):  # {{{
         plotObs = refConfig is None
         if plotObs:
 
-            refTitleLabel = 'Observations (WOCE)'
+            controlTitleLabel = 'Observations (WOCE)'
 
             diffTitleLabel = 'Model - Observations'
 
         else:
             refRunName = refConfig.get('runs', 'mainRunName')
-            refTitleLabel = 'Ref: {}'.format(refRunName)
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
 
             diffTitleLabel = 'Main - Reference'
 
@@ -139,9 +139,9 @@ class WoceTransects(AnalysisTask):  # {{{
                 for season in seasons:
                     outFileLabel = fieldNameDict[fieldName]
                     if plotObs:
-                        refFieldName = fields[fieldName]['obs']
+                        controlFieldName = fields[fieldName]['obs']
                     else:
-                        refFieldName = fields[fieldName]['mpas']
+                        controlFieldName = fields[fieldName]['mpas']
 
                     fieldNameUpper = fieldName[0].upper() + fieldName[1:]
                     fieldNameInTytle = '{} from {}'.format(
@@ -158,8 +158,8 @@ class WoceTransects(AnalysisTask):  # {{{
                             outFileLabel=outFileLabel,
                             fieldNameInTitle=fieldNameInTytle,
                             mpasFieldName=fields[fieldName]['mpas'],
-                            refFieldName=refFieldName,
-                            refTitleLabel=refTitleLabel,
+                            controlFieldName=controlFieldName,
+                            controlTitleLabel=controlTitleLabel,
                             diffTitleLabel=diffTitleLabel,
                             unitsLabel=fields[fieldName]['units'],
                             imageCaption='{} {}'.format(fieldNameInTytle,

--- a/mpas_analysis/sea_ice/climatology_map_berg_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_berg_conc.py
@@ -101,10 +101,10 @@ class ClimatologyMapIcebergConc(AnalysisTask):  # {{{
             iselValues=iselValues)
 
         if refConfig is None:
-            refTitleLabel = 'Observations (Altiberg)'
+            controlTitleLabel = 'Observations (Altiberg)'
             galleryName = 'Observations: Altiberg'
             diffTitleLabel = 'Model - Observations'
-            refFieldName = 'icebergConc'
+            controlFieldName = 'icebergConc'
             obsFileName = build_config_full_path(
                     config, 'icebergObservations',
                     'concentrationAltiberg{}'.format(hemisphere))
@@ -112,7 +112,7 @@ class ClimatologyMapIcebergConc(AnalysisTask):  # {{{
             remapObservationsSubtask = RemapAltibergConcClimatology(
                     parentTask=self, seasons=seasons,
                     fileName=obsFileName,
-                    outFilePrefix='{}{}'.format(refFieldName,
+                    outFilePrefix='{}{}'.format(controlFieldName,
                                                 hemisphere),
                     comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
@@ -120,8 +120,8 @@ class ClimatologyMapIcebergConc(AnalysisTask):  # {{{
         else:
             refRunName = refConfig.get('runs', 'mainRunName')
             galleryName = None
-            refTitleLabel = 'Ref: {}'.format(refRunName)
-            refFieldName = mpasFieldName
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
+            controlFieldName = mpasFieldName
             diffTitleLabel = 'Main - Reference'
 
             remapObservationsSubtask = None
@@ -146,8 +146,8 @@ class ClimatologyMapIcebergConc(AnalysisTask):  # {{{
                         outFileLabel='bergconc{}'.format(hemisphere),
                         fieldNameInTitle='Iceberg concentration',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'fraction',
                         imageDescription=imageDescription,

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -167,8 +167,8 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
                                                           hemisphere),
                         fieldNameInTitle='Sea ice concentration',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=obsFieldName,
-                        refTitleLabel=observationTitleLabel,
+                        controlFieldName=obsFieldName,
+                        controlTitleLabel=observationTitleLabel,
                         diffTitleLabel='Model - Observations',
                         unitsLabel=r'fraction',
                         imageDescription=imageDescription,
@@ -189,7 +189,7 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
 
         refRunName = refConfig.get('runs', 'mainRunName')
         galleryName = None
-        refTitleLabel = 'Ref: {}'.format(refRunName)
+        controlTitleLabel = 'Ref: {}'.format(refRunName)
 
         for season in seasons:
             for comparisonGridName in comparisonGridNames:
@@ -211,8 +211,8 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
                         outFileLabel='iceconc{}'.format(hemisphere),
                         fieldNameInTitle='Sea ice concentration',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=mpasFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=mpasFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel='Main - Reference',
                         unitsLabel=r'fraction',
                         imageDescription=imageDescription,

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -105,15 +105,15 @@ class ClimatologyMapSeaIceThick(AnalysisTask):  # {{{
             iselValues=iselValues)
 
         if refConfig is None:
-            refTitleLabel = 'Observations (ICESat)'
+            controlTitleLabel = 'Observations (ICESat)'
             galleryName = 'Observations: ICESat'
             diffTitleLabel = 'Model - Observations'
-            refFieldName = 'seaIceThick'
+            controlFieldName = 'seaIceThick'
         else:
             refRunName = refConfig.get('runs', 'mainRunName')
             galleryName = None
-            refTitleLabel = 'Ref: {}'.format(refRunName)
-            refFieldName = mpasFieldName
+            controlTitleLabel = 'Ref: {}'.format(refRunName)
+            controlFieldName = mpasFieldName
             diffTitleLabel = 'Main - Reference'
 
             remapObservationsSubtask = None
@@ -129,7 +129,7 @@ class ClimatologyMapSeaIceThick(AnalysisTask):  # {{{
                 remapObservationsSubtask = RemapObservedThickClimatology(
                         parentTask=self, seasons=[season],
                         fileName=obsFileName,
-                        outFilePrefix='{}{}_{}'.format(refFieldName,
+                        outFilePrefix='{}{}_{}'.format(controlFieldName,
                                                        hemisphere,
                                                        season),
                         comparisonGridNames=comparisonGridNames,
@@ -155,8 +155,8 @@ class ClimatologyMapSeaIceThick(AnalysisTask):  # {{{
                         outFileLabel='icethick{}'.format(hemisphere),
                         fieldNameInTitle='Sea ice thickness',
                         mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
+                        controlFieldName=controlFieldName,
+                        controlTitleLabel=controlTitleLabel,
                         diffTitleLabel=diffTitleLabel,
                         unitsLabel=r'm',
                         imageDescription=imageDescription,


### PR DESCRIPTION
This is intended to alleviate confusion in cases where "ref" referred to either observations or a reference run.  We now use "control" to refer to these cases.

I'm also including some PEP8 clean-up that helped me when I was checking for formatting and other issues with these changes.

closes #424 