### PR TITLE
Add support for Stickler CI for python

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,0 +1,7 @@
+linters:
+  pep8:
+    python: 3
+    fixer: true
+    max-line-length: 80
+fixers:
+  enable: true


### PR DESCRIPTION
Stickler CI makes sure that code is PEP8 compliant, either providing comments if it is not or adding commits to fix code if needed.

closes #507 