### PR TITLE
Consolidate base directory for diagnostics (obs, mapping and mask files) into one config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ used those components.
 MPAS-Analysis is available as an anaconda package via the `e3sm` channel:
 
 ``` bash
-conda install -c conda-forge -c e3sm mpas_analysis
+conda create -n mpas_analysis -c conda-forge -c e3sm mpas_analysis
 ```
 
 To use the latest version for developers, you will need to set up a conda
@@ -45,9 +45,9 @@ environment with the following packages:
 
 These can be installed via the conda command:
 ``` bash
-conda install -c conda-forge numpy scipy matplotlib netCDF4 xarray dask \
-    bottleneck basemap lxml nco pyproj pillow cmocean progressbar2 requests \
-    setuptools shapely
+conda create -n mpas_analysis -c conda-forge numpy scipy matplotlib netCDF4 \
+    xarray dask bottleneck basemap lxml nco pyproj pillow cmocean \
+    progressbar2 requests setuptools shapely
 ```
 
 Then, get the code from:
@@ -60,16 +60,16 @@ If you installed the `mpas_analysis` package, download the data that is
 necessary to MPAS-Analysis by running:
 
 ``` bash
-download_analysis_data -o /path/to/output/directory
+download_analysis_data -o /path/to/mpas_analysis/diagnostics
 ```
 
 If you are using the git repository, run:
 
 ``` bash
-./download_analysis_data.py -o /path/to/output/directory
+./download_analysis_data.py -o /path/to/mpas_analysis/diagnostics
 ```
 
-where `/path/to/output/directory` is the main folder that will contain
+where `/path/to/mpas_analysis/diagnostics` is the main folder that will contain
 two subdirectories:
 
 * `mpas_analysis`, which includes mapping and region mask files for
@@ -77,6 +77,10 @@ two subdirectories:
 * `observations`, which includes the pre-processed observations listed in the
   [Observations table](http://mpas-analysis.readthedocs.io/en/latest/observations.html)
   and used to evaluate the model results
+
+Once you have downloaded the analysis data, you will point to its location
+(your equivalent of `path/to/mpas_analysis/diagnostics` above) in the config
+option `baseDirectory` in the `[diagnostics]` section.
 
 ## List Analysis
 

--- a/config.example
+++ b/config.example
@@ -78,6 +78,16 @@ ncclimoParallelMode = serial
 # mapping files and region files.
 baseDirectory = /path/to/diagnostics
 
+# Directory for mapping files (if they have been generated already). If mapping
+# files needed by the analysis are not found here, they will be generated and
+# placed in the output mappingSubdirectory.  The user can supply an absolute
+# path here to point to a path that is not within the baseDirectory above.
+mappingSubdirectory = mpas_analysis/maps
+
+# Directory for region mask files. The user can supply an absolute path here to
+# point to a path that is not within the baseDirectory above.
+regionMaskSubdirectory = mpas_analysis/region_masks
+
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -183,6 +193,14 @@ endYear = 9999
 startYear = 1
 endYear = 9999
 
+[oceanObservations]
+## options related to ocean observations with which the results will be
+## compared
+
+# subdirectory within [diagnostics]/baseDirectory where ocean observations are
+# stored.  The user can supply an absolute path here to point to a path that is
+# not within [diagnostics]/baseDirectory.
+obsSubdirectory = observations/Ocean
 
 [oceanPreprocessedReference]
 ## options related to preprocessed ocean reference run with which the results
@@ -191,6 +209,14 @@ endYear = 9999
 # directory where ocean reference simulation results are stored
 baseDirectory = /dir/to/ocean/reference
 
+[seaIceObservations]
+## options related to sea ice observations with which the results will be
+## compared
+
+# subdirectory within [diagnostics]/baseDirectory where sea ice observations
+# are stored.  The user can supply an absolute path here to point to a path
+# that is not within [diagnostics]/baseDirectory.
+obsSubdirectory = observations/SeaIce
 
 [seaIcePreprocessedReference]
 ## options related to preprocessed sea ice reference run with which the results
@@ -199,3 +225,11 @@ baseDirectory = /dir/to/ocean/reference
 # directory where ocean reference simulation results are stored
 baseDirectory = /dir/to/seaice/reference
 
+[icebergObservations]
+## options related to iceberg observations with which the results will be
+## compared
+
+# subdirectory within [diagnostics]/baseDirectory where iceberg observations
+# are stored.  The user can supply an absolute path here to point to a path
+# that is not within [diagnostics]/baseDirectory.
+obsSubdirectory = observations/Icebergs

--- a/config.example
+++ b/config.example
@@ -54,6 +54,7 @@ preprocessedReferenceRunName = None
 # performed.
 # mainRunConfigFile = /path/to/config/file
 
+
 [execute]
 ## options related to executing parallel tasks
 
@@ -64,6 +65,19 @@ parallelTaskCount = 1
 # Set this to "bck" (background parallelism) if running on a machine that can
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = serial
+
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /path/to/diagnostics
+
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -92,11 +106,6 @@ seaIceStreamsFileName = streams.seaice
 
 # names of ocean and sea ice meshes (e.g. oEC60to30, oQU240, oRRS30to10, etc.)
 mpasMeshName = mesh
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-# mappingDirectory = /dir/for/mapping/files
 
 
 [output]
@@ -174,11 +183,6 @@ endYear = 9999
 startYear = 1
 endYear = 9999
 
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /dir/to/ocean/observations
 
 [oceanPreprocessedReference]
 ## options related to preprocessed ocean reference run with which the results
@@ -187,12 +191,6 @@ baseDirectory = /dir/to/ocean/observations
 # directory where ocean reference simulation results are stored
 baseDirectory = /dir/to/ocean/reference
 
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /dir/to/seaice/observations
 
 [seaIcePreprocessedReference]
 ## options related to preprocessed sea ice reference run with which the results
@@ -201,8 +199,3 @@ baseDirectory = /dir/to/seaice/observations
 # directory where ocean reference simulation results are stored
 baseDirectory = /dir/to/seaice/reference
 
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /path/to/masks/

--- a/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -30,6 +30,17 @@ parallelTaskCount = 4
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /space2/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -45,11 +56,6 @@ seaIceHistorySubdirectory = archive/ice/hist
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oEC60to30v3
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /space2/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -125,25 +131,6 @@ endYear = 10
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 10
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /space2/diagnostics/observations/Ocean/
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /space2/diagnostics/observations/SeaIce
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /space2/diagnostics/mpas_analysis/region_masks
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -30,6 +30,17 @@ parallelTaskCount = 4
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -38,11 +49,6 @@ baseDirectory = /lus/theta-fs0/projects/OceanClimate_2/mpeterse/20171031.tenYear
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oEC60to30v3wLI
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -112,29 +118,6 @@ endYear = 9999
 startYear = 1
 endYear = 9999
 
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/observations/Ocean
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/observations/SeaIce
-
-[timeSeriesSeaIceAreaVol]
-## options related to plotting time series of sea ice area and volume
-
-# plot on polar plot
-polarPlot = False
-
-[regions]
-# Directory containing mask files for ocean basins and ice shelves
-regionMaskDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_analysis/region_masks
-
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning
 ## circulation (MOC)
@@ -146,33 +129,3 @@ regionMaskDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_a
 # NOTE: this is a temporary option that will be removed once the online
 # MOC takes into account the bolus velocity when GM is on.
 usePostprocessingScript = True
-
-[climatologyMapSoseTemperature]
-## options related to plotting climatology maps of Antarctic
-## potential temperature at various levels, including the sea floor against
-## reference model results and SOSE reanalysis data
-
-# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
-# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['JFM', 'JAS', 'ANN']
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface, 'bot' for the sea floor
-depths = ['top', -200, -400, -600, -800, 'bot']
-
-[climatologyMapSoseSalinity]
-## options related to plotting climatology maps of Antarctic
-## salinity at various levels, including the sea floor against
-## reference model results and SOSE reanalysis data
-
-# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
-# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['JFM', 'JAS', 'ANN']
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface, 'bot' for the sea floor
-depths = ['top', -200, -400, -600, -800, 'bot']
-
-[timeSeriesAntarcticMelt]
-# a list of ice shelves to plot
-#iceShelvesToPlot = ['Antarctica', 'Peninsula', 'West Antarctica', 'East Antarctica', 'Larsen_C', 'Filchner', 'Ronne', 'Filchner-Ronne', 'Brunt_Stancomb', 'Fimbul', 'Amery', 'Totten', 'Ross_West', 'Ross_East', 'Ross', 'Getz', 'Thwaites', 'Pine_Island', 'Abbot', 'George_VI']

--- a/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
+++ b/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
@@ -30,6 +30,17 @@ parallelTaskCount = 1
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = serial
 
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -38,11 +49,6 @@ baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/azamatm/E3SM_simulations
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oRRS18to6v3
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -111,52 +117,3 @@ endYear = 10
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 9999
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/observations/Ocean
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/observations/SeaIce
-
-[timeSeriesSeaIceAreaVol]
-## options related to plotting time series of sea ice area and volume
-
-# plot on polar plot
-polarPlot = False
-
-[regions]
-# Directory containing mask files for ocean basins and ice shelves
-regionMaskDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_analysis/region_masks
-
-[climatologyMapSoseTemperature]
-## options related to plotting climatology maps of Antarctic
-## potential temperature at various levels, including the sea floor against
-## reference model results and SOSE reanalysis data
-
-# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
-# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['JFM', 'JAS', 'ANN']
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface, 'bot' for the sea floor
-depths = ['top', -200, -400, -600, -800, 'bot']
-
-[climatologyMapSoseSalinity]
-## options related to plotting climatology maps of Antarctic
-## salinity at various levels, including the sea floor against
-## reference model results and SOSE reanalysis data
-
-# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
-# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['JFM', 'JAS', 'ANN']
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface, 'bot' for the sea floor
-depths = ['top', -200, -400, -600, -800, 'bot']

--- a/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+++ b/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
@@ -19,6 +19,28 @@ mainRunName = 20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
 # performed.
 # mainRunConfigFile = /path/to/config/file
 
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 6
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lcrc/group/acme/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -27,11 +49,6 @@ baseDirectory = /lcrc/group/acme/jwolfe/acme_scratch/20170926.FCT2.A_WCYCL1850S.
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oEC60to30v3
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /lcrc/group/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -106,31 +123,6 @@ endYear = 22
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 9999
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /lcrc/group/acme/diagnostics/observations/Ocean
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /lcrc/group/acme/diagnostics/observations/SeaIce
-
-[timeSeriesSeaIceAreaVol]
-## options related to plotting time series of sea ice area and volume
-
-# plot on polar plot
-polarPlot = False
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /lcrc/group/acme/diagnostics/mpas_analysis/region_masks
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -30,6 +30,17 @@ parallelTaskCount = 1
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = serial
 
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /global/project/projectdirs/acme/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -38,11 +49,6 @@ baseDirectory = /global/cscratch1/sd/mpeterse/acme_scratch/20171201.default.GMPA
 
 # names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
 mpasMeshName = oRRS30to10v3wLI
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -112,22 +118,3 @@ endYear = 10
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 10
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/Ocean/
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/SeaIce
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/region_masks

--- a/configs/edison/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/edison/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -30,6 +30,17 @@ parallelTaskCount = 4
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /global/project/projectdirs/acme/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -45,11 +56,6 @@ seaIceHistorySubdirectory = archive/ice/hist
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oEC60to30v3
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -125,25 +131,6 @@ endYear = 10
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 10
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/Ocean/
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/SeaIce
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/region_masks
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/edison/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
+++ b/configs/edison/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
@@ -30,6 +30,17 @@ parallelTaskCount = 4
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /global/project/projectdirs/acme/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -45,11 +56,6 @@ seaIceHistorySubdirectory = run
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oRRS30to10v3wLI
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -125,22 +131,3 @@ endYear = 10
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 10
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/Ocean/
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/SeaIce
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/region_masks

--- a/configs/edison/config.20180514.G.oQU240wLI.edison
+++ b/configs/edison/config.20180514.G.oQU240wLI.edison
@@ -30,6 +30,17 @@ parallelTaskCount = 8
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /global/project/projectdirs/acme/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -45,11 +56,6 @@ runSubdirectory = run
 oceanHistorySubdirectory = run
 # subdirectory for sea ice history files
 seaIceHistorySubdirectory = run
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -125,25 +131,6 @@ endYear = 9999
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 9999
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/Ocean/
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/SeaIce
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/region_masks
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -30,6 +30,17 @@ parallelTaskCount = 1
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = serial
 
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /global/project/projectdirs/acme/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -38,11 +49,6 @@ baseDirectory = /global/cscratch1/sd/fyke/ACME_simulations/B_low_res_ice_shelves
 
 # names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
 mpasMeshName = oEC60to30v3wLI
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -116,25 +122,6 @@ endYear = 10
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 9999
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/Ocean/
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /global/project/projectdirs/acme/diagnostics/observations/SeaIce
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/region_masks
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -19,6 +19,28 @@ mainRunName = MPAS-SeaIce.QU60km_polar
 # performed.
 # mainRunConfigFile = /path/to/config/file
 
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 6
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostic
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -27,11 +49,6 @@ baseDirectory = /net/scratch2/akt/MPAS/rundirs/rundir_QU60km_polar
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = QU60
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -98,17 +115,3 @@ endYear = 1961
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 9999
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/Ocean
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/SeaIce
-

--- a/configs/lanl/config.BGCphaeo4.testrun
+++ b/configs/lanl/config.BGCphaeo4.testrun
@@ -30,6 +30,17 @@ preprocessedReferenceRunName = B1850C5_ne30_v0.4
 parallelTaskCount = 6
 ncclimoParallelMode = bck
 
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -39,11 +50,6 @@ baseDirectory = /lustre/scratch3/turquoise/shanlinw/ACME/cases/BGCacme.phaeo4/ru
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oEC60to30v3
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mpas_analysis/maps/
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -115,12 +121,6 @@ endYear = 9999
 startYear = 1
 endYear = 9999
 
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/Ocean
-
 [oceanPreprocessedReference]
 ## options related to preprocessed ocean control run with which the results
 ## will be compared (e.g. a POP, CESM or ACME v0 run)
@@ -128,25 +128,12 @@ baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/Oc
 # directory where ocean reference simulation results are stored
 baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
 
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/SeaIce
-
 [seaIcePreprocessedReference]
 ## options related to preprocessed sea ice control run with which the results
 ## will be compared (e.g. a CICE, CESM or ACME v0 run)
 
 # directory where ocean reference simulation results are stored
 baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mpas_analysis/region_masks
 
 [climatologyMapBGC]
 # Variables to plot:

--- a/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
+++ b/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
@@ -30,6 +30,17 @@ preprocessedReferenceRunName = B1850C5_ne30_v0.4
 parallelTaskCount = 6
 ncclimoParallelMode = bck
 
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -38,11 +49,6 @@ baseDirectory = /lustre/scratch3/turquoise/rileybrady/ACME/cases/GMPAS-OECO-ODMS
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oRRS30to10v3
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mpas_analysis/maps/
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -114,12 +120,6 @@ endYear = 9999
 startYear = 1
 endYear = 9999
 
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/Ocean
-
 [oceanPreprocessedReference]
 ## options related to preprocessed ocean control run with which the results
 ## will be compared (e.g. a POP, CESM or ACME v0 run)
@@ -127,25 +127,12 @@ baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/Oc
 # directory where ocean reference simulation results are stored
 baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ocn/postprocessing
 
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/SeaIce
-
 [seaIcePreprocessedReference]
 ## options related to preprocessed sea ice control run with which the results
 ## will be compared (e.g. a CICE, CESM or ACME v0 run)
 
 # directory where ocean reference simulation results are stored
 baseDirectory = /usr/projects/climate/SHARED_CLIMATE/ACMEv0_lowres/B1850C5_ne30_v0.4/ice/postprocessing
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagonstics/mpas_analysis/region_masks
 
 [climatologyMapBGC]
 preindustrial = True

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -19,6 +19,28 @@ mainRunName = MatchBoth_orig
 # performed.
 # mainRunConfigFile = /path/to/config/file
 
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 6
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -27,11 +49,6 @@ baseDirectory = /lustre/scratch3/turquoise/lvanroekel/ACME/cases/MatchBoth_orig/
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oEC60to30v3
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -102,22 +119,3 @@ endYear = 9999
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 9999
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/Ocean
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /usr/projects/climate/SHARED_CLIMATE/diagnostics/observations/SeaIce
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mpas_analysis/region_masks

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -19,6 +19,28 @@ mainRunName = 20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
 # performed.
 # mainRunConfigFile = /path/to/config/file
 
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 6
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -27,11 +49,6 @@ baseDirectory = /lustre/atlas1/cli115/proj-shared/milena/ACME/simulations/201703
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oEC60to30v3
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/mpas_analysis/mpas
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -106,25 +123,6 @@ endYear = 20
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 9999
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/observations/Ocean
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/observations/SeaIce
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/mpas_analysis/region_masks/
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -19,6 +19,28 @@ mainRunName = 20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
 # performed.
 # mainRunConfigFile = /path/to/config/file
 
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 6
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -46,11 +68,6 @@ seaIceStreamsFileName = run/streams.cice
 
 # names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
 mpasMeshName = oEC60to30v3
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/mpas
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
@@ -117,25 +134,6 @@ endYear = 10
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 9999
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/observations
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/observations/SeaIce
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /lustre/atlas/proj-shared/cli115/mpas_analysis/region_masks
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -19,6 +19,28 @@ mainRunName = GMPAS-IAF_oRRS18to6v3
 # performed.
 # mainRunConfigFile = /path/to/config/file
 
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 6
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics
+
 [input]
 ## options related to reading in the results to be analyzed
 
@@ -26,11 +48,6 @@ mainRunName = GMPAS-IAF_oRRS18to6v3
 baseDirectory = /lustre/atlas1/cli115/proj-shared/vanroek/run
 
 mpasMeshName = oRRS18to6v3
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-mappingDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
@@ -106,22 +123,3 @@ endYear = 11
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 9999
-
-[oceanObservations]
-## options related to ocean observations with which the results will be compared
-
-# directory where ocean observations are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/observations/Ocean
-
-[seaIceObservations]
-## options related to sea ice observations with which the results will be
-## compared
-
-# directory where sea ice observations are stored
-baseDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/observations/SeaIce
-
-[regions]
-## options related to ocean regions used in several analysis modules
-
-# Directory for region mask files
-regionMaskDirectory = /lustre/atlas1/proj-shared/cli115/diagnostics/mpas_analysis/region_masks

--- a/docs/config/diagnostics.rst
+++ b/docs/config/diagnostics.rst
@@ -1,0 +1,65 @@
+.. _config_diagnostics:
+
+Diagnostics
+===========
+
+The ``[diagnostics]`` section of a configuration file contains options related
+to paths containing observations, region-mask files and mapping files used to
+interpolate MPAS data and observations to common reference grids::
+
+  [diagnostics]
+  ## config options related to observations, mapping files and region files used
+  ## by MPAS-Analysis in diagnostics computations.
+
+  # The base path to the diagnostics directory.  Typically, this will be a shared
+  # directory on each E3SM supported machine (see the example config files for
+  # its location).  For other machines, this would be the directory pointed to
+  # when running "download_analysis_data.py" to get the public observations,
+  # mapping files and region files.
+  baseDirectory = /path/to/diagnostics
+
+  # Directory for mapping files (if they have been generated already). If mapping
+  # files needed by the analysis are not found here, they will be generated and
+  # placed in the output mappingSubdirectory
+  mappingSubdirectory = mpas_analysis/maps
+
+  # Directory for region mask files
+  regionMaskSubdirectory = mpas_analysis/region_masks
+
+Diagnostics Directories
+-----------------------
+
+The ``baseDirectory`` is the location where files were downloaded with the
+``download_analysis_data.py``.  If the user is on an E3SM supported machine,
+this data has already been downloaded to a shared location (see example config
+files in the subdirectories of the ``configs`` directory in the MPAS-Analysis
+repository).
+
+The remaining options point to the subdirectories for mapping files (see
+below) and region masks (see :ref:`config_colormaps`), respectively.
+Typically, there is no reason to change ``mappingSubdirectory`` or
+``regionMaskSubdirectory``, as these are the standard subdirectories created
+when these files are downloaded from the `E3SM public data repository`_.
+
+.. _config_mapping_files:
+
+Mapping Files
+-------------
+
+Mapping files are used in many MPAS-Analysis tasks to remap from either the
+native MPAS mesh or an observations grid to a comparison grid (see
+:ref:`config_comparison_grids`).  By default, these mapping files are generated
+on the fly as they are needed.  This can be a time-consuming process,
+especially for high resolution meshes, so it is useful to store a cache of
+these mapping files for reuse.  Mapping files at three standard resolutions
+are avaliable on the `E3SM public data repository`_.  The mapping files for
+the two coarser resolution meshes will be downloaded automatically along with
+the publicly available observations. (See the :ref:`quick_start` for details
+on downloading this data.)
+
+If you notice that MPAS-Analysis is generating mapping files on the fly each
+time you run, you may wish to copy them from the mapping files output
+directory (the subdirectory ``mapping/`` inside the output base directory) to
+your mapping files cache directory.
+
+.. _`E3SM public data repository`: https://web.lcrc.anl.gov/public/e3sm/diagnostics/

--- a/docs/config/input.rst
+++ b/docs/config/input.rst
@@ -135,33 +135,6 @@ Mapping files (see :ref:`config_mapping_files` below) and region mask files
 `E3SM public data repository`_ for these meshes.  For assistance with other
 mesh resolutions, please contact the MPAS-Analysis developers.
 
-.. _config_mapping_files:
-
-Mapping Files
--------------
-
-Mapping files are used in many MPAS-Analysis tasks to remap from either the
-native MPAS mesh or an observations grid to a comparison grid (see
-:ref:`config_comparison_grids`).  By default, these mapping files are generated
-on the fly as they are needed.  This can be a time-consuming process,
-especially for high resolution meshes, so it is useful to store a cache of
-these mapping files for reuse.  Mapping files at three standard resolutions
-are avaliable on the `E3SM public data repository`_.  The mapping files for
-the two coarser resolution meshes will be downloaded automatically along with
-the publicly available observations. (See the :ref:`quick_start` for details
-on downloading this data.)  To specify the path to the cache of mapping files,
-add the config option::
-
-  mappingDirectory = /dir/for/mapping/files
-
-where ``/dir/for/mapping/files`` should point to the ``mpas_analysis/maps``
-subdirectory of the data downloaded from the public repo
-
-If you notice that MPAS-Analysis is generating mapping files on the fly each
-time you run, you may wish to copy them from the mapping files output
-directory (the subdirectory ``mapping/`` inside the output base directory) to
-your mapping files cache directory.
-
 Xarray and Dask
 ---------------
 

--- a/docs/config/observations.rst
+++ b/docs/config/observations.rst
@@ -1,17 +1,17 @@
 .. _config_observations:
 
-Ocean and Sea Ice Observations
-==============================
+Ocean, Sea Ice and Iceberg Observations
+=======================================
 
-The ``[oceanObservations]`` and ``[seaIceObservations]`` sections of a
-configuration file contain options used to point to the observations files and
-folders::
+The ``[oceanObservations]``, ``[seaIceObservations]`` and
+``[icebergObservations]`` sections of a configuration file contain options used
+to point to the observations files and folders::
 
   [oceanObservations]
   ## options related to ocean observations with which the results will be compared
 
   # directory where ocean observations are stored
-  baseDirectory = /dir/to/ocean/observations
+  obsSubdirectory = observations/Ocean
   sstSubdirectory = SST
   sssSubdirectory = SSS
   mldSubdirectory = MLD
@@ -43,7 +43,7 @@ folders::
   ## compared
 
   # directory where sea ice observations are stored
-  baseDirectory = /dir/to/seaice/observations
+  obsSubdirectory = observations/SeaIce
 
   # interpolation order for observations. Likely values are
   #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
@@ -58,17 +58,27 @@ folders::
   climatologySubdirectory = clim/obs
   remappedClimSubdirectory = clim/obs/remapped
 
+  ...
+
+  [icebergObservations]
+  ## options related to iceberg observations with which the results will be
+  ## compared
+
+  # directory where sea ice observations are stored
+  obsSubdirectory = observations/Icebergs
+  concentrationAltibergSH = Altiberg/Altiberg_1991-2017.nc
+
+
 Files and Directories
 ---------------------
 
-The input directories are specified through a base directory and either
-subdirectories or file names for each set of observations.  You will always
-need to set ``baseDirectory`` for both ocean and sea ice observation to
-a directory ending in ``observations/Ocean`` and ``observations/SeaIce``,
-respectively.  The rest of these paths is determined by where you downloaded
-the observationsal data from the `E3SM public data repository`_ (see the
-:ref:`quick_start` for details).  Typically, the subdirectories and individual
-files will not need to be changed except for debugging purposes.
+The input directories are specified through a "base" subdirectory
+``obsSubdirectory`` and either subdirectories or file names for each set of
+observations.  ``obsSubdirectory`` is relative to ``baseDirectory`` in the
+``diagnostics`` section, while all file paths and other subdirectories are
+relative to ``obsSubdirectory``.  You will typically not need to change any
+of these paths, since they are structured in a standard way following the
+ `E3SM public data repository`_ (see the :ref:`quick_start` for more details).
 
 The directories for storing cached datasets before and afer remapping
 (specified in ``climatologySubdirectory`` and ``remappedClimSubdirectory``)

--- a/docs/config/regions.rst
+++ b/docs/config/regions.rst
@@ -18,9 +18,6 @@ within MPAS-Analysis using region mask files::
   plotTitles = ['Arctic', 'Equatorial (15S-15N)', 'Southern Ocean', 'Nino 3',
                 'Nino 4', 'Nino 3.4', 'Global Ocean']
 
-  # Directory for region mask files
-  regionMaskDirectory = /path/to/masks/
-
 Region Names
 ------------
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -16,6 +16,7 @@ options that are most commonly modified.
 
    config/runs
    config/execute
+   config/diagnostics
    config/input
    config/output
    config/climatology

--- a/docs/tasks/timeSeriesAntarcticMelt.rst
+++ b/docs/tasks/timeSeriesAntarcticMelt.rst
@@ -20,7 +20,7 @@ The following configuration options are available for this task::
   ## options related to plotting time series of melt below Antarctic ice shelves
 
   # list of ice shelves to plot or ['all'] for all 106 ice shelves and regions.
-  # See "regionNames" in the ice shelf masks file in regionMaskDirectory for
+  # See "regionNames" in the ice shelf masks file in regionMaskSubdirectory for
   # details.
   iceShelvesToPlot = ['Antarctica', 'Peninsula', 'West Antarctica',
                       'East Antarctica', 'Larsen_C', 'Filchner', 'Ronne',

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -27,7 +27,8 @@ mainRunName = runName
 # preprocessed to compare against (or None to turn off comparison).  Reference
 # runs of this type would have preprocessed results because they were not
 # performed with MPAS components (so they cannot be easily ingested by
-# MPAS-Analysis)
+# MPAS-Analysis).  This run name is completely unrelated to either the "main"
+# or "control" runs performed with MPAS components referred to below.
 preprocessedReferenceRunName = None
 
 # config file for a control run to which this run will be compared.  The
@@ -55,6 +56,26 @@ parallelTaskCount = 1
 # Set this to "bck" (background parallelism) if running on a machine that can
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = serial
+
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /path/to/diagnostics
+
+# Directory for mapping files (if they have been generated already). If mapping
+# files needed by the analysis are not found here, they will be generated and
+# placed in the output mappingSubdirectory
+mappingSubdirectory = mpas_analysis/maps
+
+# Directory for region mask files
+regionMaskSubdirectory = mpas_analysis/region_masks
 
 
 [input]
@@ -95,11 +116,6 @@ file_cache_maxsize = 1200
 # current maximum chunk size assumes approximately 64GB of ram and large files
 # with a single time slice.
 maxChunkSize = 10000
-
-# Directory for mapping files (if they have been generated already). If mapping
-# files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
-# mappingDirectory = /dir/for/mapping/files
 
 
 [output]
@@ -222,9 +238,6 @@ regions = ['arctic', 'equatorial', 'so', 'nino3', 'nino4', 'nino3.4', 'global']
 plotTitles = ['Arctic', 'Equatorial (15S-15N)', 'Southern Ocean', 'Nino 3',
               'Nino 4', 'Nino 3.4', 'Global Ocean']
 
-# Directory for region mask files
-regionMaskDirectory = /path/to/masks/
-
 
 [plot]
 ## options related to plotting that are the defaults across all analysis
@@ -258,7 +271,7 @@ generate = True
 ## options related to ocean observations with which the results will be compared
 
 # directory where ocean observations are stored
-baseDirectory = /dir/to/ocean/observations
+obsSubdirectory = observations/Ocean
 sstSubdirectory = SST
 sssSubdirectory = SSS
 ekeSubdirectory = EKE
@@ -309,7 +322,7 @@ baseDirectory = /dir/to/ocean/reference
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /dir/to/seaice/observations
+obsSubdirectory = observations/SeaIce
 
 # interpolation order for observations. Likely values are
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
@@ -336,7 +349,7 @@ baseDirectory = /dir/to/seaice/reference
 ## compared
 
 # directory where sea ice observations are stored
-baseDirectory = /dir/to/iceberg/observations
+obsSubdirectory = observations/Icebergs
 concentrationAltibergSH = Altiberg/Altiberg_1991-2017.nc
 
 [timeSeriesOHCAnomaly]
@@ -934,7 +947,7 @@ colorbarTicksDifference = [-100., -50., -20., -10., -5., -2., -1., 0., 1., 2.,
 ## options related to plotting time series of melt below Antarctic ice shelves
 
 # list of ice shelves to plot or ['all'] for all 106 ice shelves and regions.
-# See "regionNames" in the ice shelf masks file in regionMaskDirectory for
+# See "regionNames" in the ice shelf masks file in regionMaskSubdirectory for
 # details.
 iceShelvesToPlot = ['Antarctica', 'Peninsula', 'West Antarctica',
                     'East Antarctica', 'Larsen_C', 'Filchner', 'Ronne',

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -71,12 +71,13 @@ baseDirectory = /path/to/diagnostics
 
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
-# placed in the output mappingSubdirectory
+# placed in the output mappingSubdirectory.  The user can supply an absolute
+# path here to point to a path that is not within the baseDirectory above.
 mappingSubdirectory = mpas_analysis/maps
 
-# Directory for region mask files
+# Directory for region mask files. The user can supply an absolute path here to
+# point to a path that is not within the baseDirectory above.
 regionMaskSubdirectory = mpas_analysis/region_masks
-
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -268,9 +269,12 @@ generate = True
 
 
 [oceanObservations]
-## options related to ocean observations with which the results will be compared
+## options related to ocean observations with which the results will be
+## compared
 
-# directory where ocean observations are stored
+# subdirectory within [diagnostics]/baseDirectory where ocean observations are
+# stored.  The user can supply an absolute path here to point to a path that is
+# not within [diagnostics]/baseDirectory.
 obsSubdirectory = observations/Ocean
 sstSubdirectory = SST
 sssSubdirectory = SSS
@@ -321,7 +325,9 @@ baseDirectory = /dir/to/ocean/reference
 ## options related to sea ice observations with which the results will be
 ## compared
 
-# directory where sea ice observations are stored
+# subdirectory within [diagnostics]/baseDirectory where sea ice observations
+# are stored.  The user can supply an absolute path here to point to a path
+# that is not within [diagnostics]/baseDirectory.
 obsSubdirectory = observations/SeaIce
 
 # interpolation order for observations. Likely values are
@@ -348,7 +354,9 @@ baseDirectory = /dir/to/seaice/reference
 ## options related to iceberg observations with which the results will be
 ## compared
 
-# directory where sea ice observations are stored
+# subdirectory within [diagnostics]/baseDirectory where iceberg observations
+# are stored.  The user can supply an absolute path here to point to a path
+# that is not within [diagnostics]/baseDirectory.
 obsSubdirectory = observations/Icebergs
 concentrationAltibergSH = Altiberg/Altiberg_1991-2017.nc
 

--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -15,7 +15,7 @@ import xarray as xr
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask, get_antarctic_stereographic_projection
@@ -102,8 +102,8 @@ class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
             refTitleLabel = \
                 'Observations (Rignot et al, 2013)'
 
-            observationsDirectory = build_config_full_path(
-                config, 'oceanObservations', 'meltSubdirectory')
+            observationsDirectory = build_obs_path(
+                config, 'ocean', 'meltSubdirectory')
 
             obsFileName = \
                 '{}/Rignot_2013_melt_rates_6000.0x6000.0km_10.0km_' \

--- a/mpas_analysis/ocean/climatology_map_argo.py
+++ b/mpas_analysis/ocean/climatology_map_argo.py
@@ -26,7 +26,7 @@ from mpas_analysis.ocean.remap_depth_slices_subtask import \
 from mpas_analysis.ocean.plot_climatology_map_subtask import \
     PlotClimatologyMapSubtask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.climatology import RemapObservedClimatologySubtask
 
@@ -114,8 +114,8 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
             refTitleLabel = 'Roemmich-Gilson Argo Climatology: Potential ' \
                             'Temperature'
 
-            observationsDirectory = build_config_full_path(
-                config, 'oceanObservations', 'argoSubdirectory')
+            observationsDirectory = build_obs_path(
+                config, 'ocean', 'argoSubdirectory')
 
             obsFileName = \
                 '{}/ArgoClimatology_TS.nc'.format(
@@ -254,8 +254,8 @@ class ClimatologyMapArgoSalinity(AnalysisTask):  # {{{
 
             refTitleLabel = 'Roemmich-Gilson Argo Climatology: Salinity'
 
-            observationsDirectory = build_config_full_path(
-                config, 'oceanObservations', 'argoSubdirectory')
+            observationsDirectory = build_obs_path(
+                config, 'ocean', 'argoSubdirectory')
 
             obsFileName = \
                 '{}/ArgoClimatology_TS.nc'.format(

--- a/mpas_analysis/ocean/climatology_map_bgc.py
+++ b/mpas_analysis/ocean/climatology_map_bgc.py
@@ -12,7 +12,7 @@ import xarray as xr
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
@@ -121,9 +121,8 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
                 if preindustrial and 'DIC' in fieldName:
                     refTitleLabel += ' (Preindustrial)'
 
-                observationsDirectory = build_config_full_path(
-                    config, 'oceanObservations',
-                    '{}Subdirectory'.format(fieldName))
+                observationsDirectory = build_obs_path(
+                    config, 'ocean', '{}Subdirectory'.format(fieldName))
 
                 # If user wants to compare to preindustrial data, make sure
                 # that we load in the right DIC field.
@@ -178,7 +177,7 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
                     subtask = PlotClimatologyMapSubtask(
                             self, season, comparisonGridName,
                             remapClimatologySubtask, remapObservationsSubtask,
-                            controlConfig, subtaskName = 'plot{}_{}_{}'.format(
+                            controlConfig, subtaskName='plot{}_{}_{}'.format(
                                 fieldName, season, comparisonGridName))
 
                     subtask.set_plot_info(

--- a/mpas_analysis/ocean/climatology_map_eke.py
+++ b/mpas_analysis/ocean/climatology_map_eke.py
@@ -201,10 +201,10 @@ class RemapMpasEKEClimatology(RemapMpasClimatologySubtask):  # {{{
         # calculate mpas eddy kinetic energy
         scaleFactor = 100 * 100  # m2/s2 to cm2/s2
         eke = 0.5 * scaleFactor * \
-            (climatology.timeMonthly_avg_velocityZonalSquared
-             - climatology.timeMonthly_avg_velocityZonal ** 2
-             + climatology.timeMonthly_avg_velocityMeridionalSquared
-             - climatology.timeMonthly_avg_velocityMeridional ** 2)
+            (climatology.timeMonthly_avg_velocityZonalSquared -
+             climatology.timeMonthly_avg_velocityZonal ** 2 + 
+             climatology.timeMonthly_avg_velocityMeridionalSquaread -
+             climatology.timeMonthly_avg_velocityMeridional ** 2)
 
         # drop unnecessary fields before re-mapping
         climatology.drop(['timeMonthly_avg_velocityZonal',

--- a/mpas_analysis/ocean/climatology_map_eke.py
+++ b/mpas_analysis/ocean/climatology_map_eke.py
@@ -12,17 +12,13 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 import xarray as xr
-import datetime
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
-
-from mpas_analysis.ocean.remap_depth_slices_subtask import \
-    RemapDepthSlicesSubtask
 
 from mpas_analysis.ocean.plot_climatology_map_subtask import \
     PlotClimatologyMapSubtask
@@ -109,9 +105,8 @@ class ClimatologyMapEKE(AnalysisTask):  # {{{
             refTitleLabel = \
                 'Observations (Surface EKE from Drifter Data)'
 
-            observationsDirectory = build_config_full_path(
-                config, 'oceanObservations',
-                '{}Subdirectory'.format(fieldName))
+            observationsDirectory = build_obs_path(
+                config, 'ocean', '{}Subdirectory'.format(fieldName))
 
             obsFileName = \
                 "{}/drifter_variance.nc".format(
@@ -207,9 +202,9 @@ class RemapMpasEKEClimatology(RemapMpasClimatologySubtask):  # {{{
         scaleFactor = 100 * 100  # m2/s2 to cm2/s2
         eke = 0.5 * scaleFactor * \
             (climatology.timeMonthly_avg_velocityZonalSquared
-            - climatology.timeMonthly_avg_velocityZonal ** 2
-            + climatology.timeMonthly_avg_velocityMeridionalSquared
-            - climatology.timeMonthly_avg_velocityMeridional ** 2)
+             - climatology.timeMonthly_avg_velocityZonal ** 2
+             + climatology.timeMonthly_avg_velocityMeridionalSquared
+             - climatology.timeMonthly_avg_velocityMeridional ** 2)
 
         # drop unnecessary fields before re-mapping
         climatology.drop(['timeMonthly_avg_velocityZonal',

--- a/mpas_analysis/ocean/climatology_map_mld.py
+++ b/mpas_analysis/ocean/climatology_map_mld.py
@@ -16,7 +16,8 @@ import numpy as np
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_config_full_path, \
+    build_obs_path
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
@@ -97,9 +98,8 @@ class ClimatologyMapMLD(AnalysisTask):  # {{{
 
         if controlConfig is None:
 
-            observationsDirectory = build_config_full_path(
-                config, 'oceanObservations',
-                '{}Subdirectory'.format(fieldName))
+            observationsDirectory = build_obs_path(
+                config, 'ocean', '{}Subdirectory'.format(fieldName))
 
             obsFileName = "{}/holtetalley_mld_climatology.nc".format(
                     observationsDirectory)

--- a/mpas_analysis/ocean/climatology_map_schmidtko.py
+++ b/mpas_analysis/ocean/climatology_map_schmidtko.py
@@ -25,7 +25,7 @@ from mpas_analysis.ocean.remap_depth_slices_subtask import \
 from mpas_analysis.ocean.plot_climatology_map_subtask import \
     PlotClimatologyMapSubtask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.climatology import RemapObservedClimatologySubtask, \
     get_antarctic_stereographic_projection
@@ -102,8 +102,8 @@ class ClimatologyMapSchmidtko(AnalysisTask):  # {{{
             raise ValueError('config section {} does not contain valid list '
                              'of comparison grids'.format(sectionName))
 
-        observationsDirectory = build_config_full_path(
-            config, 'oceanObservations', 'schmidtkoSubdirectory')
+        observationsDirectory = build_obs_path(
+            config, 'ocean', 'schmidtkoSubdirectory')
 
         obsFileName = '{}/Schmidtko_et_al_2014_bottom_PT_S_PD_' \
                       '6000.0x6000.0km_10.0km_Antarctic_stereo.nc' \

--- a/mpas_analysis/ocean/climatology_map_sose.py
+++ b/mpas_analysis/ocean/climatology_map_sose.py
@@ -28,7 +28,7 @@ from mpas_analysis.ocean.plot_climatology_map_subtask import \
     PlotClimatologyMapSubtask
 from mpas_analysis.ocean.remap_sose_climatology import RemapSoseClimatology
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 
 class ClimatologyMapSose(AnalysisTask):  # {{{
@@ -193,8 +193,8 @@ class ClimatologyMapSose(AnalysisTask):  # {{{
 
                 refTitleLabel = 'State Estimate (SOSE)'
 
-                observationsDirectory = build_config_full_path(
-                    config, 'oceanObservations', 'soseSubdirectory')
+                observationsDirectory = build_obs_path(
+                    config, 'ocean', 'soseSubdirectory')
 
                 obsFileName = \
                     '{}/SOSE_2005-2010_monthly_{}_6000.0x' \

--- a/mpas_analysis/ocean/climatology_map_ssh.py
+++ b/mpas_analysis/ocean/climatology_map_ssh.py
@@ -15,7 +15,7 @@ import xarray as xr
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
@@ -100,9 +100,8 @@ class ClimatologyMapSSH(AnalysisTask):  # {{{
             refTitleLabel = 'Observations (AVISO Dynamic ' \
                 'Topography, 1993-2010)'
 
-            observationsDirectory = build_config_full_path(
-                config, 'oceanObservations',
-                '{}Subdirectory'.format(fieldName))
+            observationsDirectory = build_obs_path(
+                config, 'ocean', '{}Subdirectory'.format(fieldName))
 
             obsFileName = \
                 "{}/zos_AVISO_L4_199210-201012.nc".format(

--- a/mpas_analysis/ocean/climatology_map_sss.py
+++ b/mpas_analysis/ocean/climatology_map_sss.py
@@ -16,7 +16,7 @@ import datetime
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
@@ -98,9 +98,8 @@ class ClimatologyMapSSS(AnalysisTask):  # {{{
             refTitleLabel = \
                 'Observations (Aquarius, 2011-2014)'
 
-            observationsDirectory = build_config_full_path(
-                config, 'oceanObservations',
-                '{}Subdirectory'.format(fieldName))
+            observationsDirectory = build_obs_path(
+                config, 'ocean', '{}Subdirectory'.format(fieldName))
 
             obsFileName = \
                 "{}/Aquarius_V3_SSS_Monthly.nc".format(

--- a/mpas_analysis/ocean/climatology_map_sst.py
+++ b/mpas_analysis/ocean/climatology_map_sst.py
@@ -16,7 +16,7 @@ import datetime
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
@@ -106,9 +106,8 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
                 'Observations (Hadley/OI, {} {:04d}-{:04d})'.format(
                         period, climStartYear, climEndYear)
 
-            observationsDirectory = build_config_full_path(
-                config, 'oceanObservations',
-                '{}Subdirectory'.format(fieldName))
+            observationsDirectory = build_obs_path(
+                config, 'ocean', '{}Subdirectory'.format(fieldName))
 
             obsFileName = \
                 "{}/MODEL.SST.HAD187001-198110.OI198111-201203.nc".format(

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -23,7 +23,8 @@ import matplotlib.pyplot as plt
 
 from mpas_analysis.shared.climatology import climatology
 from mpas_analysis.shared.constants import constants
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_config_full_path, \
+    build_obs_path
 
 from mpas_analysis.shared.timekeeping.utility import datetime_to_days, \
     string_to_days_since_date
@@ -158,8 +159,8 @@ class IndexNino34(AnalysisTask):  # {{{
 
         dataSource = config.get('indexNino34', 'observationData')
 
-        observationsDirectory = build_config_full_path(
-            config, 'oceanObservations', '{}Subdirectory'.format(fieldName))
+        observationsDirectory = build_obs_path(
+            config, 'ocean', '{}Subdirectory'.format(fieldName))
 
         # specify obsTitle based on data path
         # These are the only data sets supported

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -19,7 +19,7 @@ import os
 from mpas_analysis.shared.plot.plotting import plot_vertical_section, plot_1D
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    make_directories
+    make_directories, build_obs_path
 from mpas_analysis.shared.io import write_netcdf, subset_variables
 
 from mpas_analysis.shared import AnalysisTask
@@ -109,8 +109,8 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
                                            'compareWithObservations')
         self.observationsFile = None
         if compareWithObs:
-            observationsDirectory = build_config_full_path(
-                config, 'oceanObservations', 'mhtSubdirectory')
+            observationsDirectory = build_obs_path(
+                config, 'ocean', 'mhtSubdirectory')
             observationsFile = config.get(self.sectionName, 'observationData')
             observationsFile = '{}/{}'.format(observationsDirectory,
                                               observationsFile)

--- a/mpas_analysis/ocean/plot_climatology_map_subtask.py
+++ b/mpas_analysis/ocean/plot_climatology_map_subtask.py
@@ -399,7 +399,11 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
             depthIndex = -1
             for index, depthSlice in enumerate(
                     remappedRefClimatology.depthSlice.values):
-                if depthSlice.decode("utf-8") == str(depth):
+                try:
+                    depthSlice = depthSlice.decode("utf-8")
+                except AttributeError:
+                    pass
+                if depthSlice == str(depth):
                     depthIndex = index
             if depthIndex == -1:
                 raise KeyError('The climatology you are attempting to perform '

--- a/mpas_analysis/ocean/sose_transects.py
+++ b/mpas_analysis/ocean/sose_transects.py
@@ -27,7 +27,7 @@ from mpas_analysis.ocean.compute_transects_with_vel_mag import \
 from mpas_analysis.ocean.plot_transect_subtask import PlotTransectSubtask
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    make_directories
+    make_directories, build_obs_path
 from mpas_analysis.shared.io import write_netcdf
 
 
@@ -301,8 +301,8 @@ class SoseTransectsObservations(TransectsObservations):  # {{{
 
         longitudes.sort()
 
-        observationsDirectory = build_config_full_path(
-            config, 'oceanObservations', 'soseSubdirectory')
+        observationsDirectory = build_obs_path(
+            config, 'ocean', 'soseSubdirectory')
 
         outObsDirectory = build_config_full_path(
             config=config, section='output',

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -378,7 +378,8 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
 
         # Load basin region related variables and save them to dictionary
         mpasMeshName = config.get('input', 'mpasMeshName')
-        regionMaskDirectory = config.get('regions', 'regionMaskDirectory')
+        regionMaskDirectory = build_config_full_path(config, 'diagnostics',
+                                                     'regionMasksubDirectory')
 
         dictRegion = _build_region_mask_dict(regionNames, regionMaskDirectory,
                                              mpasMeshName, self.logger)
@@ -978,7 +979,8 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
             refTopDepth, refLayerThickness = _load_mesh(self.runStreams)
 
         mpasMeshName = config.get('input', 'mpasMeshName')
-        regionMaskDirectory = config.get('regions', 'regionMaskDirectory')
+        regionMaskDirectory = build_config_full_path(config, 'diagnostics',
+                                                     'regionMasksubDirectory')
         dictRegion = _build_region_mask_dict(['Atlantic'], regionMaskDirectory,
                                              mpasMeshName, self.logger)
         dictRegion = dictRegion['Atlantic']

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -25,7 +25,7 @@ from mpas_analysis.shared.plot.plotting import timeseries_analysis_plot
 from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    make_directories
+    make_directories, build_obs_path
 
 from mpas_analysis.shared.html import write_image_xml
 
@@ -70,8 +70,8 @@ class TimeSeriesAntarcticMelt(AnalysisTask):  # {{{
             tags=['timeSeries', 'melt', 'landIceCavities'])
 
         regionMaskDirectory = build_config_full_path(config,
-                                                     'regions',
-                                                     'regionMaskDirectory')
+                                                     'diagnostics',
+                                                     'regionMaskSubdirectory')
         iceShelfMasksFile = '{}/iceShelves.geojson'.format(regionMaskDirectory)
 
         iceShelvesToPlot = config.getExpression('timeSeriesAntarcticMelt',
@@ -91,7 +91,8 @@ class TimeSeriesAntarcticMelt(AnalysisTask):  # {{{
         self.add_subtask(computeMeltSubtask)
 
         for index, iceShelf in enumerate(iceShelvesToPlot):
-            plotMeltSubtask = PlotMeltSubtask(self, iceShelf, index, controlConfig)
+            plotMeltSubtask = PlotMeltSubtask(self, iceShelf, index,
+                                              controlConfig)
             plotMeltSubtask.run_after(computeMeltSubtask)
             self.add_subtask(plotMeltSubtask)
 
@@ -428,9 +429,8 @@ class PlotMeltSubtask(AnalysisTask):
 
         # Load observations from multiple files and put in dictionary based
         # on shelf keyname
-        observationsDirectory = build_config_full_path(config,
-                                                       'oceanObservations',
-                                                       'meltSubdirectory')
+        observationsDirectory = build_obs_path(config, 'ocean',
+                                               'meltSubdirectory')
         obsFileNameDict = {'Rignot et al. (2013)':
                            'Rignot_2013_melt_rates.csv',
                            'Rignot et al. (2013) SS':

--- a/mpas_analysis/ocean/woce_transects.py
+++ b/mpas_analysis/ocean/woce_transects.py
@@ -17,7 +17,7 @@ from mpas_analysis.ocean.compute_transects_subtask import \
 
 from mpas_analysis.ocean.plot_transect_subtask import PlotTransectSubtask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from collections import OrderedDict
 
@@ -77,8 +77,8 @@ class WoceTransects(AnalysisTask):  # {{{
             verticalComparisonGrid = config.getExpression(
                     sectionName, 'verticalComparisonGrid', usenumpyfunc=True)
 
-        observationsDirectory = build_config_full_path(
-            config, 'oceanObservations', 'woceSubdirectory')
+        observationsDirectory = build_obs_path(
+            config, 'ocean', 'woceSubdirectory')
 
         obsFileNames = OrderedDict()
         for transectName in ['WOCE_A21_Drake_Passage',

--- a/mpas_analysis/sea_ice/climatology_map_berg_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_berg_conc.py
@@ -19,7 +19,7 @@ from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
 from mpas_analysis.sea_ice.plot_climatology_map_subtask import \
     PlotClimatologyMapSubtask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.grid import LatLonGridDescriptor
 
@@ -105,8 +105,8 @@ class ClimatologyMapIcebergConc(AnalysisTask):  # {{{
             galleryName = 'Observations: Altiberg'
             diffTitleLabel = 'Model - Observations'
             refFieldName = 'icebergConc'
-            obsFileName = build_config_full_path(
-                    config, 'icebergObservations',
+            obsFileName = build_obs_path(
+                    config, 'iceberg',
                     'concentrationAltiberg{}'.format(hemisphere))
 
             remapObservationsSubtask = RemapAltibergConcClimatology(

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -22,7 +22,7 @@ from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
 from mpas_analysis.sea_ice.plot_climatology_map_subtask import \
     PlotClimatologyMapSubtask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.grid import LatLonGridDescriptor
 
@@ -128,8 +128,8 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
                 observationTitleLabel = \
                     'Observations (SSM/I {})'.format(prefix)
 
-                obsFileName = build_config_full_path(
-                        config=config, section='seaIceObservations',
+                obsFileName = build_obs_path(
+                        config, 'seaIce',
                         relativePathOption='concentration{}{}_{}'.format(
                                 prefix, hemisphere, season),
                         relativePathSection=sectionName)

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -22,7 +22,7 @@ from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
 from mpas_analysis.sea_ice.plot_climatology_map_subtask import \
     PlotClimatologyMapSubtask
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.grid import LatLonGridDescriptor
 
@@ -120,8 +120,8 @@ class ClimatologyMapSeaIceThick(AnalysisTask):  # {{{
 
         for season in seasons:
             if controlConfig is None:
-                obsFileName = build_config_full_path(
-                        config=config, section='seaIceObservations',
+                obsFileName = build_obs_path(
+                        config, 'seaIce',
                         relativePathOption='thickness{}_{}'.format(hemisphere,
                                                                    season),
                         relativePathSection=sectionName)

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -20,7 +20,7 @@ from mpas_analysis.shared.plot.plotting import timeseries_analysis_plot, \
     timeseries_analysis_plot_polar
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    check_path_exists, make_directories
+    check_path_exists, make_directories, build_obs_path
 
 from mpas_analysis.shared.timekeeping.utility import date_to_days, \
     days_to_datetime, datetime_to_days, get_simulation_start_time
@@ -210,20 +210,20 @@ class TimeSeriesSeaIce(AnalysisTask):
                  'iceThickness': '[m]'}
 
         obsFileNames = {
-            'iceArea': {'NH': build_config_full_path(
-                                  config=config, section='seaIceObservations',
+            'iceArea': {'NH': build_obs_path(
+                                  config, 'seaIce',
                                   relativePathOption='areaNH',
                                   relativePathSection=sectionName),
-                        'SH': build_config_full_path(
-                                  config=config, section='seaIceObservations',
+                        'SH': build_obs_path(
+                                  config, 'seaIce',
                                   relativePathOption='areaSH',
                                   relativePathSection=sectionName)},
-            'iceVolume': {'NH': build_config_full_path(
-                                   config=config, section='seaIceObservations',
+            'iceVolume': {'NH': build_obs_path(
+                                   config, 'seaIce',
                                    relativePathOption='volNH',
                                    relativePathSection=sectionName),
-                          'SH': build_config_full_path(
-                                   config=config, section='seaIceObservations',
+                          'SH': build_obs_path(
+                                   config, 'seaIce',
                                    relativePathOption='volSH',
                                    relativePathSection=sectionName)}}
 

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -88,17 +88,12 @@ def get_remapper(config, sourceDescriptor, comparisonDescriptor,
                 comparisonDescriptor.meshName,
                 method)
 
-        if config.has_option('input', 'mappingDirectory'):
-            # a mapping directory was supplied, so we'll see if there's
-            # a mapping file there that we can use
-            mappingSubdirectory = config.get('input', 'mappingDirectory')
-            mappingFileName = '{}/{}'.format(mappingSubdirectory,
-                                             mappingBaseName)
-            if not os.path.exists(mappingFileName):
-                # nope, looks like we still need to make a mapping file
-                mappingFileName = None
+        mappingSubdirectory = build_config_full_path(config, 'diagnostics',
+                                                     'mappingSubdirectory')
 
-        if mappingFileName is None:
+        mappingFileName = '{}/{}'.format(mappingSubdirectory,
+                                         mappingBaseName)
+        if not os.path.exists(mappingFileName):
             # we don't have a mapping file yet, so get ready to create one
             # in the output subfolder if needed
             mappingSubdirectory = \

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -107,7 +107,7 @@ def build_config_full_path(config, section, relativePathOption,
                            relativePathSection=None,
                            defaultPath=None):  # {{{
     """
-    Returns a full path from a base directory and a relative path
+    Get a full path from a base directory and a relative path
 
     Parameters
     ----------
@@ -116,17 +116,23 @@ def build_config_full_path(config, section, relativePathOption,
 
     section : str
         the name of a section in `config`, which must have an option
-        `baseDirectory`
+        ``baseDirectory``
 
     relativePathOption : str
-        the name of an option in `section` of the relative path within
-        `baseDirectory` (or possibly an absolute path)
+        the name of an option in ``section`` of the relative path within
+        ``baseDirectory`` (or possibly an absolute path)
 
     relativePathSection : str, optional
-        the name of a section for `relativePathOption` if not `section`
+        the name of a section for ``relativePathOption`` if not ``section``
 
     defaultPath : str, optional
         the name of a path to return if the resulting path doesn't exist.
+
+    Returns
+    -------
+    fullPath : str
+        The full path to the given relative path within the given
+        ``baseDirectory``
     """
     # Authors
     # -------
@@ -144,6 +150,56 @@ def build_config_full_path(config, section, relativePathOption,
 
     if defaultPath is not None and not os.path.exists(fullPath):
         fullPath = defaultPath
+    return fullPath  # }}}
+
+
+def build_obs_path(config, component, relativePathOption,
+                   relativePathSection=None):  # {{{
+    """
+
+    Parameters
+    ----------
+    config : MpasAnalysisConfigParser object
+        configuration from which to read the path
+
+    component : {'ocean', 'seaIce', 'iceberg'}
+        the prefix on the ``*Observations`` section in ``config``, which must
+        have an option ``obsSubdirectory``
+
+    relativePathOption : str
+        the name of an option in `section` of the relative path within
+        ``obsSubdirectory`` (or possibly an absolute path)
+
+    relativePathSection : str, optional
+        the name of a section for ``relativePathOption`` if not
+        ``<component>Observations``
+
+    Returns
+    -------
+    fullPath : str
+        The full path to the given relative path within the observations
+        directory for the given component
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    obsSection = '{}Observations'.format(component)
+    if relativePathSection is None:
+        relativePathSection = obsSection
+
+    relativePath = config.get(relativePathSection, relativePathOption)
+    if os.path.isabs(relativePath):
+        fullPath = relativePath
+    else:
+        obsSubdirectory = config.get(obsSection, 'obsSubdirectory')
+        if os.path.isabs(obsSubdirectory):
+            fullPath = '{}/{}'.format(obsSubdirectory, relativePath)
+        else:
+            basePath = config.get('diagnostics', 'baseDirectory')
+            fullPath = '{}/{}/{}'.format(basePath, obsSubdirectory,
+                                         relativePath)
+
     return fullPath  # }}}
 
 

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -164,8 +164,8 @@ class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
         # first, see if we have cached a mask file name in the region masks
         # directory
         regionMaskDirectory = build_config_full_path(self.config,
-                                                     'regions',
-                                                     'regionMaskDirectory')
+                                                     'diagnostics',
+                                                     'regionMaskSubdirectory')
         self.maskFileName = '{}/{}_{}.nc'.format(regionMaskDirectory,
                                                  mpasMeshName,
                                                  self.outFileSuffix)

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -50,6 +50,11 @@ class TestClimatology(TestCase):
 
     def setup_config(self, maxChunkSize=10000):
         config = MpasAnalysisConfigParser()
+
+        config.add_section('diagnostics')
+        config.set('diagnostics', 'baseDirectory', self.test_dir)
+        config.set('diagnostics', 'mappingSubdirectory', 'maps')
+
         config.add_section('input')
         config.set('input', 'maxChunkSize', str(maxChunkSize))
         config.set('input', 'mpasMeshName', 'QU240')
@@ -145,8 +150,6 @@ class TestClimatology(TestCase):
 
         for mappingFileName, setName in [(defaultMappingFileName,  False),
                                          (explicitMappingFileName, True)]:
-            if setName:
-                config.set('input', 'mappingDirectory', explicitMappingPath)
 
             remapper = self.setup_mpas_remapper(config)
 
@@ -178,9 +181,6 @@ class TestClimatology(TestCase):
 
         for mappingFileName, setName in [(defaultMappingFileName,  False),
                                          (explicitMappingFileName, True)]:
-
-            if setName:
-                config.set('input', 'mappingDirectory', explicitMappingPath)
 
             remapper = self.setup_obs_remapper(config, fieldName)
 

--- a/mpas_analysis/test/test_mpas_climatology_task/config.QU240
+++ b/mpas_analysis/test/test_mpas_climatology_task/config.QU240
@@ -5,6 +5,10 @@ mainRunName = runName
 parallelTaskCount = 1
 ncclimoParallelMode = serial
 
+[diagnostics]
+baseDirectory = /dir/for/model/output
+mappingSubdirectory = .
+
 [input]
 baseDirectory = /dir/for/model/output
 runSubdirectory = .

--- a/mpas_analysis/test/test_remap_obs_clim_subtask.py
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask.py
@@ -110,7 +110,8 @@ class TestRemapObsClimSubtask(TestCase):
         config = MpasAnalysisConfigParser()
         config.read(str(configPath))
         config.set('input', 'baseDirectory', str(self.datadir))
-        config.set('oceanObservations', 'baseDirectory', str(self.datadir))
+        config.set('diagnostics', 'baseDirectory', str(self.datadir))
+        config.set('oceanObservations', 'obsSubdirectory', '.')
         config.set('output', 'baseDirectory', str(self.test_dir))
         return config
 

--- a/mpas_analysis/test/test_remap_obs_clim_subtask/config.remap_obs
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask/config.remap_obs
@@ -1,5 +1,6 @@
 [diagnostics]
 baseDirectory = /dir/to/diagnostics
+mappingSubdirectory = .
 
 [input]
 baseDirectory = /dir/for/model/output

--- a/mpas_analysis/test/test_remap_obs_clim_subtask/config.remap_obs
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask/config.remap_obs
@@ -1,3 +1,6 @@
+[diagnostics]
+baseDirectory = /dir/to/diagnostics
+
 [input]
 baseDirectory = /dir/for/model/output
 runSubdirectory = .
@@ -22,7 +25,7 @@ useNcremap = True
 renormalizationThreshold = 0.01
 
 [oceanObservations]
-baseDirectory = /dir/to/ocean/observations
+obsSubdirectory = .
 interpolationMethod = bilinear
 climatologySubdirectory = clim/obs
 remappedClimSubdirectory = clim/obs/remapped


### PR DESCRIPTION
This merge consolidates the base directory for diagnostics in each config file into one `baseDirectory` option in the new `[diagnostics]` section.  This means there is only one option that needs to be changed in order to point to the diagnostics directory on each machine instead of needing to set this directory in 4 or 5 different places.

The new `[diagnostics]` section includes the `baseDirectory` as well as the mapping and region-masks subdirectories, using the standard directory layout as on the E3SM diagnostics server.

The various `*Observations` sections (for ocean, sea ice and icebergs) have also been modified to reference this new standard base directory so users will need to change very little to set up a new config file.

Many tasks and quite a bit of documentation needed to be updated to handle these seemingly minor changes.

Example config file have also been updated with new diagnostics section.  Various other sections and options were removed as a result of the simplification.

A bug was fixed (for my convenience in debugging the code)  in the `PlotClimatologyMpasSubtask` where `decode()` was being called on `depthSlice` even though this is already a string (not an array of bytes) in python 3.  This bug shouldn't affect analysis performed with python 2.