### PR TITLE
Update names of streams and namelist files in example config files

### DIFF
--- a/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -53,10 +53,10 @@ mappingDirectory = /space2/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = run/mpas-o_in
+oceanNamelistFileName = run/mpaso_in
 oceanStreamsFileName = run/streams.ocean
-seaIceNamelistFileName = run/mpas-cice_in
-seaIceStreamsFileName = run/streams.cice
+seaIceNamelistFileName = run/mpassi_in
+seaIceStreamsFileName = run/streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -46,10 +46,10 @@ mappingDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_anal
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
+++ b/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
@@ -46,10 +46,10 @@ mappingDirectory = /lus/theta-fs0/projects/ClimateEnergy_2/diagnostics/mpas_anal
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
+++ b/configs/anvil/config.20170926.FCT2.A_WCYCL1850S.ne30_oECv3.anvil
@@ -35,10 +35,10 @@ mappingDirectory = /lcrc/group/acme/diagnostics/mpas_analysis/maps
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -46,10 +46,10 @@ mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/ma
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/edison/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/edison/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -53,10 +53,10 @@ mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/ma
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = run/mpas-o_in
+oceanNamelistFileName = run/mpaso_in
 oceanStreamsFileName = run/streams.ocean
-seaIceNamelistFileName = run/mpas-cice_in
-seaIceStreamsFileName = run/streams.cice
+seaIceNamelistFileName = run/mpassi_in
+seaIceStreamsFileName = run/streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/edison/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
+++ b/configs/edison/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
@@ -53,10 +53,10 @@ mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/ma
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = run/mpas-o_in
+oceanNamelistFileName = run/mpaso_in
 oceanStreamsFileName = run/streams.ocean
-seaIceNamelistFileName = run/mpas-cice_in
-seaIceStreamsFileName = run/streams.cice
+seaIceNamelistFileName = run/mpassi_in
+seaIceStreamsFileName = run/streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/edison/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -46,10 +46,10 @@ mappingDirectory = /global/project/projectdirs/acme/diagnostics/mpas_analysis/ma
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -35,10 +35,10 @@ mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mp
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/lanl/config.BGCphaeo4.testrun
+++ b/configs/lanl/config.BGCphaeo4.testrun
@@ -47,10 +47,10 @@ mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mp
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
+++ b/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
@@ -48,8 +48,8 @@ mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mp
 # or an absolute path.
 oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpascice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -35,10 +35,10 @@ mappingDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics/mp
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -35,10 +35,10 @@ mappingDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/mpas_analysis/mp
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -39,10 +39,10 @@ seaIceHistorySubdirectory = archive/ice/hist
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = run/mpas-o_in
+oceanNamelistFileName = run/mpaso_in
 oceanStreamsFileName = run/streams.ocean
-seaIceNamelistFileName = run/mpas-cice_in
-seaIceStreamsFileName = run/streams.cice
+seaIceNamelistFileName = run/mpassi_in
+seaIceStreamsFileName = run/streams.seaice
 
 # names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
 mpasMeshName = oEC60to30v3

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -34,10 +34,10 @@ mappingDirectory = /lustre/atlas/proj-shared/cli115/diagnostics/mpas_analysis/ma
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpas-o_in
+oceanNamelistFileName = mpaso_in
 oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpas-cice_in
-seaIceStreamsFileName = streams.cice
+seaIceNamelistFileName = mpassi_in
+seaIceStreamsFileName = streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,


### PR DESCRIPTION
Some of the example config files had old names for MPAS streams and namelist files. This PR updates these example config files to the current file names.