### PR TITLE
Make output during setup-and-check phase less verbose

### DIFF
--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - pytest
   - six
-  - numpy
+  - numpy<1.16.0
   - scipy
   - lxml
   - xarray


### PR DESCRIPTION
The full stack trace is available with the `--verbose` flag

closes #504 