### PR TITLE
Fix unsupported file_cache_maxsize for older xarray

### DIFF
--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -748,8 +748,12 @@ def main():
 
     update_time_bounds_in_config(config)
 
-    xarray.set_options(file_cache_maxsize=config.getint('input',
-                                                        'file_cache_maxsize'))
+    file_cache_maxsize = config.getint('input', 'file_cache_maxsize')
+    try:
+        xarray.set_options(file_cache_maxsize=file_cache_maxsize)
+    except ValueError:
+        # xarray version doesn't support file_cache_maxsize yet...
+        pass
 
     analyses = build_analysis_list(config, controlConfig)
     analyses = determine_analyses_to_generate(analyses)


### PR DESCRIPTION
Older versions of xarray are not supported after #501, which is undesirable and unnecessary.  All that is needed to fix this is to not raise and exception if `file_cache_maxsize` is not supported in a given xarray version.

closes #505