### PR TITLE
Fix PEP8 issues in the whole code, in anticipation of v1.2

### DIFF
--- a/docs/parse_table.py
+++ b/docs/parse_table.py
@@ -137,13 +137,13 @@ def build_obs_pages_from_xml(xmlfile):
 
         rst.write('.. _{}:\n\n'.format(nameInDocs))
         rst.write('{}\n'.format(name))
-        rst.write('='*len(name))
+        rst.write('=' * len(name))
         rst.write('\n\n')
 
         for tag in titles:
             title = titles[tag]
             rst.write('{}\n'.format(title))
-            rst.write('{}\n'.format('-'*len(title)))
+            rst.write('{}\n'.format('-' * len(title)))
             text = entry.findall(tag)[0].text.strip()
             if tag == 'tasks':
                 text = add_task_links(text)
@@ -160,7 +160,7 @@ def build_obs_pages_from_xml(xmlfile):
                     # add a link to the bibtex file
                     subdirectory = entry.findall('subdirectory')[0].text.strip()
                     text = '{}\n\n[bibtex file]({}/{}/obs.bib)'.format(
-                            text, urlBase, subdirectory)
+                        text, urlBase, subdirectory)
 
             text, footer = cleanup(text, footer)
             rst.write('{}\n\n'.format(text))
@@ -172,7 +172,7 @@ def build_obs_pages_from_xml(xmlfile):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-            description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-x", "--xml_table", dest="xml_table",
                         help="Path to file containing "
                              "xml description of table",

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -114,7 +114,7 @@ def build_analysis_list(config, controlConfig):  # {{{
                                         section='index')
 
     oceanRefYearClimatolgyTask = RefYearMpasClimatologyTask(
-            config=config,  componentName='ocean')
+        config=config, componentName='ocean')
 
     analyses.append(oceanClimatolgyTask)
     analyses.append(oceanRefYearClimatolgyTask)
@@ -130,21 +130,21 @@ def build_analysis_list(config, controlConfig):  # {{{
     analyses.append(ocean.ClimatologyMapEKE(config, oceanClimatolgyTask,
                                             controlConfig))
     analyses.append(ocean.ClimatologyMapOHCAnomaly(
-            config, oceanClimatolgyTask, oceanRefYearClimatolgyTask,
-            controlConfig))
+        config, oceanClimatolgyTask, oceanRefYearClimatolgyTask,
+        controlConfig))
 
     analyses.append(ocean.ClimatologyMapSose(
-            config, oceanClimatolgyTask, controlConfig))
+        config, oceanClimatolgyTask, controlConfig))
     analyses.append(ocean.ClimatologyMapBGC(config, oceanClimatolgyTask,
                                             controlConfig))
 
     analyses.append(ocean.ClimatologyMapArgoTemperature(
-            config, oceanClimatolgyTask, controlConfig))
+        config, oceanClimatolgyTask, controlConfig))
     analyses.append(ocean.ClimatologyMapArgoSalinity(
-            config, oceanClimatolgyTask, controlConfig))
+        config, oceanClimatolgyTask, controlConfig))
 
     analyses.append(ocean.ClimatologyMapSchmidtko(
-            config, oceanClimatolgyTask, controlConfig))
+        config, oceanClimatolgyTask, controlConfig))
 
     analyses.append(ocean.ClimatologyMapAntarcticMelt(config,
                                                       oceanClimatolgyTask,
@@ -188,17 +188,17 @@ def build_analysis_list(config, controlConfig):  # {{{
 
     analyses.append(seaIceClimatolgyTask)
     analyses.append(sea_ice.ClimatologyMapSeaIceConc(
-            config=config, mpasClimatologyTask=seaIceClimatolgyTask,
-            hemisphere='NH', controlConfig=controlConfig))
+        config=config, mpasClimatologyTask=seaIceClimatolgyTask,
+        hemisphere='NH', controlConfig=controlConfig))
     analyses.append(sea_ice.ClimatologyMapSeaIceThick(
-            config=config, mpasClimatologyTask=seaIceClimatolgyTask,
-            hemisphere='NH', controlConfig=controlConfig))
+        config=config, mpasClimatologyTask=seaIceClimatolgyTask,
+        hemisphere='NH', controlConfig=controlConfig))
     analyses.append(sea_ice.ClimatologyMapSeaIceConc(
-            config=config, mpasClimatologyTask=seaIceClimatolgyTask,
-            hemisphere='SH', controlConfig=controlConfig))
+        config=config, mpasClimatologyTask=seaIceClimatolgyTask,
+        hemisphere='SH', controlConfig=controlConfig))
     analyses.append(sea_ice.ClimatologyMapSeaIceThick(
-            config=config, mpasClimatologyTask=seaIceClimatolgyTask,
-            hemisphere='SH', controlConfig=controlConfig))
+        config=config, mpasClimatologyTask=seaIceClimatolgyTask,
+        hemisphere='SH', controlConfig=controlConfig))
     analyses.append(seaIceTimeSeriesTask)
 
     analyses.append(sea_ice.TimeSeriesSeaIce(config, seaIceTimeSeriesTask,
@@ -206,8 +206,8 @@ def build_analysis_list(config, controlConfig):  # {{{
 
     # Iceberg Analyses
     analyses.append(sea_ice.ClimatologyMapIcebergConc(
-            config=config, mpasClimatologyTask=seaIceClimatolgyTask,
-            hemisphere='SH', controlConfig=controlConfig))
+        config=config, mpasClimatologyTask=seaIceClimatolgyTask,
+        hemisphere='SH', controlConfig=controlConfig))
 
     return analyses  # }}}
 
@@ -284,7 +284,7 @@ def add_task_and_subtasks(analysisTask, analysesToGenerate, verbose,
             ValueError("task {} already added but this version was not set up "
                        "successfully. Typically, this indicates two tasks "
                        "with the same full name".format(
-                               analysisTask.fullTaskName))
+                           analysisTask.fullTaskName))
         return
 
     # for each anlaysis task, check if we want to generate this task
@@ -456,7 +456,7 @@ def run_analysis(config, analyses):  # {{{
                                                      AnalysisTask.FAIL]:
                 unfinishedCount += 1
 
-        progress.update(totalTaskCount-unfinishedCount)
+        progress.update(totalTaskCount - unfinishedCount)
 
         if unfinishedCount <= 0 and len(runningTasks.keys()) == 0:
             # we're done
@@ -467,7 +467,7 @@ def run_analysis(config, analyses):  # {{{
             if analysisTask._runStatus.value == AnalysisTask.READY:
                 if isParallel:
                     logger.info('Running {}'.format(
-                            analysisTask.printTaskName))
+                        analysisTask.printTaskName))
                     analysisTask._runStatus.value = AnalysisTask.RUNNING
                     analysisTask.start()
                     runningTasks[key] = analysisTask
@@ -486,7 +486,7 @@ def run_analysis(config, analyses):  # {{{
 
             if analysisTask._runStatus.value == AnalysisTask.SUCCESS:
                 logger.info("   Task {} has finished successfully.".format(
-                        taskTitle))
+                    taskTitle))
             elif analysisTask._runStatus.value == AnalysisTask.FAIL:
                 message = "ERROR in task {}.  See log file {} for " \
                           "details".format(taskTitle,
@@ -525,7 +525,7 @@ def run_analysis(config, analyses):  # {{{
         sys.exit(1)
     else:
         print('Log files for executed tasks can be found in {}'.format(
-                logsDirectory))
+            logsDirectory))
 
     # }}}
 
@@ -569,8 +569,8 @@ def purge_output(config):
                              'timeSeries', 'html', 'mask', 'profiles']:
             option = '{}Subdirectory'.format(subdirectory)
             directory = build_config_full_path(
-                    config=config, section='output',
-                    relativePathOption=option)
+                config=config, section='output',
+                relativePathOption=option)
             if os.path.exists(directory):
                 print('Deleting contents of {}'.format(directory))
                 if os.path.islink(directory):
@@ -583,9 +583,9 @@ def purge_output(config):
                 option = '{}Subdirectory'.format(subdirectory)
                 section = '{}Observations'.format(component)
                 directory = build_config_full_path(
-                        config=config, section='output',
-                        relativePathOption=option,
-                        relativePathSection=section)
+                    config=config, section='output',
+                    relativePathOption=option,
+                    relativePathSection=section)
                 if os.path.exists(directory):
                     print('Deleting contents of {}'.format(directory))
                     if os.path.islink(directory):
@@ -612,8 +612,8 @@ def symlink_main_run(config, defaultConfig):
             make_directories(destBase)
 
             sourceDirectory = build_config_full_path(
-                    config=mainConfig, section='output',
-                    relativePathOption=option, relativePathSection=section)
+                config=mainConfig, section='output',
+                relativePathOption=option, relativePathSection=section)
 
             os.symlink(sourceDirectory, destDirectory)
 
@@ -641,7 +641,6 @@ def symlink_main_run(config, defaultConfig):
 
 
 def main():
-
     """
     Entry point for the main script ``mpas_analysis``
     """
@@ -800,7 +799,7 @@ def download_analysis_data():
 
     urlBase = 'https://web.lcrc.anl.gov/public/e3sm/diagnostics'
     analysisFileList = pkg_resources.resource_string(
-            'mpas_analysis', 'obs/analysis_input_files').decode('utf-8')
+        'mpas_analysis', 'obs/analysis_input_files').decode('utf-8')
 
     # remove any empty strings from the list
     analysisFileList = list(filter(None, analysisFileList.split('\n')))

--- a/mpas_analysis/analysis_task_template.py
+++ b/mpas_analysis/analysis_task_template.py
@@ -177,7 +177,7 @@ class MyTask(AnalysisTask):  # {{{
         self.add_subtask(remapObservations)
 
         plotObservations = MyPlotObservationsSubtask(
-                remapObservations=remapObservations)
+            remapObservations=remapObservations)
         # This is the part that makes sure MyPlotObservationsSubtask runs after
         # MyRemapObservationsSubtask.  Note: you might do this inside of
         # MyPlotObservationsSubtask instead of here.
@@ -307,7 +307,7 @@ class MyTask(AnalysisTask):  # {{{
 
         for plotParameter in self.plotParameters:
             filePrefix = 'myPrefix_{}_{}_years{:04d}-{:04d}'.format(
-                    mainRunName, plotParameter, self.startYear, self.endYear)
+                mainRunName, plotParameter, self.startYear, self.endYear)
             self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
                                                         filePrefix))
             self.filePrefixes[plotParameter] = filePrefix
@@ -407,11 +407,11 @@ class MySubtask(AnalysisTask):
         self.parentTask = parentTask
         self.season = season
         super(MySubtask, self).__init__(
-                config=parentTask.config,
-                taskName=parentTask.taskName,
-                subtaskName=season,
-                componentName=parentTask.component,
-                tags=parentTask.tags)
+            config=parentTask.config,
+            taskName=parentTask.taskName,
+            subtaskName=season,
+            componentName=parentTask.component,
+            tags=parentTask.tags)
 
     def setup_and_check(self):
         # do whatever setup is needed for the subtask.  You don't have

--- a/mpas_analysis/configuration/mpas_analysis_config_parser.py
+++ b/mpas_analysis/configuration/mpas_analysis_config_parser.py
@@ -111,8 +111,8 @@ class MpasAnalysisConfigParser(ConfigParser):
         expressionString = self.get(section, option)
         if usenumpyfunc:
             assert '__' not in expressionString, \
-                    "'__' is not allowed in {} "\
-                    "for `usenumpyfunc=True`".format(expressionString)
+                "'__' is not allowed in {} "\
+                "for `usenumpyfunc=True`".format(expressionString)
             sanitizedstr = expressionString.replace('np.', '')\
                                            .replace('numpy.', '')\
                                            .replace('__', '')

--- a/mpas_analysis/obs/make_obs_readme_bibtex.py
+++ b/mpas_analysis/obs/make_obs_readme_bibtex.py
@@ -28,7 +28,7 @@ import os
 
 
 def spurious_newline_whitespace(data):
-    whitespace = re.findall('\n\s*', data)
+    whitespace = re.findall(r'\n\s*', data)
     if len(whitespace) > 0:
         astr = min(whitespace)
         data = data.replace(astr, "\n")
@@ -69,13 +69,13 @@ def build_readmes(xmlFile, outDir):
         readme = open('{}/README.md'.format(path), 'w')
 
         readme.write('{}\n'.format(name))
-        readme.write('='*len(name))
+        readme.write('=' * len(name))
         readme.write('\n\n')
 
         for tag in titles:
             title = titles[tag]
             readme.write('{}\n'.format(title))
-            readme.write('{}\n'.format('-'*len(title)))
+            readme.write('{}\n'.format('-' * len(title)))
             text = cleanup(entry.findall(tag)[0].text.strip())
             readme.write('{}\n\n'.format(text))
         readme.close()
@@ -113,7 +113,7 @@ def build_bibtex(xmlFile, outDir):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-            description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-o", "--outDir", dest="outDir",
                         help="Base output directory containing observations",
                         metavar="OBS_DIR", required=True)

--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -62,10 +62,10 @@ class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
         fieldName = 'meltRate'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapAntarcticMelt, self).__init__(
-                config=config, taskName='climatologyMapAntarcticMelt',
-                componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName,
-                      'landIceCavities'])
+            config=config, taskName='climatologyMapAntarcticMelt',
+            componentName='ocean',
+            tags=['climatology', 'horizontalMap', fieldName,
+                  'landIceCavities'])
 
         sectionName = self.taskName
 
@@ -113,9 +113,9 @@ class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
             galleryName = 'Observations: Rignot et al. (2013)'
 
             remapObservationsSubtask = RemapObservedAntarcticMeltClimatology(
-                    parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
-                    comparisonGridNames=comparisonGridNames)
+                parentTask=self, seasons=seasons, fileName=obsFileName,
+                outFilePrefix=refFieldName,
+                comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             diffTitleLabel = 'Model - Observations'
 
@@ -139,18 +139,18 @@ class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
                                                     controlConfig)
 
                 subtask.set_plot_info(
-                        outFileLabel=outFileLabel,
-                        fieldNameInTitle='Melt Rate',
-                        mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
-                        diffTitleLabel=diffTitleLabel,
-                        unitsLabel=r'm a$^{-1}$',
-                        imageCaption='Antarctic Melt Rate',
-                        galleryGroup='Melt Rate',
-                        groupSubtitle=None,
-                        groupLink='antarctic_melt',
-                        galleryName=galleryName)
+                    outFileLabel=outFileLabel,
+                    fieldNameInTitle='Melt Rate',
+                    mpasFieldName=mpasFieldName,
+                    refFieldName=refFieldName,
+                    refTitleLabel=refTitleLabel,
+                    diffTitleLabel=diffTitleLabel,
+                    unitsLabel=r'm a$^{-1}$',
+                    imageCaption='Antarctic Melt Rate',
+                    galleryGroup='Melt Rate',
+                    groupSubtitle=None,
+                    groupLink='antarctic_melt',
+                    galleryName=galleryName)
 
                 self.add_subtask(subtask)
         # }}}
@@ -242,7 +242,7 @@ class RemapMpasAntarcticMeltClimatology(RemapMpasClimatologySubtask):  # {{{
 
         # scale the field to m/yr from kg/m^2/s and mask out non-land-ice areas
         climatology[fieldName] = \
-            constants.sec_per_year/constants.rho_fw * \
+            constants.sec_per_year / constants.rho_fw * \
             climatology[fieldName].where(self.landIceMask)
 
         return climatology  # }}}

--- a/mpas_analysis/ocean/climatology_map_argo.py
+++ b/mpas_analysis/ocean/climatology_map_argo.py
@@ -67,10 +67,10 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
         fieldName = 'temperatureArgo'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapArgoTemperature, self).__init__(
-                config=config, taskName='climatologyMapArgoTemperature',
-                componentName='ocean',
-                tags=['climatology', 'horizontalMap', 'argo', 'temperature',
-                      'publicObs'])
+            config=config, taskName='climatologyMapArgoTemperature',
+            componentName='ocean',
+            tags=['climatology', 'horizontalMap', 'argo', 'temperature',
+                  'publicObs'])
 
         sectionName = self.taskName
 
@@ -119,18 +119,18 @@ class ClimatologyMapArgoTemperature(AnalysisTask):  # {{{
 
             obsFileName = \
                 '{}/ArgoClimatology_TS_20180710.nc'.format(
-                        observationsDirectory)
+                    observationsDirectory)
             refFieldName = 'theta'
             outFileLabel = 'tempArgo'
             galleryName = 'Roemmich-Gilson Climatology: Argo'
             diffTitleLabel = 'Model - Argo'
 
             remapObservationsSubtask = RemapArgoClimatology(
-                    parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix='{}Argo'.format(refFieldName),
-                    fieldName=refFieldName,
-                    depths=depths,
-                    comparisonGridNames=comparisonGridNames)
+                parentTask=self, seasons=seasons, fileName=obsFileName,
+                outFilePrefix='{}Argo'.format(refFieldName),
+                fieldName=refFieldName,
+                depths=depths,
+                comparisonGridNames=comparisonGridNames)
 
             self.add_subtask(remapObservationsSubtask)
 
@@ -209,9 +209,9 @@ class ClimatologyMapArgoSalinity(AnalysisTask):  # {{{
         fieldName = 'salinityArgo'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapArgoSalinity, self).__init__(
-                config=config, taskName='climatologyMapArgoSalinity',
-                componentName='ocean',
-                tags=['climatology', 'horizontalMap', 'argo', 'salinity'])
+            config=config, taskName='climatologyMapArgoSalinity',
+            componentName='ocean',
+            tags=['climatology', 'horizontalMap', 'argo', 'salinity'])
 
         sectionName = self.taskName
 
@@ -259,18 +259,18 @@ class ClimatologyMapArgoSalinity(AnalysisTask):  # {{{
 
             obsFileName = \
                 '{}/ArgoClimatology_TS_20180710.nc'.format(
-                        observationsDirectory)
+                    observationsDirectory)
             refFieldName = 'salinity'
             outFileLabel = 'salinArgo'
             galleryName = 'Roemmich-Gilson Climatology: Argo'
             diffTitleLabel = 'Model - Argo'
 
             remapObservationsSubtask = RemapArgoClimatology(
-                    parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix='{}Argo'.format(refFieldName),
-                    fieldName=refFieldName,
-                    depths=depths,
-                    comparisonGridNames=comparisonGridNames)
+                parentTask=self, seasons=seasons, fileName=obsFileName,
+                outFilePrefix='{}Argo'.format(refFieldName),
+                fieldName=refFieldName,
+                depths=depths,
+                comparisonGridNames=comparisonGridNames)
 
             self.add_subtask(remapObservationsSubtask)
 
@@ -374,8 +374,8 @@ class RemapArgoClimatology(RemapObservedClimatologySubtask):
         # call the constructor from the base class
         # (RemapObservedClimatologySubtask)
         super(RemapArgoClimatology, self).__init__(
-                parentTask, seasons, fileName, outFilePrefix,
-                comparisonGridNames, subtaskName)
+            parentTask, seasons, fileName, outFilePrefix,
+            comparisonGridNames, subtaskName)
         # }}}
 
     def get_observation_descriptor(self, fileName):  # {{{
@@ -446,10 +446,10 @@ class RemapArgoClimatology(RemapObservedClimatologySubtask):
         for depth in self.depths:
             if depth == 'top':
                 slices.append(field.sel(method='nearest', depth=0.).drop(
-                        'depth'))
+                    'depth'))
             else:
                 slices.append(field.sel(method='nearest', depth=depth).drop(
-                        'depth'))
+                    'depth'))
 
         depthNames = [str(depth) for depth in self.depths]
         field = xr.concat(slices, dim='depthSlice')

--- a/mpas_analysis/ocean/climatology_map_bgc.py
+++ b/mpas_analysis/ocean/climatology_map_bgc.py
@@ -33,6 +33,7 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
     Phillip J. Wolfram, Riley X. Brady, Xylar Asay-Davis
 
     """
+
     def __init__(self, config, mpasClimatologyTask, controlConfig=None):  # {{{
         """
         Construct the analysis task.
@@ -143,8 +144,8 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
                 observationsDirectory = build_obs_path(
                     config, 'ocean', '{}Subdirectory'.format(fieldName))
 
-                obsFileName ="{}/{}".format(observationsDirectory,
-                                            obsFileDict[fieldName])
+                obsFileName = "{}/{}".format(observationsDirectory,
+                                             obsFileDict[fieldName])
 
                 observationsLabel = config.get(fieldSectionName,
                                                'observationsLabel')
@@ -184,10 +185,10 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
                 for season in seasons:
                     # make a new subtask for this season and comparison grid
                     subtask = PlotClimatologyMapSubtask(
-                            self, season, comparisonGridName,
-                            remapClimatologySubtask, remapObservationsSubtask,
-                            controlConfig, subtaskName='plot{}_{}_{}'.format(
-                                fieldName, season, comparisonGridName))
+                        self, season, comparisonGridName,
+                        remapClimatologySubtask, remapObservationsSubtask,
+                        controlConfig, subtaskName='plot{}_{}_{}'.format(
+                            fieldName, season, comparisonGridName))
 
                     subtask.set_plot_info(
                         outFileLabel=outFileLabel,

--- a/mpas_analysis/ocean/climatology_map_mld.py
+++ b/mpas_analysis/ocean/climatology_map_mld.py
@@ -62,9 +62,9 @@ class ClimatologyMapMLD(AnalysisTask):  # {{{
         fieldName = 'mld'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapMLD, self).__init__(
-                config=config, taskName='climatologyMapMLD',
-                componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
+            config=config, taskName='climatologyMapMLD',
+            componentName='ocean',
+            tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         sectionName = self.taskName
 
@@ -102,15 +102,15 @@ class ClimatologyMapMLD(AnalysisTask):  # {{{
                 config, 'ocean', '{}Subdirectory'.format(fieldName))
 
             obsFileName = "{}/holtetalley_mld_climatology_20180710.nc".format(
-                    observationsDirectory)
+                observationsDirectory)
 
             refFieldName = 'mld'
             outFileLabel = 'mldHolteTalleyARGO'
 
             remapObservationsSubtask = RemapObservedMLDClimatology(
-                    parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
-                    comparisonGridNames=comparisonGridNames)
+                parentTask=self, seasons=seasons, fileName=obsFileName,
+                outFilePrefix=refFieldName,
+                comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             galleryName = 'Observations: Holte-Talley ARGO'
             refTitleLabel = \
@@ -137,18 +137,18 @@ class ClimatologyMapMLD(AnalysisTask):  # {{{
                                                     controlConfig)
 
                 subtask.set_plot_info(
-                        outFileLabel=outFileLabel,
-                        fieldNameInTitle='MLD',
-                        mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
-                        diffTitleLabel=diffTitleLabel,
-                        unitsLabel=r'm',
-                        imageCaption='Mean Mixed-Layer Depth',
-                        galleryGroup='Mixed-Layer Depth',
-                        groupSubtitle=None,
-                        groupLink='mld',
-                        galleryName=galleryName)
+                    outFileLabel=outFileLabel,
+                    fieldNameInTitle='MLD',
+                    mpasFieldName=mpasFieldName,
+                    refFieldName=refFieldName,
+                    refTitleLabel=refTitleLabel,
+                    diffTitleLabel=diffTitleLabel,
+                    unitsLabel=r'm',
+                    imageCaption='Mean Mixed-Layer Depth',
+                    galleryGroup='Mixed-Layer Depth',
+                    groupSubtitle=None,
+                    groupLink='mld',
+                    galleryName=galleryName)
 
                 self.add_subtask(subtask)
         # }}}

--- a/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
+++ b/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
@@ -60,9 +60,9 @@ class ClimatologyMapOHCAnomaly(AnalysisTask):  # {{{
         fieldName = 'deltaOHC'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapOHCAnomaly, self).__init__(
-                config=config, taskName='climatologyMapOHCAnomaly',
-                componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
+            config=config, taskName='climatologyMapOHCAnomaly',
+            componentName='ocean',
+            tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         sectionName = self.taskName
 
@@ -122,28 +122,28 @@ class ClimatologyMapOHCAnomaly(AnalysisTask):  # {{{
                 for season in seasons:
                     # make a new subtask for this season and comparison grid
                     subtaskName = 'plot{}_{}_{}'.format(
-                            season, comparisonGridName, depthRangeString)
+                        season, comparisonGridName, depthRangeString)
 
                     subtask = PlotClimatologyMapSubtask(
-                            self, season, comparisonGridName,
-                            remapClimatologySubtask, remapObservationsSubtask,
-                            controlConfig, subtaskName=subtaskName)
+                        self, season, comparisonGridName,
+                        remapClimatologySubtask, remapObservationsSubtask,
+                        controlConfig, subtaskName=subtaskName)
 
                     subtask.set_plot_info(
-                            outFileLabel=outFileLabel,
-                            fieldNameInTitle=r'$\Delta$OHC over {}'.format(
-                                    depthRangeString),
-                            mpasFieldName=mpasFieldName,
-                            refFieldName=refFieldName,
-                            refTitleLabel=refTitleLabel,
-                            diffTitleLabel=diffTitleLabel,
-                            unitsLabel=r'GJ m$^{-2}$',
-                            imageCaption='Anomaly in Ocean Heat Content over '
-                                         '{}'.format(depthRangeString),
-                            galleryGroup='OHC Anomaly',
-                            groupSubtitle=None,
-                            groupLink='ohc_anom',
-                            galleryName=None)
+                        outFileLabel=outFileLabel,
+                        fieldNameInTitle=r'$\Delta$OHC over {}'.format(
+                            depthRangeString),
+                        mpasFieldName=mpasFieldName,
+                        refFieldName=refFieldName,
+                        refTitleLabel=refTitleLabel,
+                        diffTitleLabel=diffTitleLabel,
+                        unitsLabel=r'GJ m$^{-2}$',
+                        imageCaption='Anomaly in Ocean Heat Content over '
+                        '{}'.format(depthRangeString),
+                        galleryGroup='OHC Anomaly',
+                        groupSubtitle=None,
+                        groupLink='ohc_anom',
+                        galleryName=None)
 
                     self.add_subtask(subtask)
         # }}}
@@ -211,13 +211,13 @@ class RemapMpasOHCClimatology(RemapMpasClimatologySubtask):  # {{{
         # Xylar Asay-Davis
 
         subtaskName = 'remapMpasClimatology_{:g}-{:g}m'.format(
-                numpy.abs(minDepth), numpy.abs(maxDepth))
+            numpy.abs(minDepth), numpy.abs(maxDepth))
         # call the constructor from the base class
         # (RemapMpasClimatologySubtask)
         super(RemapMpasOHCClimatology, self).__init__(
-                 mpasClimatologyTask, parentTask, climatologyName,
-                 variableList, seasons, comparisonGridNames,
-                 subtaskName=subtaskName)
+            mpasClimatologyTask, parentTask, climatologyName,
+            variableList, seasons, comparisonGridNames,
+            subtaskName=subtaskName)
 
         self.refYearClimatolgyTask = refYearClimatolgyTask
         self.run_after(refYearClimatolgyTask)
@@ -283,7 +283,7 @@ class RemapMpasOHCClimatology(RemapMpasClimatologySubtask):  # {{{
         climatology.deltaOHC.attrs['units'] = 'GJ m$^{-2}$'
         climatology.deltaOHC.attrs['description'] = \
             'Anomaly from year {} in ocean heat content'.format(
-                    self.refYearClimatolgyTask.startYear)
+            self.refYearClimatolgyTask.startYear)
 
         climatology = climatology.drop(self.variableList)
 
@@ -310,7 +310,7 @@ class RemapMpasOHCClimatology(RemapMpasClimatologySubtask):  # {{{
                             dsRestart.layerThickness)
 
         vertIndex = xarray.DataArray.from_dict(
-                {'dims': ('nVertLevels',), 'data': numpy.arange(nVertLevels)})
+            {'dims': ('nVertLevels',), 'data': numpy.arange(nVertLevels)})
 
         temperature = climatology['timeMonthly_avg_activeTracers_temperature']
         layerThickness = climatology['timeMonthly_avg_layerThickness']
@@ -322,7 +322,7 @@ class RemapMpasOHCClimatology(RemapMpasClimatologySubtask):  # {{{
             temperature = temperature.where(mask)
             layerThickness = layerThickness.where(mask)
 
-        ohc = unitsScalefactor*rho*cp * layerThickness * temperature
+        ohc = unitsScalefactor * rho * cp * layerThickness * temperature
         ohc = ohc.sum(dim='nVertLevels')
         return ohc  # }}}
 

--- a/mpas_analysis/ocean/climatology_map_schmidtko.py
+++ b/mpas_analysis/ocean/climatology_map_schmidtko.py
@@ -83,8 +83,8 @@ class ClimatologyMapSchmidtko(AnalysisTask):  # {{{
 
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapSchmidtko, self).__init__(
-                config=config, taskName='climatologyMapSchmidtko',
-                componentName='ocean', tags=tags)
+            config=config, taskName='climatologyMapSchmidtko',
+            componentName='ocean', tags=tags)
 
         sectionName = self.taskName
 
@@ -138,12 +138,12 @@ class ClimatologyMapSchmidtko(AnalysisTask):  # {{{
                 outFileLabel = '{}Schmidtko'.format(fieldPrefix)
 
                 remapObservationsSubtask = RemapSchmidtko(
-                        parentTask=self, seasons=seasons, fileName=obsFileName,
-                        outFilePrefix='{}Schmidtko'.format(fieldPrefix),
-                        fieldName=refFieldName,
-                        comparisonGridNames=comparisonGridNames,
-                        subtaskName='remapObservations{}'.format(
-                                upperFieldPrefix))
+                    parentTask=self, seasons=seasons, fileName=obsFileName,
+                    outFilePrefix='{}Schmidtko'.format(fieldPrefix),
+                    fieldName=refFieldName,
+                    comparisonGridNames=comparisonGridNames,
+                    subtaskName='remapObservations{}'.format(
+                        upperFieldPrefix))
 
                 self.add_subtask(remapObservationsSubtask)
 
@@ -239,8 +239,8 @@ class RemapSchmidtko(RemapObservedClimatologySubtask):  # {{{
         # call the constructor from the base class
         # (RemapObservedClimatologySubtask)
         super(RemapSchmidtko, self).__init__(
-                parentTask, seasons, fileName, outFilePrefix,
-                comparisonGridNames, subtaskName)
+            parentTask, seasons, fileName, outFilePrefix,
+            comparisonGridNames, subtaskName)
         # }}}
 
     def get_observation_descriptor(self, fileName):  # {{{

--- a/mpas_analysis/ocean/climatology_map_sose.py
+++ b/mpas_analysis/ocean/climatology_map_sose.py
@@ -123,9 +123,9 @@ class ClimatologyMapSose(AnalysisTask):  # {{{
 
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapSose, self).__init__(
-                config=config, taskName='climatologyMapSose',
-                componentName='ocean',
-                tags=tags)
+            config=config, taskName='climatologyMapSose',
+            componentName='ocean',
+            tags=tags)
 
         sectionName = self.taskName
 
@@ -145,7 +145,7 @@ class ClimatologyMapSose(AnalysisTask):  # {{{
         if len(comparisonGridNames) == 0:
             raise ValueError('config section {} does not contain valid '
                              'list of comparison grids'.format(
-                                     sectionName))
+                                 sectionName))
 
         if not numpy.any([field['3D'] for field in fields]):
             depths = None
@@ -199,21 +199,21 @@ class ClimatologyMapSose(AnalysisTask):  # {{{
                 obsFileName = \
                     '{}/SOSE_2005-2010_monthly_{}_6000.0x' \
                     '6000.0km_10.0km_Antarctic_stereo_20180710.nc'.format(
-                            observationsDirectory, field['obsFilePrefix'])
+                        observationsDirectory, field['obsFilePrefix'])
                 refFieldName = field['obsFieldName']
                 outFileLabel = '{}SOSE'.format(fieldPrefix)
                 galleryName = 'State Estimate: SOSE'
                 diffTitleLabel = 'Model - State Estimate'
 
                 remapObsSubtask = RemapSoseClimatology(
-                        parentTask=self, seasons=seasons, fileName=obsFileName,
-                        outFilePrefix='{}SOSE'.format(refFieldName),
-                        fieldName=refFieldName,
-                        botFieldName=field['obsBotFieldName'],
-                        depths=fieldDepths,
-                        comparisonGridNames=comparisonGridNames,
-                        subtaskName='remapObservations{}'.format(
-                                upperFieldPrefix))
+                    parentTask=self, seasons=seasons, fileName=obsFileName,
+                    outFilePrefix='{}SOSE'.format(refFieldName),
+                    fieldName=refFieldName,
+                    botFieldName=field['obsBotFieldName'],
+                    depths=fieldDepths,
+                    comparisonGridNames=comparisonGridNames,
+                    subtaskName='remapObservations{}'.format(
+                        upperFieldPrefix))
 
                 self.add_subtask(remapObsSubtask)
 

--- a/mpas_analysis/ocean/climatology_map_ssh.py
+++ b/mpas_analysis/ocean/climatology_map_ssh.py
@@ -60,9 +60,9 @@ class ClimatologyMapSSH(AnalysisTask):  # {{{
         fieldName = 'ssh'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapSSH, self).__init__(
-                config=config, taskName='climatologyMapSSH',
-                componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
+            config=config, taskName='climatologyMapSSH',
+            componentName='ocean',
+            tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         mpasFieldName = 'timeMonthly_avg_pressureAdjustedSSH'
 
@@ -111,9 +111,9 @@ class ClimatologyMapSSH(AnalysisTask):  # {{{
             galleryName = 'Observations: AVISO'
 
             remapObservationsSubtask = RemapObservedSSHClimatology(
-                    parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
-                    comparisonGridNames=comparisonGridNames)
+                parentTask=self, seasons=seasons, fileName=obsFileName,
+                outFilePrefix=refFieldName,
+                comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             diffTitleLabel = 'Model - Observations'
 
@@ -138,18 +138,18 @@ class ClimatologyMapSSH(AnalysisTask):  # {{{
                                                     removeMean=True)
 
                 subtask.set_plot_info(
-                        outFileLabel=outFileLabel,
-                        fieldNameInTitle='Zero-mean SSH',
-                        mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
-                        diffTitleLabel=diffTitleLabel,
-                        unitsLabel=r'cm',
-                        imageCaption='Mean Sea Surface Height',
-                        galleryGroup='Sea Surface Height',
-                        groupSubtitle=None,
-                        groupLink='ssh',
-                        galleryName=galleryName)
+                    outFileLabel=outFileLabel,
+                    fieldNameInTitle='Zero-mean SSH',
+                    mpasFieldName=mpasFieldName,
+                    refFieldName=refFieldName,
+                    refTitleLabel=refTitleLabel,
+                    diffTitleLabel=diffTitleLabel,
+                    unitsLabel=r'cm',
+                    imageCaption='Mean Sea Surface Height',
+                    galleryGroup='Sea Surface Height',
+                    groupSubtitle=None,
+                    groupLink='ssh',
+                    galleryName=galleryName)
 
                 self.add_subtask(subtask)
         # }}}

--- a/mpas_analysis/ocean/climatology_map_sss.py
+++ b/mpas_analysis/ocean/climatology_map_sss.py
@@ -59,9 +59,9 @@ class ClimatologyMapSSS(AnalysisTask):  # {{{
         fieldName = 'sss'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapSSS, self).__init__(
-                config=config, taskName='climatologyMapSSS',
-                componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
+            config=config, taskName='climatologyMapSSS',
+            componentName='ocean',
+            tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         mpasFieldName = 'timeMonthly_avg_activeTracers_salinity'
         iselValues = {'nVertLevels': 0}
@@ -109,9 +109,9 @@ class ClimatologyMapSSS(AnalysisTask):  # {{{
             galleryName = 'Observations: Aquarius'
 
             remapObservationsSubtask = RemapObservedSSSClimatology(
-                    parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
-                    comparisonGridNames=comparisonGridNames)
+                parentTask=self, seasons=seasons, fileName=obsFileName,
+                outFilePrefix=refFieldName,
+                comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             diffTitleLabel = 'Model - Observations'
 
@@ -135,18 +135,18 @@ class ClimatologyMapSSS(AnalysisTask):  # {{{
                                                     controlConfig)
 
                 subtask.set_plot_info(
-                        outFileLabel=outFileLabel,
-                        fieldNameInTitle='SSS',
-                        mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
-                        diffTitleLabel=diffTitleLabel,
-                        unitsLabel=r'PSU',
-                        imageCaption='Mean Sea Surface Salinity',
-                        galleryGroup='Sea Surface Salinity',
-                        groupSubtitle=None,
-                        groupLink='sss',
-                        galleryName=galleryName)
+                    outFileLabel=outFileLabel,
+                    fieldNameInTitle='SSS',
+                    mpasFieldName=mpasFieldName,
+                    refFieldName=refFieldName,
+                    refTitleLabel=refTitleLabel,
+                    diffTitleLabel=diffTitleLabel,
+                    unitsLabel=r'PSU',
+                    imageCaption='Mean Sea Surface Salinity',
+                    galleryGroup='Sea Surface Salinity',
+                    groupSubtitle=None,
+                    groupLink='sss',
+                    galleryName=galleryName)
 
                 self.add_subtask(subtask)
         # }}}

--- a/mpas_analysis/ocean/climatology_map_sst.py
+++ b/mpas_analysis/ocean/climatology_map_sst.py
@@ -59,9 +59,9 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
         fieldName = 'sst'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapSST, self).__init__(
-                config=config, taskName='climatologyMapSST',
-                componentName='ocean',
-                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
+            config=config, taskName='climatologyMapSST',
+            componentName='ocean',
+            tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         mpasFieldName = 'timeMonthly_avg_activeTracers_temperature'
         iselValues = {'nVertLevels': 0}
@@ -104,7 +104,7 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
 
             refTitleLabel = \
                 'Observations (Hadley/OI, {} {:04d}-{:04d})'.format(
-                        period, climStartYear, climEndYear)
+                    period, climStartYear, climEndYear)
 
             observationsDirectory = build_obs_path(
                 config, 'ocean', '{}Subdirectory'.format(fieldName))
@@ -117,9 +117,9 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
             galleryName = 'Observations: Hadley-NOAA-OI'
 
             remapObservationsSubtask = RemapObservedSSTClimatology(
-                    parentTask=self, seasons=seasons, fileName=obsFileName,
-                    outFilePrefix=refFieldName,
-                    comparisonGridNames=comparisonGridNames)
+                parentTask=self, seasons=seasons, fileName=obsFileName,
+                outFilePrefix=refFieldName,
+                comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
             diffTitleLabel = 'Model - Observations'
 
@@ -143,18 +143,18 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
                                                     controlConfig)
 
                 subtask.set_plot_info(
-                        outFileLabel=outFileLabel,
-                        fieldNameInTitle='SST',
-                        mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
-                        diffTitleLabel=diffTitleLabel,
-                        unitsLabel=r'$^o$C',
-                        imageCaption='Mean Sea Surface Temperature',
-                        galleryGroup='Sea Surface Temperature',
-                        groupSubtitle=None,
-                        groupLink='sst',
-                        galleryName=galleryName)
+                    outFileLabel=outFileLabel,
+                    fieldNameInTitle='SST',
+                    mpasFieldName=mpasFieldName,
+                    refFieldName=refFieldName,
+                    refTitleLabel=refTitleLabel,
+                    diffTitleLabel=diffTitleLabel,
+                    unitsLabel=r'$^o$C',
+                    imageCaption='Mean Sea Surface Temperature',
+                    galleryGroup='Sea Surface Temperature',
+                    groupSubtitle=None,
+                    groupLink='sst',
+                    galleryName=galleryName)
 
                 self.add_subtask(subtask)
         # }}}

--- a/mpas_analysis/ocean/compute_anomaly_subtask.py
+++ b/mpas_analysis/ocean/compute_anomaly_subtask.py
@@ -164,15 +164,15 @@ class ComputeAnomalySubtask(AnalysisTask):
             anomalyEndDate = '{:04d}-12-31_23:59:59'.format(anomalyYear)
 
         ds = compute_moving_avg_anomaly_from_start(
-                timeSeriesFileName=self.inputFile,
-                variableList=self.variableList,
-                anomalyStartTime=anomalyRefDate,
-                anomalyEndTime=anomalyEndDate,
-                startDate=startDate,
-                endDate=endDate,
-                calendar=self.calendar,
-                movingAveragePoints=self.movingAveragePoints,
-                alter_dataset=self.alter_dataset)
+            timeSeriesFileName=self.inputFile,
+            variableList=self.variableList,
+            anomalyStartTime=anomalyRefDate,
+            anomalyEndTime=anomalyEndDate,
+            startDate=startDate,
+            endDate=endDate,
+            calendar=self.calendar,
+            movingAveragePoints=self.movingAveragePoints,
+            alter_dataset=self.alter_dataset)
 
         outFileName = self.outFileName
         if not os.path.isabs(outFileName):

--- a/mpas_analysis/ocean/compute_transects_subtask.py
+++ b/mpas_analysis/ocean/compute_transects_subtask.py
@@ -186,16 +186,16 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):  # {{{
             transectNumber.extend(localIndices)
 
         self.transectNumber = xr.DataArray.from_dict(
-                {'dims': ('nPoints'),
-                 'data': transectNumber})
+            {'dims': ('nPoints'),
+             'data': transectNumber})
 
         self.x = xr.DataArray.from_dict(
-                {'dims': ('nPoints'),
-                 'data': x})
+            {'dims': ('nPoints'),
+             'data': x})
 
         self.collectionDescriptor = PointCollectionDescriptor(
-                lats, lons, collectionName=self.transectCollectionName,
-                units='degrees', outDimension='nPoints')
+            lats, lons, collectionName=self.transectCollectionName,
+            units='degrees', outDimension='nPoints')
 
         self.add_comparison_grid_descriptor(self.transectCollectionName,
                                             self.collectionDescriptor)
@@ -247,7 +247,7 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):  # {{{
         for season in self.seasons:
 
             remappedFileName = self.get_remapped_file_name(
-                    season, comparisonGridName=self.transectCollectionName)
+                season, comparisonGridName=self.transectCollectionName)
 
             with xr.open_dataset(remappedFileName) as ds:
                 transectNames = list(obsDatasets.keys())
@@ -255,9 +255,9 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):  # {{{
                     self.logger.info('  {}'.format(transectName))
                     dsObs = obsDatasets[transectName]
                     outFileName = self.get_remapped_file_name(
-                            season, comparisonGridName=transectName)
+                        season, comparisonGridName=transectName)
                     outObsFileName = self.obsDatasets.get_out_file_name(
-                            transectName, self.verticalComparisonGridName)
+                        transectName, self.verticalComparisonGridName)
                     self._vertical_interp(ds, transectIndex, dsObs,
                                           outFileName, outObsFileName)
                 ds.close()
@@ -289,8 +289,8 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):  # {{{
         # Xylar Asay-Davis
 
         zIndex = xr.DataArray.from_dict(
-                {'dims': ('nVertLevels',),
-                 'data': numpy.arange(climatology.sizes['nVertLevels'])})
+            {'dims': ('nVertLevels',),
+             'data': numpy.arange(climatology.sizes['nVertLevels'])})
 
         cellMask = zIndex < self.maxLevelCell
 
@@ -383,14 +383,14 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):  # {{{
             ds['z'] = z
             # remap each variable
             ds = interp_1d(ds, inInterpDim='nVertLevels', inInterpCoord='zMid',
-                           outInterpDim='nzOut',  outInterpCoord='z')
+                           outInterpDim='nzOut', outInterpCoord='z')
             ds = ds.rename({'nzOut': 'nz'})
 
         if self.verticalComparisonGridName != 'obs' and 'nz' in dsObs.dims:
             dsObs['zOut'] = z
             # remap each variable
             dsObs = interp_1d(dsObs, inInterpDim='nz', inInterpCoord='z',
-                              outInterpDim='nzOut',  outInterpCoord='zOut')
+                              outInterpDim='nzOut', outInterpCoord='zOut')
             dsObs = dsObs.rename({'nzOut': 'nz'})
             write_netcdf(dsObs, outObsFileName)
 
@@ -487,7 +487,7 @@ class TransectsObservations(object):  # {{{
                 dsObs.load()
             else:
                 dsObs = self.build_observational_dataset(
-                        self.obsFileNames[name], name)
+                    self.obsFileNames[name], name)
 
                 dsObs.load()
                 # make sure lat and lon are coordinates
@@ -612,16 +612,16 @@ class TransectsObservations(object):  # {{{
         dxIn = self._haversine(lon[0:-1], lat[0:-1], lon[1:], lat[1:])
 
         nSegments = numpy.maximum(
-                (dxIn/self.horizontalResolution + 0.5).astype(int), 1)
+            (dxIn / self.horizontalResolution + 0.5).astype(int), 1)
 
         xIn = numpy.zeros(lat.shape)
         xIn[1:] = numpy.cumsum(dxIn)
 
         outIndex = []
-        for index in range(len(xIn)-1):
+        for index in range(len(xIn) - 1):
             n = nSegments[index]
-            outIndex.extend(index + numpy.arange(0, n)/n)
-        outIndex.append(len(xIn)-1)
+            outIndex.extend(index + numpy.arange(0, n) / n)
+        outIndex.append(len(xIn) - 1)
 
         xOut = numpy.interp(outIndex, numpy.arange(len(xIn)), xIn)
 
@@ -651,8 +651,8 @@ class TransectsObservations(object):  # {{{
         # haversine formula
         dlon = lon2 - lon1
         dlat = lat2 - lat1
-        a = numpy.sin(dlat/2.)**2 + numpy.cos(lat1) * numpy.cos(lat2) * \
-            numpy.sin(dlon/2.)**2
+        a = numpy.sin(dlat / 2.)**2 + numpy.cos(lat1) * numpy.cos(lat2) * \
+            numpy.sin(dlon / 2.)**2
         c = 2 * numpy.arcsin(numpy.sqrt(a))
         r = 6371  # Radius of earth in kilometers. Use 3956 for miles
         return c * r  # }}}

--- a/mpas_analysis/ocean/geojson_transects.py
+++ b/mpas_analysis/ocean/geojson_transects.py
@@ -58,9 +58,9 @@ class GeojsonTransects(AnalysisTask):  # {{{
 
         # call the constructor from the base class (AnalysisTask)
         super(GeojsonTransects, self).__init__(
-                config=config, taskName='geojsonTransects',
-                componentName='ocean',
-                tags=tags)
+            config=config, taskName='geojsonTransects',
+            componentName='ocean',
+            tags=tags)
 
         sectionName = self.taskName
 
@@ -79,7 +79,7 @@ class GeojsonTransects(AnalysisTask):  # {{{
             verticalComparisonGrid = None
         else:
             verticalComparisonGrid = config.getExpression(
-                    sectionName, 'verticalComparisonGrid', usenumpyfunc=True)
+                sectionName, 'verticalComparisonGrid', usenumpyfunc=True)
 
         fields = config.getExpression(sectionName, 'fields')
 
@@ -101,8 +101,8 @@ class GeojsonTransects(AnalysisTask):  # {{{
                                                       horizontalResolution)
 
         transectsObservations = GeojsonTransectsObservations(
-                config, obsFileNames,  horizontalResolution,
-                transectCollectionName)
+            config, obsFileNames, horizontalResolution,
+            transectCollectionName)
 
         computeTransectsSubtask = ComputeTransectsSubtask(
             mpasClimatologyTask=mpasClimatologyTask,
@@ -140,8 +140,8 @@ class GeojsonTransects(AnalysisTask):  # {{{
 
                     fieldPrefixUpper = fieldPrefix[0].upper() + fieldPrefix[1:]
                     fieldNameInTytle = '{} from {}'.format(
-                            field['titleName'],
-                            transectName.replace('_', ' '))
+                        field['titleName'],
+                        transectName.replace('_', ' '))
 
                     # make a new subtask for this season and comparison grid
                     subtask = PlotTransectSubtask(self, season, transectName,
@@ -150,20 +150,20 @@ class GeojsonTransects(AnalysisTask):  # {{{
                                                   plotObs, controlConfig)
 
                     subtask.set_plot_info(
-                            outFileLabel=outFileLabel,
-                            fieldNameInTitle=fieldNameInTytle,
-                            mpasFieldName=field['mpas'],
-                            refFieldName=refFieldName,
-                            refTitleLabel=refTitleLabel,
-                            diffTitleLabel=diffTitleLabel,
-                            unitsLabel=field['units'],
-                            imageCaption=fieldNameInTytle,
-                            galleryGroup='Geojson Transects',
-                            groupSubtitle=None,
-                            groupLink='geojson',
-                            galleryName=field['titleName'],
-                            configSectionName='geojson{}Transects'.format(
-                                    fieldPrefixUpper))
+                        outFileLabel=outFileLabel,
+                        fieldNameInTitle=fieldNameInTytle,
+                        mpasFieldName=field['mpas'],
+                        refFieldName=refFieldName,
+                        refTitleLabel=refTitleLabel,
+                        diffTitleLabel=diffTitleLabel,
+                        unitsLabel=field['units'],
+                        imageCaption=fieldNameInTytle,
+                        galleryGroup='Geojson Transects',
+                        groupSubtitle=None,
+                        groupLink='geojson',
+                        galleryName=field['titleName'],
+                        configSectionName='geojson{}Transects'.format(
+                            fieldPrefixUpper))
 
                     self.add_subtask(subtask)
         # }}}
@@ -184,7 +184,6 @@ class GeojsonTransectsObservations(TransectsObservations):  # {{{
     # Authors
     # -------
     # Xylar Asay-Davis
-
 
     def build_observational_dataset(self, fileName, transectName):  # {{{
         '''

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -117,7 +117,7 @@ class IndexNino34(AnalysisTask):  # {{{
 
         if regionToPlot not in ['nino3.4', 'nino3', 'nino4']:
             raise ValueError('Unexpectes El Nino Index region {}'.format(
-                    regionToPlot))
+                regionToPlot))
         ninoIndexNumber = regionToPlot[4:]
 
         self.xmlFileNames = []
@@ -165,11 +165,13 @@ class IndexNino34(AnalysisTask):  # {{{
         # specify obsTitle based on data path
         # These are the only data sets supported
         if dataSource == 'HADIsst':
-            dataPath = "{}/HADIsst_nino34_20180710.nc".format(observationsDirectory)
+            dataPath = "{}/HADIsst_nino34_20180710.nc".format(
+                observationsDirectory)
             obsTitle = 'HADSST'
             refDate = '1870-01-01'
         elif dataSource == 'ERS_SSTv4':
-            dataPath = "{}/ERS_SSTv4_nino34_20180710.nc".format(observationsDirectory)
+            dataPath = "{}/ERS_SSTv4_nino34_20180710.nc".format(
+                observationsDirectory)
             obsTitle = 'ERS SSTv4'
             refDate = '1800-01-01'
         else:
@@ -200,7 +202,7 @@ class IndexNino34(AnalysisTask):  # {{{
         nino34Obs = dsObs.sst
 
         self.logger.info('  Compute El Nino {} Index...'.format(
-                ninoIndexNumber))
+            ninoIndexNumber))
         varName = self.variableList[0]
         regionSST = ds[varName].isel(nOceanRegions=regionIndex)
         nino34Main = self._compute_nino34_index(regionSST, calendar)
@@ -209,7 +211,7 @@ class IndexNino34(AnalysisTask):  # {{{
         # nino34Obs = compute_nino34_index(dsObs.sst, calendar)
 
         self.logger.info(' Computing El Nino {} power spectra...'.format(
-                ninoIndexNumber))
+            ninoIndexNumber))
         spectraMain = self._compute_nino34_spectra(nino34Main)
 
         # Compute the observational spectra over the whole record
@@ -242,12 +244,12 @@ class IndexNino34(AnalysisTask):  # {{{
                 self.controlConfig, 'output', 'timeSeriesSubdirectory')
 
             refFileName = '{}/{}.nc'.format(
-                    baseDirectory, self.mpasTimeSeriesTask.fullTaskName)
+                baseDirectory, self.mpasTimeSeriesTask.fullTaskName)
 
             dsRef = open_mpas_dataset(
-                    fileName=refFileName,
-                    calendar=calendar,
-                    variableList=self.variableList)
+                fileName=refFileName,
+                calendar=calendar,
+                variableList=self.variableList)
 
             regionSSTRef = dsRef[varName].isel(nOceanRegions=regionIndex)
             nino34Ref = self._compute_nino34_index(regionSSTRef, calendar)
@@ -266,18 +268,18 @@ class IndexNino34(AnalysisTask):  # {{{
         # Convert frequencies to period in years
         for s in spectra:
             s['period'] = \
-                1.0 / (constants.eps + s['f']*constants.sec_per_year)
+                1.0 / (constants.eps + s['f'] * constants.sec_per_year)
 
         self.logger.info(' Plot El Nino {} index and spectra...'.format(
-                ninoIndexNumber))
+            ninoIndexNumber))
 
         outFileName = '{}/nino{}_{}.png'.format(self.plotsDirectory,
                                                 ninoIndexNumber, mainRunName)
         self._nino34_timeseries_plot(
-                nino34s=nino34s,
-                title=u'El Niño {} Index'.format(ninoIndexNumber),
-                panelTitles=titles,
-                outFileName=outFileName)
+            nino34s=nino34s,
+            title=u'El Niño {} Index'.format(ninoIndexNumber),
+            panelTitles=titles,
+            outFileName=outFileName)
 
         self._write_xml(filePrefix='nino{}_{}'.format(ninoIndexNumber,
                                                       mainRunName),
@@ -288,10 +290,10 @@ class IndexNino34(AnalysisTask):  # {{{
                                                         ninoIndexNumber,
                                                         mainRunName)
         self._nino34_spectra_plot(
-                spectra=spectra,
-                title=u'El Niño {} power spectrum'.format(ninoIndexNumber),
-                panelTitles=titles,
-                outFileName=outFileName)
+            spectra=spectra,
+            title=u'El Niño {} power spectrum'.format(ninoIndexNumber),
+            panelTitles=titles,
+            outFileName=outFileName)
 
         self._write_xml(filePrefix='nino{}_spectra_{}'.format(ninoIndexNumber,
                                                               mainRunName),
@@ -395,7 +397,7 @@ class IndexNino34(AnalysisTask):  # {{{
                                     1.0 / constants.sec_per_month)
 
         # computes power spectra, smoothed with a weighted running mean
-        nwts = max(1, int(7*len(ninoIndex) / 1200))
+        nwts = max(1, int(7 * len(ninoIndex) / 1200))
         # verify window length is odd, if not, add 1
         if nwts % 2 == 0:
             nwts += 1
@@ -413,12 +415,12 @@ class IndexNino34(AnalysisTask):  # {{{
         # Uses Chi squared test
 
         r = self._autocorr(ninoIndex)[0, 1]
-        r2 = 2.*r
+        r2 = 2. * r
         rsq = r**2
 
         # In the temp2 variable, f is converted to give wavenumber, i.e.
         # 0,1,2,...,N/2
-        temp2 = r2*np.cos(2.*np.pi*f*constants.sec_per_month)
+        temp2 = r2 * np.cos(2. * np.pi * f * constants.sec_per_month)
         mkov = 1. / (1. + rsq - temp2)
 
         sum1 = np.sum(mkov)
@@ -426,13 +428,15 @@ class IndexNino34(AnalysisTask):  # {{{
         scale = sum2 / sum1
 
         df = 2. / (constants.tapcoef * sum(wgts**2))
-        xLow = stats.chi2.interval(0.95, df)[1]/df
-        xHigh = stats.chi2.interval(0.99, df)[1]/df
+        xLow = stats.chi2.interval(0.95, df)[1] / df
+        xHigh = stats.chi2.interval(0.99, df)[1] / df
 
         # return Spectra, 99% confidence level, 95% confidence level,
         #        and Red-noise fit
-        spectra = {'f': f, 'spectrum': pxxSmooth, 'conf99': mkov*scale*xHigh,
-                   'conf95': mkov*scale*xLow, 'redNoise': mkov*scale}
+        spectra = {'f': f, 'spectrum': pxxSmooth,
+                   'conf99': mkov * scale * xHigh,
+                   'conf95': mkov * scale * xLow,
+                   'redNoise': mkov * scale}
         return spectra
         # }}}
 
@@ -454,7 +458,7 @@ class IndexNino34(AnalysisTask):  # {{{
         # -------
         # Luke Van Roekel
 
-        return np.corrcoef(np.array([x[0:len(x)-t], x[t:len(x)]]))  # }}}
+        return np.corrcoef(np.array([x[0:len(x) - t], x[t:len(x)]]))  # }}}
 
     def _running_mean(self, inputData, wgts):  # {{{
         """
@@ -478,8 +482,8 @@ class IndexNino34(AnalysisTask):  # {{{
         nt = len(inputData)
         sp = (len(wgts) - 1) // 2
         runningMean = inputData.copy()
-        for k in range(sp, nt-(sp+1)):
-            runningMean[k] = sum(wgts*inputData[k-sp:k+sp+1].values)
+        for k in range(sp, nt - (sp + 1)):
+            runningMean[k] = sum(wgts * inputData[k - sp:k + sp + 1].values)
 
         return runningMean  # }}}
 
@@ -564,7 +568,7 @@ class IndexNino34(AnalysisTask):  # {{{
                                                  xmax=periodMax))
 
         for plotIndex in range(3):
-            plt.subplot(3, 1, plotIndex+1)
+            plt.subplot(3, 1, plotIndex + 1)
 
             period = spectra[plotIndex]['period']
             for curveIndex in range(4):
@@ -574,7 +578,7 @@ class IndexNino34(AnalysisTask):  # {{{
             plt.xlim(10, 1)
 
             plt.legend(loc='upper right')
-            plt.ylim(0, 0.9*maxYval)
+            plt.ylim(0, 0.9 * maxYval)
 
             if panelTitles[plotIndex] is not None:
                 plt.title(panelTitles[plotIndex], **title_font)
@@ -593,7 +597,7 @@ class IndexNino34(AnalysisTask):  # {{{
         # }}}
 
     def _nino34_timeseries_plot(self, nino34s, title, panelTitles, outFileName,
-                                xlabel='Time (years)', ylabel='($\degree$C)',
+                                xlabel='Time (years)', ylabel=r'($\degree$C)',
                                 titleFontSize=None, figsize=(9, 21), dpi=None,
                                 maxXTicks=20, lineWidth=2):
         # {{{
@@ -652,7 +656,7 @@ class IndexNino34(AnalysisTask):  # {{{
             fig.suptitle(title, y=0.92, **title_font)
 
         for plotIndex in range(3):
-            plt.subplot(3, 1, plotIndex+1)
+            plt.subplot(3, 1, plotIndex + 1)
             index = nino34s[plotIndex].values
             time = nino34s[plotIndex].Time.values
             self._plot_nino_timeseries(index, time, xlabel, ylabel,
@@ -709,9 +713,9 @@ class IndexNino34(AnalysisTask):  # {{{
 
         y2 = np.zeros(nt)
 
-        plt.plot(time, 0.4*np.ones(nt), '--k',
+        plt.plot(time, 0.4 * np.ones(nt), '--k',
                  linewidth=lineWidth)
-        plt.plot(time, -0.4*np.ones(nt), '--k',
+        plt.plot(time, -0.4 * np.ones(nt), '--k',
                  linewidth=lineWidth)
         plt.fill_between(time, y1, y2, where=y1 > y2,
                          facecolor='red', interpolate=True, linewidth=0)

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -137,8 +137,8 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
 
         for prefix in prefixes:
             filePrefix = '{}_{}_years{:04d}-{:04d}'.format(
-                    prefix, mainRunName,
-                    self.startYear, self.endYear)
+                prefix, mainRunName,
+                self.startYear, self.endYear)
             self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
                                                         filePrefix))
             self.filePrefixes[prefix] = filePrefix
@@ -200,9 +200,10 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             refLayerThickness = np.zeros(nVertLevels)
             refLayerThickness[0] = refBottomDepth[0]
             refLayerThickness[1:nVertLevels] = \
-                refBottomDepth[1:nVertLevels] - refBottomDepth[0:nVertLevels-1]
+                refBottomDepth[1:nVertLevels] - \
+                refBottomDepth[0:nVertLevels - 1]
 
-            refZMid = -refBottomDepth + 0.5*refLayerThickness
+            refZMid = -refBottomDepth + 0.5 * refLayerThickness
 
             binBoundaryMerHeatTrans = None
             # first try timeSeriesStatsMonthly for bin boundaries, then try
@@ -242,7 +243,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             self.logger.info('   Load data...')
 
             climatologyFileName = self.mpasClimatologyTask.get_file_name(
-                    season='ANN')
+                season='ANN')
 
             variableList = ['timeMonthly_avg_meridionalHeatTransportLat',
                             'timeMonthly_avg_meridionalHeatTransportLatZ']
@@ -266,7 +267,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
         xLabel = 'latitude [deg]'
         yLabel = 'meridional heat transport [PW]'
         title = 'Global MHT (ANN, years {:04d}-{:04d})\n {}'.format(
-                 self.startYear, self.endYear, mainRunName)
+            self.startYear, self.endYear, mainRunName)
         filePrefix = self.filePrefixes['mht']
         figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
         lineColors = ['k']
@@ -299,8 +300,8 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             controlEndYear = self.controlConfig.getint('climatology',
                                                        'endYear')
             controlDirectory = build_config_full_path(
-                    self.controlConfig, 'output',
-                    'mpasClimatologySubdirectory')
+                self.controlConfig, 'output',
+                'mpasClimatologySubdirectory')
 
             controlFileName = \
                 '{}/meridionalHeatTransport_years{:04d}-{:04d}.nc'.format(
@@ -314,7 +315,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             legendText.append(controlRunName)
             xArrays.append(dsControl.binBoundaryMerHeatTrans)
             fieldArrays.append(
-                    dsControl.timeMonthly_avg_meridionalHeatTransportLat)
+                dsControl.timeMonthly_avg_meridionalHeatTransportLat)
             errArrays.append(None)
 
         if len(legendText) == 1:
@@ -336,7 +337,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
                 annualClimatology.timeMonthly_avg_meridionalHeatTransportLatZ
             MHTLatZ = MHTLatZVar.values.T[:, :]
             for k in range(nVertLevels):
-                MHTLatZ[k, :] = MHTLatZ[k, :]/refLayerThickness[k]
+                MHTLatZ[k, :] = MHTLatZ[k, :] / refLayerThickness[k]
 
             x = binBoundaryMerHeatTrans
             y = refZMid
@@ -344,7 +345,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             xLabel = 'latitude [deg]'
             yLabel = 'depth [m]'
             title = 'Global MHT (ANN, years {:04d}-{:04d})\n {}'.format(
-                     self.startYear, self.endYear, mainRunName)
+                self.startYear, self.endYear, mainRunName)
             filePrefix = self.filePrefixes['mhtZ']
             figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
             colorbarLabel = '[PW/m]'

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -99,27 +99,27 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
                                            self.regionMaskSuffix)
 
         masksSubtask = ComputeRegionMasksSubtask(
-                self, masksFile,
-                outFileSuffix=self.regionMaskSuffix,
-                featureList=self.regionNames)
+            self, masksFile,
+            outFileSuffix=self.regionMaskSuffix,
+            featureList=self.regionNames)
 
         if 'all' in self.regionNames:
             self.regionNames = get_feature_list(config, masksFile)
 
         self.masksSubtask = masksSubtask
 
-        years = range(self.startYear, self.endYear+1)
+        years = range(self.startYear, self.endYear + 1)
 
         # in the end, we'll combine all the time series into one, but we create
         # this task first so it's easier to tell it to run after all the
         # compute tasks
         combineSubtask = CombineRegionalProfileTimeSeriesSubtask(
-                self, startYears=years, endYears=years)
+            self, startYears=years, endYears=years)
 
         # run one subtask per year
         for year in years:
             computeSubtask = ComputeRegionalProfileTimeSeriesSubtask(
-                    self, startYear=year, endYear=year)
+                self, startYear=year, endYear=year)
             computeSubtask.run_after(masksSubtask)
             combineSubtask.run_after(computeSubtask)
 
@@ -128,10 +128,10 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
                 prefix = field['prefix']
                 for regionName in self.regionNames:
                     subtaskName = 'plotHovmoller_{}_{}'.format(
-                            prefix, regionName.replace(' ', '_'))
+                        prefix, regionName.replace(' ', '_'))
                     inFileName = '{}/{}_{:04d}-{:04d}.nc'.format(
-                            self.regionMaskSuffix, self.regionMaskSuffix,
-                            self.startYear, self.endYear)
+                        self.regionMaskSuffix, self.regionMaskSuffix,
+                        self.startYear, self.endYear)
                     titleName = field['titleName']
                     caption = 'Time series of {} {} vs ' \
                               'depth'.format(regionName.replace('_', ' '),
@@ -160,7 +160,7 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
             for regionName in self.regionNames:
                 for season in self.seasons:
                     plotSubtask = PlotRegionalProfileTimeSeriesSubtask(
-                            self, season, regionName, field, controlConfig)
+                        self, season, regionName, field, controlConfig)
                     plotSubtask.run_after(combineSubtask)
                     self.add_subtask(plotSubtask)
 
@@ -259,20 +259,20 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
         timeSeriesName = self.parentTask.regionMaskSuffix
 
         outputDirectory = '{}/{}/'.format(
-                build_config_full_path(self.config, 'output',
-                                       'timeseriesSubdirectory'),
-                timeSeriesName)
+            build_config_full_path(self.config, 'output',
+                                   'timeseriesSubdirectory'),
+            timeSeriesName)
         try:
             os.makedirs(outputDirectory)
         except OSError:
             pass
 
         outputFileName = '{}/{}_{:04d}-{:04d}.nc'.format(
-                outputDirectory, timeSeriesName, self.startYear, self.endYear)
+            outputDirectory, timeSeriesName, self.startYear, self.endYear)
 
         inputFiles = sorted(self.historyStreams.readpath(
-                'timeSeriesStatsMonthlyOutput', startDate=startDate,
-                endDate=endDate, calendar=self.calendar))
+            'timeSeriesStatsMonthlyOutput', startDate=startDate,
+            endDate=endDate, calendar=self.calendar))
 
         years, months = get_files_year_month(inputFiles,
                                              self.historyStreams,
@@ -293,8 +293,8 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
                 for inIndex in range(dsIn.dims['Time']):
 
                     mask = np.logical_and(
-                            dsIn.year[inIndex].values == years,
-                            dsIn.month[inIndex].values == months)
+                        dsIn.year[inIndex].values == years,
+                        dsIn.month[inIndex].values == months)
                     if np.count_nonzero(mask) == 0:
                         outputValid = False
                         break
@@ -338,7 +338,7 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
         cellMasks = dsRegionMask.regionCellMasks
         regionNamesVar = dsRegionMask.regionNames
 
-        totalArea = (cellMasks*areaCell*vertMask).sum('nCells')
+        totalArea = (cellMasks * areaCell * vertMask).sum('nCells')
 
         datasets = []
         for timeIndex, fileName in enumerate(inputFiles):
@@ -367,11 +367,11 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
 
                 meanName = '{}_mean'.format(prefix)
                 dsLocal[meanName] = \
-                    (cellMasks*areaCell*var).sum('nCells')/totalArea
+                    (cellMasks * areaCell * var).sum('nCells') / totalArea
 
                 meanSquaredName = '{}_meanSquared'.format(prefix)
                 dsLocal[meanSquaredName] = \
-                    (cellMasks*areaCell*var**2).sum('nCells')/totalArea
+                    (cellMasks * areaCell * var**2).sum('nCells') / totalArea
 
             # drop the original variables
             dsLocal = dsLocal.drop(variableList)
@@ -399,8 +399,8 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
         with xr.open_dataset(restartFile) as dsRestart:
             depths = dsRestart.refBottomDepth.values
             z = np.zeros(depths.shape)
-            z[0] = -0.5*depths[0]
-            z[1:] = -0.5*(depths[0:-1] + depths[1:])
+            z[0] = -0.5 * depths[0]
+            z[1:] = -0.5 * (depths[0:-1] + depths[1:])
 
         dsOut.coords['z'] = (('nVertLevels'), z)
         dsOut['z'].attrs['units'] = 'meters'
@@ -459,13 +459,13 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
         timeSeriesName = self.parentTask.regionMaskSuffix
 
         outputDirectory = '{}/{}/'.format(
-                build_config_full_path(self.config, 'output',
-                                       'timeseriesSubdirectory'),
-                timeSeriesName)
+            build_config_full_path(self.config, 'output',
+                                   'timeseriesSubdirectory'),
+            timeSeriesName)
 
         outputFileName = '{}/{}_{:04d}-{:04d}.nc'.format(
-                outputDirectory, timeSeriesName, self.startYears[0],
-                self.endYears[-1])
+            outputDirectory, timeSeriesName, self.startYears[0],
+            self.endYears[-1])
 
         if os.path.exists(outputFileName):
             ds = xr.open_dataset(outputFileName, decode_times=False)
@@ -474,7 +474,7 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
             inFileNames = []
             for startYear, endYear in zip(self.startYears, self.endYears):
                 inFileName = '{}/{}_{:04d}-{:04d}.nc'.format(
-                        outputDirectory, timeSeriesName, startYear, endYear)
+                    outputDirectory, timeSeriesName, startYear, endYear)
                 inFileNames.append(inFileName)
 
             ds = xr.open_mfdataset(inFileNames, concat_dim='Time',
@@ -496,8 +496,8 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
 
         for season in self.parentTask.seasons:
             outputFileName = '{}/{}_{}_{:04d}-{:04d}.nc'.format(
-                    outputDirectory, timeSeriesName, season,
-                    self.startYears[0], self.endYears[-1])
+                outputDirectory, timeSeriesName, season,
+                self.startYears[0], self.endYears[-1])
             if not os.path.exists(outputFileName):
                 monthValues = constants.monthDictionary[season]
                 dsSeason = compute_climatology(ds, monthValues,
@@ -515,7 +515,7 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
                     stdName = '{}_std'.format(prefix)
 
                     dsSeason[stdName] = np.sqrt(meanSquared - mean**2).where(
-                            profileMask)
+                        profileMask)
                     dsSeason['{}_mean'.format(prefix)] = mean
 
                 dsSeason.coords['regionNames'] = regionNames
@@ -616,9 +616,9 @@ class PlotRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
         self.filePrefixes = {}
 
         self.filePrefix = '{}_{}_{}_years{:04d}-{:04d}'.format(
-                    self.field['prefix'], self.regionName.replace(' ', '_'),
-                    self.season, self.parentTask.startYear,
-                    self.parentTask.endYear)
+            self.field['prefix'], self.regionName.replace(' ', '_'),
+            self.season, self.parentTask.startYear,
+            self.parentTask.endYear)
         self.xmlFileNames = ['{}/{}.xml'.format(self.plotsDirectory,
                                                 self.filePrefix)]
         # }}}
@@ -639,8 +639,8 @@ class PlotRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
                                              'profilesSubdirectory')
         timeSeriesName = self.parentTask.regionMaskSuffix
         inFileName = '{}/{}_{}_{:04d}-{:04d}.nc'.format(
-                inDirectory, timeSeriesName, self.season,
-                self.parentTask.startYear, self.parentTask.endYear)
+            inDirectory, timeSeriesName, self.season,
+            self.parentTask.startYear, self.parentTask.endYear)
 
         ds = xr.open_dataset(inFileName)
         allRegionNames = [bytes.decode(name) for name in
@@ -741,7 +741,6 @@ class PlotRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
     def plot(self, zArrays, fieldArrays, errArrays, lineColors, lineWidths,
              legendText, title, xLabel, yLabel, fileName, xLim=None, yLim=None,
              figureSize=(10, 4), dpi=None):  # {{{
-
         """
         Plots a 1D line plot with error bars if available.
 
@@ -820,9 +819,9 @@ class PlotRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
             plt.plot(fieldArray, zArray, color=color, linewidth=linewidth,
                      label=label)
             if errArray is not None:
-                plt.fill_betweenx(zArray, fieldArray, fieldArray+errArray,
+                plt.fill_betweenx(zArray, fieldArray, fieldArray + errArray,
                                   facecolor=color, alpha=0.2)
-                plt.fill_betweenx(zArray, fieldArray, fieldArray-errArray,
+                plt.fill_betweenx(zArray, fieldArray, fieldArray - errArray,
                                   facecolor=color, alpha=0.2)
         # plt.grid()
         # plt.axvline(0.0, linestyle='-', color='k')

--- a/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
+++ b/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
@@ -219,7 +219,7 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                                               self.inFileName)
 
         preprocessedReferenceRunName = config.get(
-                'runs', 'preprocessedReferenceRunName')
+            'runs', 'preprocessedReferenceRunName')
         if preprocessedReferenceRunName != 'None':
 
             assert(not os.path.isabs(self.inFileName))
@@ -233,7 +233,7 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                 '{}/preprocessed/intermediate_{}'.format(baseDirectory,
                                                          self.inFileName)
             self.preprocessedFileName = '{}/preprocessed/{}'.format(
-                    baseDirectory, self.inFileName)
+                baseDirectory, self.inFileName)
 
         if not os.path.isabs(self.inFileName):
             baseDirectory = build_config_full_path(
@@ -248,7 +248,7 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                                             self.regionName,
                                             mainRunName)
         self.xmlFileNames = ['{}/{}.xml'.format(
-                self.plotsDirectory, self.filePrefix)]
+            self.plotsDirectory, self.filePrefix)]
 
         return  # }}}
 
@@ -341,10 +341,10 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
             legendText.append(legends[rangeIndex])
 
         preprocessedReferenceRunName = config.get(
-                'runs', 'preprocessedReferenceRunName')
+            'runs', 'preprocessedReferenceRunName')
         if preprocessedReferenceRunName != 'None':
             preprocessedInputDirectory = config.get(
-                    'oceanPreprocessedReference', 'baseDirectory')
+                'oceanPreprocessedReference', 'baseDirectory')
 
             self.logger.info('  Load in preprocessed reference data...')
             preprocessedFilePrefix = config.get(self.sectionName,
@@ -354,12 +354,12 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                 preprocessedReferenceRunName)
 
             combine_time_series_with_ncrcat(
-                    inFilesPreprocessed, self.preprocessedIntermediateFileName,
-                    logger=self.logger)
+                inFilesPreprocessed, self.preprocessedIntermediateFileName,
+                logger=self.logger)
             dsPreprocessed = open_mpas_dataset(
-                    fileName=self.preprocessedIntermediateFileName,
-                    calendar=calendar,
-                    timeVariableNames='xtime')
+                fileName=self.preprocessedIntermediateFileName,
+                calendar=calendar,
+                timeVariableNames='xtime')
 
             yearStart = days_to_datetime(ds.Time.min(), calendar=calendar).year
             yearEnd = days_to_datetime(ds.Time.max(), calendar=calendar).year
@@ -411,7 +411,7 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                 else:
                     self.logger.warning('Warning: Preprocessed variable {} '
                                         'not found. Skipping.'.format(
-                                                variableName))
+                                            variableName))
                     timeSeries.extend(None)
 
                 lineColors.append(color)

--- a/mpas_analysis/ocean/plot_hovmoller_subtask.py
+++ b/mpas_analysis/ocean/plot_hovmoller_subtask.py
@@ -204,7 +204,7 @@ class PlotHovmollerSubtask(AnalysisTask):
                                             self.regionName,
                                             mainRunName)
         self.xmlFileNames = ['{}/{}.xml'.format(
-                self.plotsDirectory, self.filePrefix)]
+            self.plotsDirectory, self.filePrefix)]
 
         return  # }}}
 
@@ -217,7 +217,7 @@ class PlotHovmollerSubtask(AnalysisTask):
         # Xylar Asay-Davis, Milena Veneziani, Greg Streletz
 
         self.logger.info("\nPlotting {} time series vs. depth...".format(
-                self.fieldNameInTitle))
+            self.fieldNameInTitle))
 
         config = self.config
 
@@ -255,8 +255,8 @@ class PlotHovmollerSubtask(AnalysisTask):
             # reference depth [m]
             depths = dsRestart.refBottomDepth.values
             z = np.zeros(depths.shape)
-            z[0] = -0.5*depths[0]
-            z[1:] = -0.5*(depths[0:-1] + depths[1:])
+            z[0] = -0.5 * depths[0]
+            z[1:] = -0.5 * (depths[0:-1] + depths[1:])
 
         Time = ds.Time.values
         field = ds[self.mpasFieldName].values.transpose()
@@ -305,7 +305,7 @@ class PlotHovmollerSubtask(AnalysisTask):
             groupLink=self.groupLink,
             gallery=self.galleryName,
             thumbnailDescription='{} {}'.format(
-                    regionNameInTitle, self.thumbnailSuffix),
+                regionNameInTitle, self.thumbnailSuffix),
             imageDescription=self.imageCaption,
             imageCaption=self.imageCaption)
 

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -155,8 +155,8 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         # call the constructor from the base class (AnalysisTask)
         super(PlotTransectSubtask, self).__init__(
-                config=config, taskName=taskName, subtaskName=subtaskName,
-                componentName='ocean', tags=tags)
+            config=config, taskName=taskName, subtaskName=subtaskName,
+            componentName='ocean', tags=tags)
 
         # this task should not run until the remapping subtasks are done, since
         # it relies on data from those subtasks
@@ -298,7 +298,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         # first read the model climatology
         remappedFileName = \
             self.remapMpasClimatologySubtask.get_remapped_file_name(
-                    season=season, comparisonGridName=transectName)
+                season=season, comparisonGridName=transectName)
 
         remappedModelClimatology = xr.open_dataset(remappedFileName)
 
@@ -317,7 +317,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             if 'Time' in remappedRefClimatology.dims:
                 monthValues = constants.monthDictionary[season]
                 remappedRefClimatology = compute_climatology(
-                        remappedRefClimatology, monthValues, maskVaries=True)
+                    remappedRefClimatology, monthValues, maskVaries=True)
 
         elif self.controlConfig is not None:
             climatologyName = self.remapMpasClimatologySubtask.climatologyName
@@ -335,7 +335,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             if controlStartYear != self.startYear or \
                     controlEndYear != self.endYear:
                 self.refTitleLabel = '{}\n(years {:04d}-{:04d})'.format(
-                        self.refTitleLabel, controlStartYear, controlEndYear)
+                    self.refTitleLabel, controlStartYear, controlEndYear)
 
         else:
             remappedRefClimatology = None
@@ -470,7 +470,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         if compareAsContours:
             labelContours = config.getboolean(
-                    'transects', 'labelContoursOnContourComparisonPlots')
+                'transects', 'labelContoursOnContourComparisonPlots')
         else:
             labelContours = config.getboolean('transects',
                                               'labelContoursOnHeatmaps')
@@ -512,7 +512,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             comparisonContourLineColor=comparisonContourLineColor,
             labelContours=labelContours,
             contourLabelPrecision=contourLabelPrecision
-            )
+        )
 
         caption = '{} {}'.format(season, self.imageCaption)
         write_image_xml(
@@ -620,8 +620,9 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
                 # the longitudinal extent of the transect is 360
                 # degrees minus this value.
 
-            else:   # if max >= min, the transect has covered the
-                    # entire longitudinal range (360 degrees)
+            else:
+                # if max >= min, the transect has covered the
+                # entire longitudinal range (360 degrees)
 
                 lon_extent = 360.0
 

--- a/mpas_analysis/ocean/remap_depth_slices_subtask.py
+++ b/mpas_analysis/ocean/remap_depth_slices_subtask.py
@@ -134,7 +134,7 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):  # {{{
         # over the vertical is used to collapse the array in the vertical
         # dimension
         zBot = zMid.where(zMid.verticalIndex == self.maxLevelCell).sum(
-                dim='nVertLevels')
+            dim='nVertLevels')
 
         verticalIndices = np.zeros((len(self.depths), ds.dims['nCells']), int)
 
@@ -152,7 +152,7 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):  # {{{
                 mask[depthIndex, :] = self.maxLevelCell.values >= 0
             else:
 
-                verticalIndex = np.argmin(np.abs(zMid-depth), axis=1)
+                verticalIndex = np.argmin(np.abs(zMid - depth), axis=1)
 
                 verticalIndices[depthIndex, :] = verticalIndex.values
                 mask[depthIndex, :] = np.logical_and(depth <= zTop,
@@ -215,7 +215,7 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):  # {{{
 
             # mask only the values with the right vertical index
             da = climatology[variableName].where(
-                    climatology.verticalIndex == self.verticalIndices)
+                climatology.verticalIndex == self.verticalIndices)
 
             # Each vertical layer has at most one non-NaN value so the "sum"
             # over the vertical is used to collapse the array in the vertical

--- a/mpas_analysis/ocean/remap_sose_climatology.py
+++ b/mpas_analysis/ocean/remap_sose_climatology.py
@@ -91,8 +91,8 @@ class RemapSoseClimatology(RemapObservedClimatologySubtask):
         # call the constructor from the base class
         # (RemapObservedClimatologySubtask)
         super(RemapSoseClimatology, self).__init__(
-                parentTask, seasons, fileName, outFilePrefix,
-                comparisonGridNames, subtaskName)
+            parentTask, seasons, fileName, outFilePrefix,
+            comparisonGridNames, subtaskName)
         # }}}
 
     def get_observation_descriptor(self, fileName):  # {{{
@@ -154,12 +154,12 @@ class RemapSoseClimatology(RemapObservedClimatologySubtask):
             for depth in self.depths:
                 if depth == 'top':
                     slices.append(field.sel(method='nearest', z=0.).drop(
-                            'z'))
+                        'z'))
                 elif depth == 'bot':
                     slices.append(dsObs[self.botFieldName])
                 else:
                     level = field.sel(method='nearest', z=depth).drop(
-                            'z')
+                        'z')
                     slices.append(level)
 
             depthNames = [str(depth) for depth in self.depths]

--- a/mpas_analysis/ocean/sose_transects.py
+++ b/mpas_analysis/ocean/sose_transects.py
@@ -67,9 +67,9 @@ class SoseTransects(AnalysisTask):  # {{{
 
         # call the constructor from the base class (AnalysisTask)
         super(SoseTransects, self).__init__(
-                config=config, taskName='soseTransects',
-                componentName='ocean',
-                tags=tags)
+            config=config, taskName='soseTransects',
+            componentName='ocean',
+            tags=tags)
 
         sectionName = self.taskName
 
@@ -84,12 +84,10 @@ class SoseTransects(AnalysisTask):  # {{{
             verticalComparisonGrid = None
         else:
             verticalComparisonGrid = config.getExpression(
-                    sectionName, 'verticalComparisonGrid', usenumpyfunc=True)
+                sectionName, 'verticalComparisonGrid', usenumpyfunc=True)
 
-        longitudes = config.getExpression(sectionName, 'longitudes',
-                                          usenumpyfunc=True)
-
-        longitudes.sort()
+        longitudes = sorted(config.getExpression(sectionName, 'longitudes',
+                                                 usenumpyfunc=True))
 
         fields = \
             [{'prefix': 'temperature',
@@ -141,8 +139,8 @@ class SoseTransects(AnalysisTask):  # {{{
                                                       horizontalResolution)
 
         transectsObservations = SoseTransectsObservations(
-                config, horizontalResolution,
-                transectCollectionName, fields)
+            config, horizontalResolution,
+            transectCollectionName, fields)
 
         computeTransectsSubtask = ComputeTransectsWithVelMag(
             mpasClimatologyTask=mpasClimatologyTask,
@@ -182,7 +180,7 @@ class SoseTransects(AnalysisTask):  # {{{
                         refFieldName = field['mpas']
 
                     fieldNameInTytle = r'{} at {}$\degree$ Longitude'.format(
-                            field['titleName'], lon)
+                        field['titleName'], lon)
 
                     # make a new subtask for this season and comparison grid
                     subtask = PlotTransectSubtask(self, season, transectName,
@@ -191,21 +189,21 @@ class SoseTransects(AnalysisTask):  # {{{
                                                   plotObs, controlConfig)
 
                     subtask.set_plot_info(
-                            outFileLabel=outFileLabel,
-                            fieldNameInTitle=fieldNameInTytle,
-                            mpasFieldName=field['mpas'],
-                            refFieldName=refFieldName,
-                            refTitleLabel=refTitleLabel,
-                            diffTitleLabel=diffTitleLabel,
-                            unitsLabel=field['units'],
-                            imageCaption='{} {}'.format(fieldNameInTytle,
-                                                        season),
-                            galleryGroup='SOSE Transects',
-                            groupSubtitle=None,
-                            groupLink='sose_transects',
-                            galleryName=field['titleName'],
-                            configSectionName='sose{}Transects'.format(
-                                    fieldPrefixUpper))
+                        outFileLabel=outFileLabel,
+                        fieldNameInTitle=fieldNameInTytle,
+                        mpasFieldName=field['mpas'],
+                        refFieldName=refFieldName,
+                        refTitleLabel=refTitleLabel,
+                        diffTitleLabel=diffTitleLabel,
+                        unitsLabel=field['units'],
+                        imageCaption='{} {}'.format(fieldNameInTytle,
+                                                    season),
+                        galleryGroup='SOSE Transects',
+                        groupSubtitle=None,
+                        groupLink='sose_transects',
+                        galleryName=field['titleName'],
+                        configSectionName='sose{}Transects'.format(
+                            fieldPrefixUpper))
 
                     self.add_subtask(subtask)
         # }}}
@@ -296,10 +294,8 @@ class SoseTransectsObservations(TransectsObservations):  # {{{
 
         config = self.config
 
-        longitudes = config.getExpression('soseTransects', 'longitudes',
-                                          usenumpyfunc=True)
-
-        longitudes.sort()
+        longitudes = sorted(config.getExpression('soseTransects', 'longitudes',
+                                                 usenumpyfunc=True))
 
         observationsDirectory = build_obs_path(
             config, 'ocean', 'soseSubdirectory')
@@ -338,7 +334,7 @@ class SoseTransectsObservations(TransectsObservations):  # {{{
 
             fileName = '{}/SOSE_2005-2010_monthly_{}_SouthernOcean' \
                        '_0.167x0.167degree_20180710.nc'.format(
-                               observationsDirectory, prefix)
+                           observationsDirectory, prefix)
 
             dsLocal = xr.open_dataset(fileName)
             dsLocal.load()
@@ -346,14 +342,14 @@ class SoseTransectsObservations(TransectsObservations):  # {{{
             if fieldName == 'zonalVel':
                 # need to average in longitude
                 nLon = dsLocal.sizes['lon']
-                lonIndicesP1 = numpy.mod(numpy.arange(nLon)+1, nLon)
-                dsLocal = 0.5*(dsLocal + dsLocal.isel(lon=lonIndicesP1))
+                lonIndicesP1 = numpy.mod(numpy.arange(nLon) + 1, nLon)
+                dsLocal = 0.5 * (dsLocal + dsLocal.isel(lon=lonIndicesP1))
 
             if fieldName == 'meridVel':
                 # need to average in latitude
                 nLat = dsLocal.sizes['lat']
-                latIndicesP1 = numpy.mod(numpy.arange(nLat)+1, nLat)
-                dsLocal = 0.5*(dsLocal + dsLocal.isel(lat=latIndicesP1))
+                latIndicesP1 = numpy.mod(numpy.arange(nLat) + 1, nLat)
+                dsLocal = 0.5 * (dsLocal + dsLocal.isel(lat=latIndicesP1))
 
             dsLocal = dsLocal.sel(lon=longitudes, method=str('nearest'))
 
@@ -376,7 +372,7 @@ class SoseTransectsObservations(TransectsObservations):  # {{{
                           '2005-2010 average of the Southern Ocean State ' \
                           'Estimate (SOSE)'
             dsObs['velMag'] = numpy.sqrt(
-                    dsObs.zonalVel**2 + dsObs.meridVel**2)
+                dsObs.zonalVel**2 + dsObs.meridVel**2)
             dsObs.velMag.attrs['units'] = 'm s$^{-1}$'
             dsObs.velMag.attrs['description'] = description
 
@@ -420,7 +416,7 @@ class SoseTransectsObservations(TransectsObservations):  # {{{
         dsObs = dsObs.rename({'lat': 'nPoints', 'z': 'nz'})
         dsObs['lat'] = dsObs.nPoints
         dsObs['z'] = dsObs.nz
-        dsObs['lon'] = ('nPoints', lon*numpy.ones(dsObs.sizes['nPoints']))
+        dsObs['lon'] = ('nPoints', lon * numpy.ones(dsObs.sizes['nPoints']))
         dsObs = dsObs.drop(['nPoints', 'nz'])
 
         return dsObs  # }}}

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -77,25 +77,25 @@ class StreamfunctionMOC(AnalysisTask):  # {{{
                   'publicObs'])
 
         computeClimSubtask = ComputeMOCClimatologySubtask(
-                self, mpasClimatologyTask)
+            self, mpasClimatologyTask)
         plotClimSubtask = PlotMOCClimatologySubtask(self, controlConfig)
         plotClimSubtask.run_after(computeClimSubtask)
 
         startYear = config.getint('timeSeries', 'startYear')
         endYear = config.getint('timeSeries', 'endYear')
 
-        years = range(startYear, endYear+1)
+        years = range(startYear, endYear + 1)
 
         # in the end, we'll combine all the time series into one, but we create
         # this task first so it's easier to tell it to run after all the
         # compute tasks
         combineTimeSeriesSubtask = CombineMOCTimeSeriesSubtask(
-                self, startYears=years, endYears=years)
+            self, startYears=years, endYears=years)
 
         # run one subtask per year
         for year in years:
             computeTimeSeriesSubtask = ComputeMOCTimeSeriesSubtask(
-                    self, startYear=year, endYear=year)
+                self, startYear=year, endYear=year)
             combineTimeSeriesSubtask.run_after(computeTimeSeriesSubtask)
 
         plotTimeSeriesSubtask = PlotMOCTimeSeriesSubtask(self, controlConfig)
@@ -185,7 +185,7 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
         self.sectionName = 'streamfunctionMOC'
 
         self.usePostprocessing = config.getExpression(
-                self.sectionName, 'usePostprocessingScript')
+            self.sectionName, 'usePostprocessingScript')
 
         if not self.usePostprocessing and self.mocAnalysisMemberEnabled:
             variableList = \
@@ -199,8 +199,8 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
             self.includeBolus = self.namelist.getbool('config_use_standardgm')
             if self.includeBolus:
                 variableList.extend(
-                        ['timeMonthly_avg_normalGMBolusVelocity',
-                         'timeMonthly_avg_vertGMBolusVelocityTop'])
+                    ['timeMonthly_avg_normalGMBolusVelocity',
+                     'timeMonthly_avg_vertGMBolusVelocityTop'])
 
         self.mpasClimatologyTask.add_variables(variableList=variableList,
                                                seasons=['ANN'])
@@ -228,7 +228,6 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
         # }}}
 
     def _compute_moc_climo_analysismember(self):  # {{{
-
         '''compute mean MOC streamfunction from analysis member'''
 
         config = self.config
@@ -239,8 +238,8 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
         make_directories(outputDirectory)
 
         outputFileName = '{}/mocStreamfunction_years{:04d}-{:04d}.nc'.format(
-                           outputDirectory, self.startYear,
-                           self.endYear)
+            outputDirectory, self.startYear,
+            self.endYear)
 
         if os.path.exists(outputFileName):
             return
@@ -262,9 +261,9 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
         refLayerThickness = np.zeros(nVertLevels)
         refLayerThickness[0] = refBottomDepth[0]
         refLayerThickness[1:nVertLevels] = \
-            refBottomDepth[1:nVertLevels] - refBottomDepth[0:nVertLevels-1]
+            refBottomDepth[1:nVertLevels] - refBottomDepth[0:nVertLevels - 1]
 
-        refZMid = refBottomDepth - 0.5*refLayerThickness
+        refZMid = refBottomDepth - 0.5 * refLayerThickness
 
         binBoundaryMocStreamfunction = None
         # first try timeSeriesStatsMonthly for bin boundaries, then try
@@ -355,7 +354,6 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
         # }}}
 
     def _compute_moc_climo_postprocess(self):  # {{{
-
         '''compute mean MOC streamfunction as a post-process'''
 
         config = self.config
@@ -365,8 +363,8 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
         make_directories(outputDirectory)
 
         outputFileName = '{}/mocStreamfunction_years{:04d}-{:04d}.nc'.format(
-                           outputDirectory, self.startYear,
-                           self.endYear)
+            outputDirectory, self.startYear,
+            self.endYear)
 
         if os.path.exists(outputFileName):
             return
@@ -387,7 +385,7 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
         # Add Global regionCellMask=1 everywhere to make the algorithm
         # for the global moc similar to that of the regional moc
         dictRegion['Global'] = {
-                'cellMask': np.ones(np.size(latCell))}
+            'cellMask': np.ones(np.size(latCell))}
         regionNames.append('Global')
 
         # Compute and plot annual climatology of MOC streamfunction
@@ -456,7 +454,7 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
                 indRegion = dictRegion[region]['indices']
                 latBins = latCell[indRegion]
                 latBins = np.arange(np.amin(latBins),
-                                    np.amax(latBins)+latBinSize,
+                                    np.amax(latBins) + latBinSize,
                                     latBinSize)
             mocTop = _compute_moc(latBins, nVertLevels, latCell,
                                   regionCellMask, transportZ, velArea)
@@ -573,8 +571,8 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
 
         for region in self.regionNames:
             filePrefix = 'moc{}_{}_years{:04d}-{:04d}'.format(
-                    region, mainRunName,
-                    self.startYear, self.endYear)
+                region, mainRunName,
+                self.startYear, self.endYear)
 
             self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
                                                         filePrefix))
@@ -609,7 +607,7 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
         # Define plotting variables
         mainRunName = config.get('runs', 'mainRunName')
         movingAveragePointsClimatological = config.getint(
-                self.sectionName, 'movingAveragePointsClimatological')
+            self.sectionName, 'movingAveragePointsClimatological')
         colorbarLabel = '[Sv]'
         xLabel = 'latitude [deg]'
         yLabel = 'depth [m]'
@@ -617,8 +615,8 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
         for region in self.regionNames:
             self.logger.info('   Plot climatological {} MOC...'.format(region))
             title = '{} MOC (ANN, years {:04d}-{:04d})'.format(
-                     region, self.startYear,
-                     self.endYear)
+                region, self.startYear,
+                self.endYear)
             filePrefix = self.filePrefixes[region]
             figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
@@ -644,28 +642,28 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
                 temp = np.zeros((refNz, nx))
                 for zIndex in range(refNz):
                     temp[zIndex, :] = np.interp(
-                            x, refLat[region], refMOC[region][zIndex, :],
-                            left=np.nan, right=np.nan)
+                        x, refLat[region], refMOC[region][zIndex, :],
+                        left=np.nan, right=np.nan)
                 refRegionMOC = np.zeros((nz, nx))
                 for xIndex in range(nx):
                     refRegionMOC[:, xIndex] = np.interp(
-                            depth, refDepth, temp[:, xIndex],
-                            left=np.nan, right=np.nan)
+                        depth, refDepth, temp[:, xIndex],
+                        left=np.nan, right=np.nan)
 
                 diff = regionMOC - refRegionMOC
 
             plot_vertical_section_comparison(
-                    config, x, z, regionMOC, refRegionMOC, diff,
-                    fileout=figureName,
-                    colorMapSectionName='streamfunctionMOC{}'.format(region),
-                    cbarLabel=colorbarLabel,
-                    title=title,
-                    modelTitle=mainRunName,
-                    refTitle=refTitle,
-                    diffTitle=diffTitle,
-                    xlabel=xLabel,
-                    ylabel=yLabel,
-                    N=movingAveragePointsClimatological)
+                config, x, z, regionMOC, refRegionMOC, diff,
+                fileout=figureName,
+                colorMapSectionName='streamfunctionMOC{}'.format(region),
+                cbarLabel=colorbarLabel,
+                title=title,
+                modelTitle=mainRunName,
+                refTitle=refTitle,
+                diffTitle=diffTitle,
+                xlabel=xLabel,
+                ylabel=yLabel,
+                N=movingAveragePointsClimatological)
 
             caption = '{} Meridional Overturning Streamfunction'.format(region)
             write_image_xml(
@@ -680,7 +678,6 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
                 imageCaption=caption)  # }}}
 
     def _load_moc(self, config):  # {{{
-
         '''compute mean MOC streamfunction from analysis member'''
 
         startYear = config.getint('climatology', 'startYear')
@@ -692,8 +689,8 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
         make_directories(outputDirectory)
 
         inputFileName = '{}/mocStreamfunction_years{:04d}-{:04d}.nc'.format(
-                           outputDirectory, startYear,
-                           endYear)
+            outputDirectory, startYear,
+            endYear)
 
         # Read from file
         ncFile = netCDF4.Dataset(inputFileName, mode='r')
@@ -738,7 +735,7 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
             componentName=parentTask.componentName,
             tags=parentTask.tags,
             subtaskName='computeMOCTimeSeries_{:04d}-{:04d}'.format(
-                    startYear, endYear))
+                startYear, endYear))
 
         parentTask.add_subtask(self)
         self.startYear = startYear
@@ -774,7 +771,7 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         self.sectionName = 'streamfunctionMOC'
 
         self.usePostprocessing = config.getExpression(
-                self.sectionName, 'usePostprocessingScript')
+            self.sectionName, 'usePostprocessingScript')
 
         if not self.usePostprocessing and self.mocAnalysisMemberEnabled:
             self.variableList = \
@@ -788,8 +785,8 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
             self.includeBolus = self.namelist.getbool('config_use_standardgm')
             if self.includeBolus:
                 self.variableList.extend(
-                        ['timeMonthly_avg_normalGMBolusVelocity',
-                         'timeMonthly_avg_vertGMBolusVelocityTop'])
+                    ['timeMonthly_avg_normalGMBolusVelocity',
+                     'timeMonthly_avg_vertGMBolusVelocityTop'])
         # }}}
 
     def run_task(self):  # {{{
@@ -815,7 +812,6 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         # }}}
 
     def _compute_moc_time_series_analysismember(self):  # {{{
-
         '''compute MOC time series from analysis member'''
 
         # Compute and plot time series of Atlantic MOC at 26.5N (RAPID array)
@@ -824,15 +820,15 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         self.logger.info('   Load data...')
 
         outputDirectory = '{}/moc/'.format(
-                build_config_full_path(self.config, 'output',
-                                       'timeseriesSubdirectory'))
+            build_config_full_path(self.config, 'output',
+                                   'timeseriesSubdirectory'))
         try:
             os.makedirs(outputDirectory)
         except OSError:
             pass
 
         outputFileName = '{}/mocTimeSeries_{:04d}-{:04d}.nc'.format(
-                outputDirectory, self.startYear, self.endYear)
+            outputDirectory, self.startYear, self.endYear)
 
         streamName = 'timeSeriesStatsMonthlyOutput'
 
@@ -864,8 +860,8 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         indlat26 = np.where(np.abs(dLat) == np.amin(np.abs(dLat)))
 
         inputFiles = sorted(self.historyStreams.readpath(
-                streamName, startDate=self.startDate,
-                endDate=self.endDate, calendar=self.calendar))
+            streamName, startDate=self.startDate,
+            endDate=self.endDate, calendar=self.calendar))
 
         years, months = get_files_year_month(inputFiles,
                                              self.historyStreams,
@@ -891,8 +887,8 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
                 for inIndex in range(dsMOCIn.dims['Time']):
 
                     mask = np.logical_and(
-                            dsMOCIn.year[inIndex].values == years,
-                            dsMOCIn.month[inIndex].values == months)
+                        dsMOCIn.year[inIndex].values == years,
+                        dsMOCIn.month[inIndex].values == months)
 
                     outIndex = np.where(mask)[0][0]
 
@@ -954,7 +950,6 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         # }}}
 
     def _compute_moc_time_series_postprocess(self):  # {{{
-
         '''compute MOC time series as a post-process'''
 
         config = self.config
@@ -965,15 +960,15 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         self.logger.info('   Load data...')
 
         outputDirectory = '{}/moc/'.format(
-                build_config_full_path(self.config, 'output',
-                                       'timeseriesSubdirectory'))
+            build_config_full_path(self.config, 'output',
+                                   'timeseriesSubdirectory'))
         try:
             os.makedirs(outputDirectory)
         except OSError:
             pass
 
         outputFileName = '{}/mocTimeSeries_{:04d}-{:04d}.nc'.format(
-                outputDirectory, self.startYear, self.endYear)
+            outputDirectory, self.startYear, self.endYear)
 
         dvEdge, areaCell, refBottomDepth, latCell, nVertLevels, \
             refTopDepth, refLayerThickness = _load_mesh(self.runStreams)
@@ -990,7 +985,7 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         indRegion = dictRegion['indices']
         latBins = latCell[indRegion]
         latBins = np.arange(np.amin(latBins),
-                            np.amax(latBins)+latBinSize,
+                            np.amax(latBins) + latBinSize,
                             latBinSize)
         latAtlantic = latBins
         dLat = latAtlantic - 26.5
@@ -1003,8 +998,8 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
 
         streamName = 'timeSeriesStatsMonthlyOutput'
         inputFiles = sorted(self.historyStreams.readpath(
-                streamName, startDate=self.startDate,
-                endDate=self.endDate, calendar=self.calendar))
+            streamName, startDate=self.startDate,
+            endDate=self.endDate, calendar=self.calendar))
 
         years, months = get_files_year_month(inputFiles,
                                              self.historyStreams,
@@ -1030,8 +1025,8 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
                 for inIndex in range(dsMOCIn.dims['Time']):
 
                     mask = np.logical_and(
-                            dsMOCIn.year[inIndex].values == years,
-                            dsMOCIn.month[inIndex].values == months)
+                        dsMOCIn.year[inIndex].values == years,
+                        dsMOCIn.month[inIndex].values == months)
 
                     outIndex = np.where(mask)[0][0]
 
@@ -1161,8 +1156,8 @@ class CombineMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         # -------
         # Xylar Asay-Davis
         outputDirectory = '{}/moc/'.format(
-                build_config_full_path(self.config, 'output',
-                                       'timeseriesSubdirectory'))
+            build_config_full_path(self.config, 'output',
+                                   'timeseriesSubdirectory'))
         try:
             os.makedirs(outputDirectory)
         except OSError:
@@ -1171,14 +1166,14 @@ class CombineMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         outputFileNames = []
         for startYear, endYear in zip(self.startYears, self.endYears):
             outputFileName = '{}/mocTimeSeries_{:04d}-{:04d}.nc'.format(
-                    outputDirectory, startYear, endYear)
+                outputDirectory, startYear, endYear)
             outputFileNames.append(outputFileName)
 
         ds = xr.open_mfdataset(outputFileNames, concat_dim='Time',
                                decode_times=False)
 
         outputFileName = '{}/mocTimeSeries_{:04d}-{:04d}.nc'.format(
-                outputDirectory, self.startYears[0], self.endYears[-1])
+            outputDirectory, self.startYears[0], self.endYears[-1])
         write_netcdf(ds, outputFileName)  # }}}
     # }}}
 
@@ -1278,7 +1273,7 @@ class PlotMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         self.logger.info('   Plot time series of max Atlantic MOC at 26.5N...')
         xLabel = 'Time [years]'
         yLabel = '[Sv]'
-        title = 'Max Atlantic MOC at $26.5\degree$N\n {}'.format(mainRunName)
+        title = r'Max Atlantic MOC at $26.5\degree$N\n {}'.format(mainRunName)
         filePrefix = self.filePrefix
 
         figureName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
@@ -1334,7 +1329,6 @@ class PlotMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         # }}}
 
     def _load_moc(self, config):  # {{{
-
         '''compute mean MOC streamfunction from analysis member'''
 
         outputDirectory = build_config_full_path(config, 'output',
@@ -1344,7 +1338,7 @@ class PlotMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         endYear = config.getint('timeSeries', 'endYear')
 
         inputFileName = '{}/moc/mocTimeSeries_{:04d}-{:04d}.nc'.format(
-                outputDirectory, startYear, endYear)
+            outputDirectory, startYear, endYear)
 
         dsMOCTimeSeries = xr.open_dataset(inputFileName, decode_times=False)
         return dsMOCTimeSeries  # }}}
@@ -1366,13 +1360,13 @@ def _load_mesh(runStreams):  # {{{
     latCell = np.rad2deg(ncFile.variables['latCell'][:])
     ncFile.close()
     nVertLevels = len(refBottomDepth)
-    refTopDepth = np.zeros(nVertLevels+1)
-    refTopDepth[1:nVertLevels+1] = refBottomDepth[0:nVertLevels]
+    refTopDepth = np.zeros(nVertLevels + 1)
+    refTopDepth[1:nVertLevels + 1] = refBottomDepth[0:nVertLevels]
     refLayerThickness = np.zeros(nVertLevels)
     refLayerThickness[0] = refBottomDepth[0]
     refLayerThickness[1:nVertLevels] = \
         (refBottomDepth[1:nVertLevels] -
-         refBottomDepth[0:nVertLevels-1])
+         refBottomDepth[0:nVertLevels - 1])
 
     return dvEdge, areaCell, refBottomDepth, latCell, nVertLevels, \
         refTopDepth, refLayerThickness
@@ -1419,7 +1413,6 @@ def _build_region_mask_dict(regionNames, regionMaskDirectory, mpasMeshName,
 def _compute_transport(maxEdgesInTransect, transectEdgeGlobalIDs,
                        transectEdgeMaskSigns, nz, dvEdge,
                        refLayerThickness, horizontalVel):  # {{{
-
     '''compute mass transport across southern transect of ocean basin'''
 
     transportZEdge = np.zeros([nz, maxEdgesInTransect])
@@ -1438,16 +1431,15 @@ def _compute_transport(maxEdgesInTransect, transectEdgeGlobalIDs,
 
 def _compute_moc(latBins, nz, latCell, regionCellMask, transportZ,
                  velArea):  # {{{
-
     '''compute meridionally integrated MOC streamfunction'''
 
-    mocTop = np.zeros([np.size(latBins), nz+1])
-    mocTop[0, range(1, nz+1)] = transportZ.cumsum()
+    mocTop = np.zeros([np.size(latBins), nz + 1])
+    mocTop[0, range(1, nz + 1)] = transportZ.cumsum()
     for iLat in range(1, np.size(latBins)):
         indlat = np.logical_and(np.logical_and(
-                     regionCellMask == 1, latCell >= latBins[iLat-1]),
-                     latCell < latBins[iLat])
-        mocTop[iLat, :] = mocTop[iLat-1, :] + \
+            regionCellMask == 1, latCell >= latBins[iLat - 1]),
+            latCell < latBins[iLat])
+        mocTop[iLat, :] = mocTop[iLat - 1, :] + \
             velArea[indlat, :].sum(axis=0)
     # convert m^3/s to Sverdrup
     mocTop = mocTop * m3ps_to_Sv

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -80,9 +80,9 @@ class TimeSeriesAntarcticMelt(AnalysisTask):  # {{{
             iceShelvesToPlot = get_feature_list(config, iceShelfMasksFile)
 
         masksSubtask = ComputeRegionMasksSubtask(
-                self, iceShelfMasksFile,
-                outFileSuffix='iceShelfMasks',
-                featureList=iceShelvesToPlot)
+            self, iceShelfMasksFile,
+            outFileSuffix='iceShelfMasks',
+            featureList=iceShelvesToPlot)
 
         self.add_subtask(masksSubtask)
 
@@ -225,7 +225,7 @@ class ComputeMeltSubtask(AnalysisTask):  # {{{
         # -------
         # Xylar Asay-Davis, Stephen Price
 
-        self.logger.info("\Computing Antarctic melt rate time series...")
+        self.logger.info(r"\Computing Antarctic melt rate time series...")
 
         self.logger.info('  Load melt rate data...')
 
@@ -268,7 +268,7 @@ class ComputeMeltSubtask(AnalysisTask):  # {{{
             mpasTimeSeriesTask.runStreams.readpath('restart')[0]
 
         dsRestart = xarray.open_dataset(restartFileName)
-        areaCell = dsRestart.landIceFraction.isel(Time=0)*dsRestart.areaCell
+        areaCell = dsRestart.landIceFraction.isel(Time=0) * dsRestart.areaCell
 
         regionMaskFileName = self.masksSubtask.maskFileName
 
@@ -290,12 +290,12 @@ class ComputeMeltSubtask(AnalysisTask):  # {{{
 
         # convert from kg/s to kg/yr
         totalMeltFlux = constants.sec_per_year * \
-            (cellMasks*areaCell*freshwaterFlux).sum(dim='nCells')
+            (cellMasks * areaCell * freshwaterFlux).sum(dim='nCells')
 
-        totalArea = (cellMasks*areaCell).sum(dim='nCells')
+        totalArea = (cellMasks * areaCell).sum(dim='nCells')
 
         # from kg/m^2/yr to m/yr
-        meltRates = (1./constants.rho_fw) * (totalMeltFlux/totalArea)
+        meltRates = (1. / constants.rho_fw) * (totalMeltFlux / totalArea)
 
         # convert from kg/yr to GT/yr
         totalMeltFlux /= constants.kg_per_GT
@@ -458,10 +458,10 @@ class PlotMeltSubtask(AnalysisTask):
                 # build dict of obs. keyed to filename description
                 # (which will be used for plotting)
                 obsDict[obsName] = {
-                        'meltFlux': meltFlux,
-                        'meltFluxUncertainty': meltFluxUncertainty,
-                        'meltRate': meltRate,
-                        'meltRateUncertainty': meltRateUncertainty}
+                    'meltFlux': meltFlux,
+                    'meltFluxUncertainty': meltFluxUncertainty,
+                    'meltRate': meltRate,
+                    'meltRateUncertainty': meltRateUncertainty}
                 break
 
         # If areas from obs file used need to be converted from sq km to sq m

--- a/mpas_analysis/ocean/time_series_ohc_anomaly.py
+++ b/mpas_analysis/ocean/time_series_ohc_anomaly.py
@@ -74,32 +74,32 @@ class TimeSeriesOHCAnomaly(AnalysisTask):
         timeSeriesFileName = 'regionAveragedOHCAnomaly.nc'
 
         anomalyTask = ComputeAnomalySubtask(
-                parentTask=self,
-                mpasTimeSeriesTask=mpasTimeSeriesTask,
-                outFileName=timeSeriesFileName,
-                variableList=list(self.variableDict.keys()),
-                movingAveragePoints=movingAveragePoints,
-                alter_dataset=self._compute_ohc)
+            parentTask=self,
+            mpasTimeSeriesTask=mpasTimeSeriesTask,
+            outFileName=timeSeriesFileName,
+            variableList=list(self.variableDict.keys()),
+            movingAveragePoints=movingAveragePoints,
+            alter_dataset=self._compute_ohc)
         self.add_subtask(anomalyTask)
 
         for regionName in regionNames:
             caption = 'Trend of {} OHC Anomaly vs depth'.format(
-                    regionName)
+                regionName)
             plotTask = PlotHovmollerSubtask(
-                    parentTask=self,
-                    regionName=regionName,
-                    inFileName=timeSeriesFileName,
-                    outFileLabel='ohcAnomalyZ',
-                    fieldNameInTitle='OHC Anomaly',
-                    mpasFieldName=mpasFieldName,
-                    unitsLabel=r'[$\times 10^{22}$ J]',
-                    sectionName='hovmollerOHCAnomaly',
-                    thumbnailSuffix=u'ΔOHC',
-                    imageCaption=caption,
-                    galleryGroup='Trends vs Depth',
-                    groupSubtitle=None,
-                    groupLink='trendsvsdepth',
-                    galleryName=None)
+                parentTask=self,
+                regionName=regionName,
+                inFileName=timeSeriesFileName,
+                outFileLabel='ohcAnomalyZ',
+                fieldNameInTitle='OHC Anomaly',
+                mpasFieldName=mpasFieldName,
+                unitsLabel=r'[$\times 10^{22}$ J]',
+                sectionName='hovmollerOHCAnomaly',
+                thumbnailSuffix=u'ΔOHC',
+                imageCaption=caption,
+                galleryGroup='Trends vs Depth',
+                groupSubtitle=None,
+                groupLink='trendsvsdepth',
+                galleryName=None)
 
             plotTask.run_after(anomalyTask)
             self.add_subtask(plotTask)
@@ -107,21 +107,21 @@ class TimeSeriesOHCAnomaly(AnalysisTask):
             caption = 'Running Mean of the Anomaly in {} Ocean Heat ' \
                 'Content'.format(regionName)
             plotTask = PlotDepthIntegratedTimeSeriesSubtask(
-                    parentTask=self,
-                    regionName=regionName,
-                    inFileName=timeSeriesFileName,
-                    outFileLabel='ohcAnomaly',
-                    fieldNameInTitle='OHC Anomaly',
-                    mpasFieldName=mpasFieldName,
-                    yAxisLabel=r'$\Delta$OHC [$\times 10^{22}$ J]',
-                    sectionName='timeSeriesOHCAnomaly',
-                    thumbnailSuffix=u'ΔOHC',
-                    imageCaption=caption,
-                    galleryGroup='Time Series',
-                    groupSubtitle=None,
-                    groupLink='timeseries',
-                    galleryName=None,
-                    controlConfig=controlConfig)
+                parentTask=self,
+                regionName=regionName,
+                inFileName=timeSeriesFileName,
+                outFileLabel='ohcAnomaly',
+                fieldNameInTitle='OHC Anomaly',
+                mpasFieldName=mpasFieldName,
+                yAxisLabel=r'$\Delta$OHC [$\times 10^{22}$ J]',
+                sectionName='timeSeriesOHCAnomaly',
+                thumbnailSuffix=u'ΔOHC',
+                imageCaption=caption,
+                galleryGroup='Time Series',
+                groupSubtitle=None,
+                groupLink='timeseries',
+                galleryName=None,
+                controlConfig=controlConfig)
 
             plotTask.run_after(anomalyTask)
             self.add_subtask(plotTask)
@@ -146,7 +146,7 @@ class TimeSeriesOHCAnomaly(AnalysisTask):
 
         unitsScalefactor = 1e-22
 
-        ds['ohc'] = unitsScalefactor*rho*cp*ds['sumLayerMaskValue'] * \
+        ds['ohc'] = unitsScalefactor * rho * cp * ds['sumLayerMaskValue'] * \
             ds['avgLayerArea'] * ds['avgLayerThickness'] * \
             ds['avgLayerTemperature']
         ds.ohc.attrs['units'] = '$10^{22}$ J'

--- a/mpas_analysis/ocean/time_series_salinity_anomaly.py
+++ b/mpas_analysis/ocean/time_series_salinity_anomaly.py
@@ -62,31 +62,31 @@ class TimeSeriesSalinityAnomaly(AnalysisTask):
         timeSeriesFileName = 'regionAveragedSalinityAnomaly.nc'
 
         anomalyTask = ComputeAnomalySubtask(
-                parentTask=self,
-                mpasTimeSeriesTask=mpasTimeSeriesTask,
-                outFileName=timeSeriesFileName,
-                variableList=[mpasFieldName],
-                movingAveragePoints=movingAveragePoints)
+            parentTask=self,
+            mpasTimeSeriesTask=mpasTimeSeriesTask,
+            outFileName=timeSeriesFileName,
+            variableList=[mpasFieldName],
+            movingAveragePoints=movingAveragePoints)
         self.add_subtask(anomalyTask)
 
         for regionName in regionNames:
             caption = 'Trend of {} Salinity Anomaly vs depth'.format(
-                    regionName)
+                regionName)
             plotTask = PlotHovmollerSubtask(
-                    parentTask=self,
-                    regionName=regionName,
-                    inFileName=timeSeriesFileName,
-                    outFileLabel='SAnomalyZ',
-                    fieldNameInTitle='Salinity Anomaly',
-                    mpasFieldName=mpasFieldName,
-                    unitsLabel='[PSU]',
-                    sectionName=sectionName,
-                    thumbnailSuffix=u'ΔS',
-                    imageCaption=caption,
-                    galleryGroup='Trends vs Depth',
-                    groupSubtitle=None,
-                    groupLink='trendsvsdepth',
-                    galleryName=None)
+                parentTask=self,
+                regionName=regionName,
+                inFileName=timeSeriesFileName,
+                outFileLabel='SAnomalyZ',
+                fieldNameInTitle='Salinity Anomaly',
+                mpasFieldName=mpasFieldName,
+                unitsLabel='[PSU]',
+                sectionName=sectionName,
+                thumbnailSuffix=u'ΔS',
+                imageCaption=caption,
+                galleryGroup='Trends vs Depth',
+                groupSubtitle=None,
+                groupLink='trendsvsdepth',
+                galleryName=None)
 
             plotTask.run_after(anomalyTask)
             self.add_subtask(plotTask)

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -108,8 +108,8 @@ class TimeSeriesSST(AnalysisTask):
         self.mpasTimeSeriesTask.add_variables(variableList=self.variableList)
 
         if config.get('runs', 'preprocessedReferenceRunName') != 'None':
-                check_path_exists(config.get('oceanPreprocessedReference',
-                                             'baseDirectory'))
+            check_path_exists(config.get('oceanPreprocessedReference',
+                                         'baseDirectory'))
 
         self.inputFile = self.mpasTimeSeriesTask.outputFile
 
@@ -182,19 +182,20 @@ class TimeSeriesSST(AnalysisTask):
                 self.controlConfig, 'output', 'timeSeriesSubdirectory')
 
             controlFileName = '{}/{}.nc'.format(
-                    baseDirectory, self.mpasTimeSeriesTask.fullTaskName)
+                baseDirectory, self.mpasTimeSeriesTask.fullTaskName)
 
-            controlStartYear = self.controlConfig.getint('timeSeries', 'startYear')
+            controlStartYear = self.controlConfig.getint(
+                'timeSeries', 'startYear')
             controlEndYear = self.controlConfig.getint('timeSeries', 'endYear')
             controlStartDate = '{:04d}-01-01_00:00:00'.format(controlStartYear)
             controlEndDate = '{:04d}-12-31_23:59:59'.format(controlEndYear)
 
             dsRefSST = open_mpas_dataset(
-                    fileName=controlFileName,
-                    calendar=calendar,
-                    variableList=self.variableList,
-                    startDate=controlStartDate,
-                    endDate=controlEndDate)
+                fileName=controlFileName,
+                calendar=calendar,
+                variableList=self.variableList,
+                startDate=controlStartDate,
+                endDate=controlEndDate)
         else:
             dsRefSST = None
 
@@ -230,7 +231,7 @@ class TimeSeriesSST(AnalysisTask):
 
             title = '{} SST'.format(plotTitles[regionIndex])
             xLabel = 'Time [years]'
-            yLabel = '[$\degree$C]'
+            yLabel = r'[$\degree$C]'
 
             varName = self.variableList[0]
             SST = dsSST[varName].isel(nOceanRegions=regionIndex)
@@ -282,7 +283,7 @@ class TimeSeriesSST(AnalysisTask):
                                      yearStrideXTicks=yearStrideXTicks)
 
             caption = 'Running Mean of {} Sea Surface Temperature'.format(
-                    region)
+                region)
             write_image_xml(
                 config=config,
                 filePrefix=filePrefix,

--- a/mpas_analysis/ocean/time_series_temperature_anomaly.py
+++ b/mpas_analysis/ocean/time_series_temperature_anomaly.py
@@ -62,31 +62,31 @@ class TimeSeriesTemperatureAnomaly(AnalysisTask):
         timeSeriesFileName = 'regionAveragedTemperatureAnomaly.nc'
 
         anomalyTask = ComputeAnomalySubtask(
-                parentTask=self,
-                mpasTimeSeriesTask=mpasTimeSeriesTask,
-                outFileName=timeSeriesFileName,
-                variableList=[mpasFieldName],
-                movingAveragePoints=movingAveragePoints)
+            parentTask=self,
+            mpasTimeSeriesTask=mpasTimeSeriesTask,
+            outFileName=timeSeriesFileName,
+            variableList=[mpasFieldName],
+            movingAveragePoints=movingAveragePoints)
         self.add_subtask(anomalyTask)
 
         for regionName in regionNames:
             caption = 'Trend of {} Potential Temperature Anomaly vs ' \
                       'Depth'.format(regionName)
             plotTask = PlotHovmollerSubtask(
-                    parentTask=self,
-                    regionName=regionName,
-                    inFileName=timeSeriesFileName,
-                    outFileLabel='TAnomalyZ',
-                    fieldNameInTitle='Potential Temperature Anomaly',
-                    mpasFieldName=mpasFieldName,
-                    unitsLabel='[$\degree$C]',
-                    sectionName=sectionName,
-                    thumbnailSuffix=u'Δϴ',
-                    imageCaption=caption,
-                    galleryGroup='Trends vs Depth',
-                    groupSubtitle=None,
-                    groupLink='trendsvsdepth',
-                    galleryName=None)
+                parentTask=self,
+                regionName=regionName,
+                inFileName=timeSeriesFileName,
+                outFileLabel='TAnomalyZ',
+                fieldNameInTitle='Potential Temperature Anomaly',
+                mpasFieldName=mpasFieldName,
+                unitsLabel=r'[$\degree$C]',
+                sectionName=sectionName,
+                thumbnailSuffix=u'Δϴ',
+                imageCaption=caption,
+                galleryGroup='Trends vs Depth',
+                groupSubtitle=None,
+                groupLink='trendsvsdepth',
+                galleryName=None)
 
             plotTask.run_after(anomalyTask)
             self.add_subtask(plotTask)

--- a/mpas_analysis/ocean/utility.py
+++ b/mpas_analysis/ocean/utility.py
@@ -58,11 +58,11 @@ def compute_zmid(bottomDepth, maxLevelCell, layerThickness):  # {{{
 
     thicknessSum = layerThickness.sum(dim='nVertLevels')
     thicknessCumSum = layerThickness.cumsum(dim='nVertLevels')
-    zSurface = -bottomDepth+thicknessSum
+    zSurface = -bottomDepth + thicknessSum
 
     zLayerBot = zSurface - thicknessCumSum
 
-    zMid = zLayerBot + 0.5*layerThickness
+    zMid = zLayerBot + 0.5 * layerThickness
 
     return zMid  # }}}
 

--- a/mpas_analysis/ocean/woce_transects.py
+++ b/mpas_analysis/ocean/woce_transects.py
@@ -58,9 +58,9 @@ class WoceTransects(AnalysisTask):  # {{{
 
         # call the constructor from the base class (AnalysisTask)
         super(WoceTransects, self).__init__(
-                config=config, taskName='woceTransects',
-                componentName='ocean',
-                tags=tags)
+            config=config, taskName='woceTransects',
+            componentName='ocean',
+            tags=tags)
 
         sectionName = self.taskName
 
@@ -75,7 +75,7 @@ class WoceTransects(AnalysisTask):  # {{{
             verticalComparisonGrid = None
         else:
             verticalComparisonGrid = config.getExpression(
-                    sectionName, 'verticalComparisonGrid', usenumpyfunc=True)
+                sectionName, 'verticalComparisonGrid', usenumpyfunc=True)
 
         observationsDirectory = build_obs_path(
             config, 'ocean', 'woceSubdirectory')
@@ -160,8 +160,8 @@ class WoceTransects(AnalysisTask):  # {{{
                     fieldNameUpper = fieldName[0].upper() + fieldName[1:]
                     titleName = fields[fieldName]['titleName']
                     fieldNameInTytle = '{} from {}'.format(
-                            titleName,
-                            transectName.replace('_', ' '))
+                        titleName,
+                        transectName.replace('_', ' '))
 
                     # make a new subtask for this season and comparison grid
                     subtask = PlotTransectSubtask(self, season, transectName,
@@ -170,21 +170,21 @@ class WoceTransects(AnalysisTask):  # {{{
                                                   plotObs, controlConfig)
 
                     subtask.set_plot_info(
-                            outFileLabel=outFileLabel,
-                            fieldNameInTitle=fieldNameInTytle,
-                            mpasFieldName=fields[fieldName]['mpas'],
-                            refFieldName=refFieldName,
-                            refTitleLabel=refTitleLabel,
-                            diffTitleLabel=diffTitleLabel,
-                            unitsLabel=fields[fieldName]['units'],
-                            imageCaption='{} {}'.format(fieldNameInTytle,
-                                                        season),
-                            galleryGroup='WOCE Transects',
-                            groupSubtitle=None,
-                            groupLink='woce',
-                            galleryName=titleName,
-                            configSectionName='woce{}Transects'.format(
-                                    fieldNameUpper))
+                        outFileLabel=outFileLabel,
+                        fieldNameInTitle=fieldNameInTytle,
+                        mpasFieldName=fields[fieldName]['mpas'],
+                        refFieldName=refFieldName,
+                        refTitleLabel=refTitleLabel,
+                        diffTitleLabel=diffTitleLabel,
+                        unitsLabel=fields[fieldName]['units'],
+                        imageCaption='{} {}'.format(fieldNameInTytle,
+                                                    season),
+                        galleryGroup='WOCE Transects',
+                        groupSubtitle=None,
+                        groupLink='woce',
+                        galleryName=titleName,
+                        configSectionName='woce{}Transects'.format(
+                            fieldNameUpper))
 
                     self.add_subtask(subtask)
         # }}}

--- a/mpas_analysis/sea_ice/climatology_map_berg_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_berg_conc.py
@@ -61,9 +61,9 @@ class ClimatologyMapIcebergConc(AnalysisTask):  # {{{
         fieldName = 'IcebergConc'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapIcebergConc, self).__init__(
-                config=config, taskName=taskName,
-                componentName='seaIce',
-                tags=['icebergs', 'climatology', 'horizontalMap', fieldName])
+            config=config, taskName=taskName,
+            componentName='seaIce',
+            tags=['icebergs', 'climatology', 'horizontalMap', fieldName])
 
         mpasFieldName = 'timeMonthly_avg_bergAreaCell'
         iselValues = None
@@ -106,15 +106,15 @@ class ClimatologyMapIcebergConc(AnalysisTask):  # {{{
             diffTitleLabel = 'Model - Observations'
             refFieldName = 'icebergConc'
             obsFileName = build_obs_path(
-                    config, 'iceberg',
-                    'concentrationAltiberg{}'.format(hemisphere))
+                config, 'iceberg',
+                'concentrationAltiberg{}'.format(hemisphere))
 
             remapObservationsSubtask = RemapAltibergConcClimatology(
-                    parentTask=self, seasons=seasons,
-                    fileName=obsFileName,
-                    outFilePrefix='{}{}'.format(refFieldName,
-                                                hemisphere),
-                    comparisonGridNames=comparisonGridNames)
+                parentTask=self, seasons=seasons,
+                fileName=obsFileName,
+                outFilePrefix='{}{}'.format(refFieldName,
+                                            hemisphere),
+                comparisonGridNames=comparisonGridNames)
             self.add_subtask(remapObservationsSubtask)
 
         else:
@@ -135,28 +135,28 @@ class ClimatologyMapIcebergConc(AnalysisTask):  # {{{
                 imageCaption = imageDescription
                 galleryGroup = \
                     '{}-Hemisphere Iceberg Concentration'.format(
-                            hemisphereLong)
+                        hemisphereLong)
                 # make a new subtask for this season and comparison grid
                 subtask = PlotClimatologyMapSubtask(
-                        self, hemisphere, season, comparisonGridName,
-                        remapClimatologySubtask, remapObservationsSubtask,
-                        controlConfig)
+                    self, hemisphere, season, comparisonGridName,
+                    remapClimatologySubtask, remapObservationsSubtask,
+                    controlConfig)
 
                 subtask.set_plot_info(
-                        outFileLabel='bergconc{}'.format(hemisphere),
-                        fieldNameInTitle='Iceberg concentration',
-                        mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
-                        diffTitleLabel=diffTitleLabel,
-                        unitsLabel=r'fraction',
-                        imageDescription=imageDescription,
-                        imageCaption=imageCaption,
-                        galleryGroup=galleryGroup,
-                        groupSubtitle=None,
-                        groupLink='{}_conc'.format(hemisphere.lower()),
-                        galleryName=galleryName,
-                        maskValue=None)
+                    outFileLabel='bergconc{}'.format(hemisphere),
+                    fieldNameInTitle='Iceberg concentration',
+                    mpasFieldName=mpasFieldName,
+                    refFieldName=refFieldName,
+                    refTitleLabel=refTitleLabel,
+                    diffTitleLabel=diffTitleLabel,
+                    unitsLabel=r'fraction',
+                    imageDescription=imageDescription,
+                    imageCaption=imageCaption,
+                    galleryGroup=galleryGroup,
+                    groupSubtitle=None,
+                    groupLink='{}_conc'.format(hemisphere.lower()),
+                    galleryName=galleryName,
+                    maskValue=None)
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -64,9 +64,9 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
         fieldName = 'seaIceConc'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapSeaIceConc, self).__init__(
-                config=config, taskName=taskName,
-                componentName='seaIce',
-                tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
+            config=config, taskName=taskName,
+            componentName='seaIce',
+            tags=['climatology', 'horizontalMap', fieldName, 'publicObs'])
 
         mpasFieldName = 'timeMonthly_avg_iceAreaCell'
         iselValues = None
@@ -129,19 +129,19 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
                     'Observations (SSM/I {})'.format(prefix)
 
                 obsFileName = build_obs_path(
-                        config, 'seaIce',
-                        relativePathOption='concentration{}{}_{}'.format(
-                                prefix, hemisphere, season),
-                        relativePathSection=sectionName)
+                    config, 'seaIce',
+                    relativePathOption='concentration{}{}_{}'.format(
+                        prefix, hemisphere, season),
+                    relativePathSection=sectionName)
 
                 remapObservationsSubtask = RemapObservedConcClimatology(
-                        parentTask=self, seasons=[season],
-                        fileName=obsFileName,
-                        outFilePrefix='{}{}{}_{}'.format(
-                                obsFieldName,  prefix, hemisphere, season),
-                        comparisonGridNames=comparisonGridNames,
-                        subtaskName='remapObservations_{}{}'.format(
-                                prefix,  season))
+                    parentTask=self, seasons=[season],
+                    fileName=obsFileName,
+                    outFilePrefix='{}{}{}_{}'.format(
+                        obsFieldName, prefix, hemisphere, season),
+                    comparisonGridNames=comparisonGridNames,
+                    subtaskName='remapObservations_{}{}'.format(
+                        prefix, season))
                 self.add_subtask(remapObservationsSubtask)
                 for comparisonGridName in comparisonGridNames:
 
@@ -153,7 +153,7 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
                             imageDescription, prefix)
                     galleryGroup = \
                         '{}-Hemisphere Sea-Ice Concentration'.format(
-                                hemisphereLong)
+                            hemisphereLong)
                     # make a new subtask for this season and comparison
                     # grid
                     subtask = PlotClimatologyMapSubtask(
@@ -177,7 +177,7 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
                         groupSubtitle=None,
                         groupLink='{}_conc'.format(hemisphere.lower()),
                         galleryName='Observations: SSM/I {}'.format(
-                                prefix))
+                            prefix))
 
                     self.add_subtask(subtask)
         # }}}
@@ -200,7 +200,7 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
                 imageCaption = imageDescription
                 galleryGroup = \
                     '{}-Hemisphere Sea-Ice Concentration'.format(
-                            hemisphereLong)
+                        hemisphereLong)
                 # make a new subtask for this season and comparison
                 # grid
                 subtask = PlotClimatologyMapSubtask(
@@ -208,19 +208,19 @@ class ClimatologyMapSeaIceConc(AnalysisTask):  # {{{
                     remapClimatologySubtask, controlConfig=controlConfig)
 
                 subtask.set_plot_info(
-                        outFileLabel='iceconc{}'.format(hemisphere),
-                        fieldNameInTitle='Sea ice concentration',
-                        mpasFieldName=mpasFieldName,
-                        refFieldName=mpasFieldName,
-                        refTitleLabel=refTitleLabel,
-                        diffTitleLabel='Main - Control',
-                        unitsLabel=r'fraction',
-                        imageDescription=imageDescription,
-                        imageCaption=imageCaption,
-                        galleryGroup=galleryGroup,
-                        groupSubtitle=None,
-                        groupLink='{}_conc'.format(hemisphere.lower()),
-                        galleryName=galleryName)
+                    outFileLabel='iceconc{}'.format(hemisphere),
+                    fieldNameInTitle='Sea ice concentration',
+                    mpasFieldName=mpasFieldName,
+                    refFieldName=mpasFieldName,
+                    refTitleLabel=refTitleLabel,
+                    diffTitleLabel='Main - Control',
+                    unitsLabel=r'fraction',
+                    imageDescription=imageDescription,
+                    imageCaption=imageCaption,
+                    galleryGroup=galleryGroup,
+                    groupSubtitle=None,
+                    groupLink='{}_conc'.format(hemisphere.lower()),
+                    galleryName=galleryName)
 
                 self.add_subtask(subtask)
         # }}}

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -64,10 +64,10 @@ class ClimatologyMapSeaIceThick(AnalysisTask):  # {{{
         fieldName = 'seaIceThick'
         # call the constructor from the base class (AnalysisTask)
         super(ClimatologyMapSeaIceThick, self).__init__(
-                config=config, taskName=taskName,
-                componentName='seaIce',
-                tags=['climatology', 'horizontalMap', fieldName,
-                      'publicObs'])
+            config=config, taskName=taskName,
+            componentName='seaIce',
+            tags=['climatology', 'horizontalMap', fieldName,
+                  'publicObs'])
 
         mpasFieldName = 'timeMonthly_avg_iceVolumeCell'
         iselValues = None
@@ -121,19 +121,19 @@ class ClimatologyMapSeaIceThick(AnalysisTask):  # {{{
         for season in seasons:
             if controlConfig is None:
                 obsFileName = build_obs_path(
-                        config, 'seaIce',
-                        relativePathOption='thickness{}_{}'.format(hemisphere,
-                                                                   season),
-                        relativePathSection=sectionName)
+                    config, 'seaIce',
+                    relativePathOption='thickness{}_{}'.format(hemisphere,
+                                                               season),
+                    relativePathSection=sectionName)
 
                 remapObservationsSubtask = RemapObservedThickClimatology(
-                        parentTask=self, seasons=[season],
-                        fileName=obsFileName,
-                        outFilePrefix='{}{}_{}'.format(refFieldName,
-                                                       hemisphere,
-                                                       season),
-                        comparisonGridNames=comparisonGridNames,
-                        subtaskName='remapObservations{}'.format(season))
+                    parentTask=self, seasons=[season],
+                    fileName=obsFileName,
+                    outFilePrefix='{}{}_{}'.format(refFieldName,
+                                                   hemisphere,
+                                                   season),
+                    comparisonGridNames=comparisonGridNames,
+                    subtaskName='remapObservations{}'.format(season))
                 self.add_subtask(remapObservationsSubtask)
 
             for comparisonGridName in comparisonGridNames:
@@ -144,28 +144,28 @@ class ClimatologyMapSeaIceThick(AnalysisTask):  # {{{
                 imageCaption = imageDescription
                 galleryGroup = \
                     '{}-Hemisphere Sea-Ice Thickness'.format(
-                            hemisphereLong)
+                        hemisphereLong)
                 # make a new subtask for this season and comparison grid
                 subtask = PlotClimatologyMapSubtask(
-                        self, hemisphere, season, comparisonGridName,
-                        remapClimatologySubtask, remapObservationsSubtask,
-                        controlConfig)
+                    self, hemisphere, season, comparisonGridName,
+                    remapClimatologySubtask, remapObservationsSubtask,
+                    controlConfig)
 
                 subtask.set_plot_info(
-                        outFileLabel='icethick{}'.format(hemisphere),
-                        fieldNameInTitle='Sea ice thickness',
-                        mpasFieldName=mpasFieldName,
-                        refFieldName=refFieldName,
-                        refTitleLabel=refTitleLabel,
-                        diffTitleLabel=diffTitleLabel,
-                        unitsLabel=r'm',
-                        imageDescription=imageDescription,
-                        imageCaption=imageCaption,
-                        galleryGroup=galleryGroup,
-                        groupSubtitle=None,
-                        groupLink='{}_thick'.format(hemisphere.lower()),
-                        galleryName=galleryName,
-                        maskValue=0)
+                    outFileLabel='icethick{}'.format(hemisphere),
+                    fieldNameInTitle='Sea ice thickness',
+                    mpasFieldName=mpasFieldName,
+                    refFieldName=refFieldName,
+                    refTitleLabel=refTitleLabel,
+                    diffTitleLabel=diffTitleLabel,
+                    unitsLabel=r'm',
+                    imageDescription=imageDescription,
+                    imageCaption=imageCaption,
+                    galleryGroup=galleryGroup,
+                    groupSubtitle=None,
+                    groupLink='{}_thick'.format(hemisphere.lower()),
+                    galleryName=galleryName,
+                    maskValue=0)
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/sea_ice/plot_climatology_map_subtask.py
+++ b/mpas_analysis/sea_ice/plot_climatology_map_subtask.py
@@ -156,8 +156,8 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
 
         # call the constructor from the base class (AnalysisTask)
         super(PlotClimatologyMapSubtask, self).__init__(
-                config=config, taskName=taskName, subtaskName=subtaskName,
-                componentName='seaIce', tags=tags)
+            config=config, taskName=taskName, subtaskName=subtaskName,
+            componentName='seaIce', tags=tags)
 
         # this task should not run until the remapping subtasks are done, since
         # it relies on data from those subtasks
@@ -266,8 +266,8 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
         self.xmlFileNames = []
 
         self.filePrefix = '{}_{}_{}_years{:04d}-{:04d}'.format(
-                self.outFileLabel, mainRunName,
-                self.season, self.startYear, self.endYear)
+            self.outFileLabel, mainRunName,
+            self.season, self.startYear, self.endYear)
         self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
                                                     self.filePrefix))
 
@@ -288,8 +288,8 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
 
         self.logger.info("\nPlotting 2-d maps of {} climatologies for "
                          "{} against {}...".format(
-                                 self.fieldNameInTitle,
-                                 season, self.refTitleLabel))
+                             self.fieldNameInTitle,
+                             season, self.refTitleLabel))
 
         mainRunName = config.get('runs', 'mainRunName')
         startYear = self.startYear
@@ -310,7 +310,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
 
         remappedFileName = \
             self.remapMpasClimatologySubtask.get_remapped_file_name(
-                    season=season, comparisonGridName=comparisonGridName)
+                season=season, comparisonGridName=comparisonGridName)
         remappedClimatology = xr.open_dataset(remappedFileName)
 
         modelOutput = remappedClimatology[self.mpasFieldName].values
@@ -345,7 +345,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
             if controlStartYear != self.startYear or \
                     controlEndYear != self.endYear:
                 self.refTitleLabel = '{}\n(years {:04d}-{:04d})'.format(
-                        self.refTitleLabel, controlStartYear, controlEndYear)
+                    self.refTitleLabel, controlStartYear, controlEndYear)
         else:
             remappedRefClimatology = None
 
@@ -376,7 +376,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
             normType = config.get(sectionName, 'normTypeResult')
             normArgs = config.getExpression(sectionName, 'normArgsResult')
             if normType == 'log':
-                epsilon = 1e-2*normArgs['vmin']
+                epsilon = 1e-2 * normArgs['vmin']
                 modelOutput = np.maximum(modelOutput, epsilon)
                 if refOutput is not None:
                     refOutput = np.maximum(refOutput, epsilon)

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -118,8 +118,8 @@ class TimeSeriesSeaIce(AnalysisTask):
         self.inputFile = self.mpasTimeSeriesTask.outputFile
 
         if config.get('runs', 'preprocessedReferenceRunName') != 'None':
-                check_path_exists(config.get('seaIcePreprocessedReference',
-                                             'baseDirectory'))
+            check_path_exists(config.get('seaIcePreprocessedReference',
+                                         'baseDirectory'))
 
         # get a list of timeSeriesStatsMonthly output files from the streams
         # file, reading only those that are between the start and end dates
@@ -166,9 +166,9 @@ class TimeSeriesSeaIce(AnalysisTask):
                                             variableName)
 
                 self.xmlFileNames.append('{}/{}.xml'.format(
-                        self.plotsDirectory, filePrefix))
+                    self.plotsDirectory, filePrefix))
                 polarXMLFileNames.append('{}/{}_polar.xml'.format(
-                        self.plotsDirectory, filePrefix))
+                    self.plotsDirectory, filePrefix))
         else:
 
             for hemisphere in ['NH', 'SH']:
@@ -178,9 +178,9 @@ class TimeSeriesSeaIce(AnalysisTask):
                                                   mainRunName)
 
                     self.xmlFileNames.append('{}/{}.xml'.format(
-                            self.plotsDirectory, filePrefix))
+                        self.plotsDirectory, filePrefix))
                     polarXMLFileNames.append('{}/{}_polar.xml'.format(
-                            self.plotsDirectory, filePrefix))
+                        self.plotsDirectory, filePrefix))
 
         if polarPlot:
             self.xmlFileNames.extend(polarXMLFileNames)
@@ -211,21 +211,21 @@ class TimeSeriesSeaIce(AnalysisTask):
 
         obsFileNames = {
             'iceArea': {'NH': build_obs_path(
-                                  config, 'seaIce',
-                                  relativePathOption='areaNH',
-                                  relativePathSection=sectionName),
-                        'SH': build_obs_path(
-                                  config, 'seaIce',
-                                  relativePathOption='areaSH',
-                                  relativePathSection=sectionName)},
+                config, 'seaIce',
+                relativePathOption='areaNH',
+                relativePathSection=sectionName),
+                'SH': build_obs_path(
+                config, 'seaIce',
+                relativePathOption='areaSH',
+                relativePathSection=sectionName)},
             'iceVolume': {'NH': build_obs_path(
-                                   config, 'seaIce',
-                                   relativePathOption='volNH',
-                                   relativePathSection=sectionName),
-                          'SH': build_obs_path(
-                                   config, 'seaIce',
-                                   relativePathOption='volSH',
-                                   relativePathSection=sectionName)}}
+                config, 'seaIce',
+                relativePathOption='volNH',
+                relativePathSection=sectionName),
+                'SH': build_obs_path(
+                config, 'seaIce',
+                relativePathOption='volSH',
+                relativePathSection=sectionName)}}
 
         # Some plotting rules
         titleFontSize = config.get('timeSeriesSeaIceAreaVol', 'titleFontSize')
@@ -480,9 +480,9 @@ class TimeSeriesSeaIce(AnalysisTask):
                                               hemisphere,
                                               mainRunName)
                 thumbnailDescription = '{} {}'.format(
-                        hemisphere, plotTitles[variableName])
+                    hemisphere, plotTitles[variableName])
                 caption = 'Running mean of {}'.format(
-                        thumbnailDescription)
+                    thumbnailDescription)
                 write_image_xml(
                     config,
                     filePrefix,
@@ -561,24 +561,24 @@ class TimeSeriesSeaIce(AnalysisTask):
                   MpasRelativeDelta(repSecondTime, repStartTime))
 
         startIndex = 0
-        while(dsStartTime > repStartTime + (startIndex+1)*period):
+        while(dsStartTime > repStartTime + (startIndex + 1) * period):
             startIndex += 1
 
         endIndex = 0
-        while(dsEndTime > repEndTime + endIndex*period):
+        while(dsEndTime > repEndTime + endIndex * period):
             endIndex += 1
 
         dsShift = dsToReplicate.copy()
 
         times = days_to_datetime(dsShift.Time, calendar=calendar)
         dsShift.coords['Time'] = ('Time',
-                                  datetime_to_days(times + startIndex*period,
+                                  datetime_to_days(times + startIndex * period,
                                                    calendar=calendar))
         # replicate cycle:
         for cycleIndex in range(startIndex, endIndex):
             dsNew = dsToReplicate.copy()
             dsNew.coords['Time'] = \
-                ('Time', datetime_to_days(times + (cycleIndex+1)*period,
+                ('Time', datetime_to_days(times + (cycleIndex + 1) * period,
                                           calendar=calendar))
             dsShift = xr.concat([dsShift, dsNew], dim='Time')
 
@@ -627,10 +627,10 @@ class TimeSeriesSeaIce(AnalysisTask):
             else:
                 mask = dsMesh.latCell < 0
 
-            dsAreaSum = (ds.where(mask)*dsMesh.areaCell).sum('nCells')
+            dsAreaSum = (ds.where(mask) * dsMesh.areaCell).sum('nCells')
             dsAreaSum = dsAreaSum.rename(
-                    {'timeMonthly_avg_iceAreaCell': 'iceArea',
-                     'timeMonthly_avg_iceVolumeCell': 'iceVolume'})
+                {'timeMonthly_avg_iceAreaCell': 'iceArea',
+                 'timeMonthly_avg_iceVolumeCell': 'iceVolume'})
             dsAreaSum['iceThickness'] = (dsAreaSum.iceVolume /
                                          dsMesh.areaCell.sum('nCells'))
 

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -199,7 +199,7 @@ class AnalysisTask(Process):  # {{{
         self.plotsDirectory = build_config_full_path(self.config, 'output',
                                                      'plotsSubdirectory')
         namelistFileName = build_config_full_path(
-            self.config,  'input',
+            self.config, 'input',
             '{}NamelistFileName'.format(self.componentName))
         self.namelist = NameList(namelistFileName)
 
@@ -455,7 +455,7 @@ class AnalysisTask(Process):  # {{{
                       'are analyzing was run with an\n'
                       'older version of MPAS-O that did not support '
                       'this flag.  Assuming enabled.'.format(
-                              analysisOptionName))
+                          analysisOptionName))
 
         if not enabled and raiseException:
             raise RuntimeError('*** MPAS-Analysis relies on {} = .true.\n'
@@ -550,6 +550,7 @@ class StreamToLogger(object):  # {{{
 
     Fake file-like stream object that redirects writes to a logger instance.
     """
+
     def __init__(self, logger, log_level=logging.INFO):
         self.logger = logger
         self.log_level = log_level
@@ -585,7 +586,7 @@ def update_time_bounds_from_file_names(config, section, componentName):  # {{{
         defaultPath=runDirectory)
 
     namelistFileName = build_config_full_path(
-        config,  'input',
+        config, 'input',
         '{}NamelistFileName'.format(componentName))
     try:
         namelist = NameList(namelistFileName)
@@ -614,8 +615,8 @@ def update_time_bounds_from_file_names(config, section, componentName):  # {{{
     streamName = 'timeSeriesStatsMonthlyOutput'
     try:
         inputFiles = historyStreams.readpath(
-                streamName, startDate=startDate, endDate=endDate,
-                calendar=calendar)
+            streamName, startDate=startDate, endDate=endDate,
+            calendar=calendar)
     except ValueError:
         # this component likely doesn't have output in this run
         return
@@ -631,7 +632,7 @@ def update_time_bounds_from_file_names(config, section, componentName):  # {{{
     startYear = years[firstIndex]
 
     # search for the end of the last full year
-    lastIndex = len(years)-1
+    lastIndex = len(years) - 1
     while(lastIndex >= 0 and months[lastIndex] != 12):
         lastIndex -= 1
     endYear = years[lastIndex]

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -83,10 +83,10 @@ def get_remapper(config, sourceDescriptor, comparisonDescriptor,
         # we need to remap because the grids don't match
 
         mappingBaseName = '{}_{}_to_{}_{}.nc'.format(
-                mappingFilePrefix,
-                sourceDescriptor.meshName,
-                comparisonDescriptor.meshName,
-                method)
+            mappingFilePrefix,
+            sourceDescriptor.meshName,
+            comparisonDescriptor.meshName,
+            method)
 
         mappingSubdirectory = build_config_full_path(config, 'diagnostics',
                                                      'mappingSubdirectory')
@@ -271,7 +271,7 @@ def add_years_months_days_in_month(ds, calendar=None):  # {{{
                       'will be computed with\n'
                       'month durations ignoring leap years.')
 
-            daysInMonth = numpy.array([constants.daysInMonth[int(month)-1] for
+            daysInMonth = numpy.array([constants.daysInMonth[int(month) - 1] for
                                        month in ds.month.values], float)
             ds.coords['daysInMonth'] = ('Time', daysInMonth)
 
@@ -423,7 +423,7 @@ def get_unmasked_mpas_climatology_file_name(config, season, componentName):
     endMonth = monthValues[-1]
 
     suffix = '{:04d}{:02d}_{:04d}{:02d}_climo'.format(
-            startYear, startMonth, endYear, endMonth)
+        startYear, startMonth, endYear, endMonth)
 
     if season in constants.abrevMonthNames:
         season = '{:02d}'.format(monthValues[0])
@@ -475,8 +475,8 @@ def get_masked_mpas_climatology_file_name(config, season, componentName,
     stageDirectory = '{}/masked'.format(climatologyBaseDirectory)
 
     directory = '{}/{}_{}'.format(
-            stageDirectory, climatologyName,
-            mpasMeshName)
+        stageDirectory, climatologyName,
+        mpasMeshName)
 
     make_directories(directory)
 
@@ -485,12 +485,12 @@ def get_masked_mpas_climatology_file_name(config, season, componentName,
     endMonth = monthValues[-1]
 
     suffix = '{:04d}{:02d}_{:04d}{:02d}_climo'.format(
-            startYear, startMonth, endYear, endMonth)
+        startYear, startMonth, endYear, endMonth)
 
     if season in constants.abrevMonthNames:
         season = '{:02d}'.format(monthValues[0])
     fileName = '{}/{}_{}_{}.nc'.format(
-            directory, ncclimoModel, season, suffix)
+        directory, ncclimoModel, season, suffix)
 
     return fileName  # }}}
 
@@ -560,12 +560,12 @@ def get_remapped_mpas_climatology_file_name(config, season, componentName,
     endMonth = monthValues[-1]
 
     suffix = '{:04d}{:02d}_{:04d}{:02d}_climo'.format(
-            startYear, startMonth, endYear, endMonth)
+        startYear, startMonth, endYear, endMonth)
 
     if season in constants.abrevMonthNames:
         season = '{:02d}'.format(monthValues[0])
     fileName = '{}/{}_{}_{}.nc'.format(
-            directory, ncclimoModel, season, suffix)
+        directory, ncclimoModel, season, suffix)
 
     return fileName  # }}}
 
@@ -663,13 +663,13 @@ def _setup_climatology_caching(ds, startYearClimo, endYearClimo,
 
     cacheInfo = []
 
-    cacheIndices = -1*numpy.ones(ds.dims['Time'], int)
+    cacheIndices = -1 * numpy.ones(ds.dims['Time'], int)
     monthsInDs = ds.month.values
     yearsInDs = ds.year.values
 
     # figure out which files to load and which years go in each file
-    for firstYear in range(startYearClimo, endYearClimo+1, yearsPerCacheFile):
-        years = range(firstYear, firstYear+yearsPerCacheFile)
+    for firstYear in range(startYearClimo, endYearClimo + 1, yearsPerCacheFile):
+        years = range(firstYear, firstYear + yearsPerCacheFile)
 
         yearString, fileSuffix = _get_year_string(years[0], years[-1])
         outputFileClimo = '{}_{}.nc'.format(cachePrefix, fileSuffix)
@@ -687,7 +687,7 @@ def _setup_climatology_caching(ds, startYearClimo, endYearClimo,
 
                 os.remove(outputFileClimo)
 
-            monthsIfDone = len(monthValues)*len(years)
+            monthsIfDone = len(monthValues) * len(years)
             if ((dsCached is not None) and
                     (dsCached.attrs['totalMonths'] == monthsIfDone)):
                 # also complete, so we can move on
@@ -736,7 +736,7 @@ def _cache_individual_climatologies(ds, cacheInfo, printProgress,
 
         monthCount = dsYear.dims['Time']
 
-        climatology = compute_climatology(dsYear,  monthValues, calendar,
+        climatology = compute_climatology(dsYear, monthValues, calendar,
                                           maskVaries=False)
 
         climatology.attrs['totalDays'] = totalDays
@@ -785,7 +785,8 @@ def _cache_aggregated_climatology(startYearClimo, endYearClimo, cachePrefix,
             done = True
 
         elif climatology is not None:
-            monthsIfDone = (endYearClimo-startYearClimo+1)*len(monthValues)
+            monthsIfDone = (
+                endYearClimo - startYearClimo + 1) * len(monthValues)
             if climatology.attrs['totalMonths'] == monthsIfDone:
                 # also complete, so we can move on
                 done = True

--- a/mpas_analysis/shared/climatology/comparison_descriptors.py
+++ b/mpas_analysis/shared/climatology/comparison_descriptors.py
@@ -107,8 +107,8 @@ def _get_lat_lon_comparison_descriptor(config):  # {{{
                                              'comparisonLatResolution',
                                              constants.dLongitude)
 
-    nLat = int((constants.latmax-constants.latmin)/comparisonLatRes)+1
-    nLon = int((constants.lonmax-constants.lonmin)/comparisonLonRes)+1
+    nLat = int((constants.latmax - constants.latmin) / comparisonLatRes) + 1
+    nLon = int((constants.lonmax - constants.lonmin) / comparisonLonRes) + 1
     lat = numpy.linspace(constants.latmin, constants.latmax, nLat)
     lon = numpy.linspace(constants.lonmin, constants.lonmax, nLon)
 
@@ -145,8 +145,8 @@ def _get_antarctic_stereographic_comparison_descriptor(config):  # {{{
 
     projection = get_antarctic_stereographic_projection()
 
-    xMax = 0.5*comparisonStereoWidth*1e3
-    nx = int(comparisonStereoWidth/comparisonStereoResolution)+1
+    xMax = 0.5 * comparisonStereoWidth * 1e3
+    nx = int(comparisonStereoWidth / comparisonStereoResolution) + 1
     x = numpy.linspace(-xMax, xMax, nx)
 
     meshName = '{}x{}km_{}km_Antarctic_stereo'.format(

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -154,8 +154,8 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         for variable in variableList:
             if variable not in self.allVariables:
                 raise ValueError(
-                        '{} is not available in timeSeriesStatsMonthly '
-                        'output:\n{}'.format(variable, self.allVariables))
+                    '{} is not available in timeSeriesStatsMonthly '
+                    'output:\n{}'.format(variable, self.allVariables))
 
             if variable not in self.variableList:
                 self.variableList.append(variable)
@@ -202,8 +202,8 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         # reading only those that are between the start and end dates
         streamName = 'timeSeriesStatsMonthlyOutput'
         self.inputFiles = self.historyStreams.readpath(
-                streamName, startDate=self.startDate, endDate=self.endDate,
-                calendar=self.calendar)
+            streamName, startDate=self.startDate, endDate=self.endDate,
+            calendar=self.calendar)
 
         if len(self.inputFiles) == 0:
             raise IOError('No files were found in stream {} between {} and '
@@ -231,8 +231,8 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
 
         self.logger.info('\nComputing MPAS climatologies from files:\n'
                          '    {} through\n    {}'.format(
-                                 os.path.basename(self.inputFiles[0]),
-                                 os.path.basename(self.inputFiles[-1])))
+                             os.path.basename(self.inputFiles[0]),
+                             os.path.basename(self.inputFiles[-1])))
 
         seasonsToCheck = list(constants.abrevMonthNames)
         for season in self.seasons:
@@ -244,7 +244,7 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
 
             climatologyFileName = self.get_file_name(season)
             climatologyDirectory = get_unmasked_mpas_climatology_directory(
-                    self.config)
+                self.config)
 
             if not os.path.exists(climatologyFileName):
                 allExist = False
@@ -261,8 +261,8 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
 
         if not allExist:
             self._compute_climatologies_with_ncclimo(
-                    inDirectory=self.symlinkDirectory,
-                    outDirectory=climatologyDirectory)
+                inDirectory=self.symlinkDirectory,
+                outDirectory=climatologyDirectory)
 
         # }}}
 
@@ -340,7 +340,7 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
             config, 'output', 'mpasClimatologySubdirectory')
 
         symlinkDirectory = '{}/source_symlinks'.format(
-                climatologyBaseDirectory)
+            climatologyBaseDirectory)
 
         make_directories(symlinkDirectory)
 

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -247,10 +247,10 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
             for season in self.seasons:
 
                 maskedClimatologyFileName = self.get_masked_file_name(
-                        season)
+                    season)
 
                 remappedFileName = self.get_remapped_file_name(
-                        season, comparisonGridName)
+                    season, comparisonGridName)
 
                 if not os.path.exists(remappedFileName):
                     self._remap(inFileName=maskedClimatologyFileName,
@@ -330,8 +330,8 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
         # Xylar Asay-Davis
 
         fileName = get_remapped_mpas_climatology_file_name(
-                self.config, season, self.componentName, self.climatologyName,
-                comparisonGridName)
+            self.config, season, self.componentName, self.climatologyName,
+            comparisonGridName)
 
         return fileName  # }}}
 
@@ -464,14 +464,14 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
 
             if stage == 'masked':
                 directory = '{}/{}_{}'.format(
-                        stageDirectory, self.climatologyName,
-                        mpasMeshName)
+                    stageDirectory, self.climatologyName,
+                    mpasMeshName)
             elif stage == 'remapped':
                 directory = '{}/{}_{}_to_{}'.format(
-                        stageDirectory,
-                        self.climatologyName,
-                        mpasMeshName,
-                        comparisonFullMeshNames[comparisonGridName])
+                    stageDirectory,
+                    self.climatologyName,
+                    mpasMeshName,
+                    comparisonFullMeshNames[comparisonGridName])
 
             make_directories(directory)
 
@@ -480,14 +480,14 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
             endMonth = monthValues[-1]
 
             suffix = '{:04d}{:02d}_{:04d}{:02d}_climo'.format(
-                    self.mpasClimatologyTask.startYear, startMonth,
-                    self.mpasClimatologyTask.endYear, endMonth)
+                self.mpasClimatologyTask.startYear, startMonth,
+                self.mpasClimatologyTask.endYear, endMonth)
 
             if season in constants.abrevMonthNames:
                 season = '{:02d}'.format(monthValues[0])
             fileName = '{}/{}_{}_{}.nc'.format(
-                    directory, self.mpasClimatologyTask.ncclimoModel, season,
-                    suffix)
+                directory, self.mpasClimatologyTask.ncclimoModel, season,
+                suffix)
 
             self._outputDirs[key] = directory
             self._outputFiles[key] = fileName
@@ -600,7 +600,7 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
 
         # customize (if this function has been overridden)
         remappedClimatology = self.customize_remapped_climatology(
-                remappedClimatology, comparisonGridName, season)
+            remappedClimatology, comparisonGridName, season)
 
         write_netcdf(remappedClimatology, outFileName)  # }}}
 

--- a/mpas_analysis/shared/climatology/remap_observed_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_observed_climatology_subtask.py
@@ -100,8 +100,8 @@ class RemapObservedClimatologySubtask(AnalysisTask):  # {{{
 
         # call the constructor from the base class (AnalysisTask)
         super(RemapObservedClimatologySubtask, self).__init__(
-                config=config, taskName=taskName, subtaskName=subtaskName,
-                componentName=componentName, tags=tags)
+            config=config, taskName=taskName, subtaskName=subtaskName,
+            componentName=componentName, tags=tags)
         # }}}
 
     def setup_and_check(self):  # {{{
@@ -151,18 +151,18 @@ class RemapObservedClimatologySubtask(AnalysisTask):  # {{{
             for season in self.seasons:
 
                 remappedFileName = self.get_file_name(
-                        stage='remapped',
-                        season=season,
-                        comparisonGridName=comparisonGridName)
+                    stage='remapped',
+                    season=season,
+                    comparisonGridName=comparisonGridName)
 
                 if not os.path.exists(remappedFileName):
 
                     ds = xr.open_dataset(obsFileName)
 
                     climatologyFileName = self.get_file_name(
-                            stage='climatology',
-                            season=season,
-                            comparisonGridName=comparisonGridName)
+                        stage='climatology',
+                        season=season,
+                        comparisonGridName=comparisonGridName)
                     if 'month' in ds.variables.keys() and \
                             'year' in ds.variables.keys():
                         # this data set is not yet a climatology, so compute
@@ -336,16 +336,16 @@ class RemapObservedClimatologySubtask(AnalysisTask):  # {{{
         for comparisonGridName in self.comparisonGridNames:
 
             comparisonDescriptor = get_comparison_descriptor(
-                    config, comparisonGridName=comparisonGridName)
+                config, comparisonGridName=comparisonGridName)
 
             self.remappers[comparisonGridName] = get_remapper(
-                    config=config,
-                    sourceDescriptor=obsDescriptor,
-                    comparisonDescriptor=comparisonDescriptor,
-                    mappingFilePrefix='map_obs_{}'.format(outFilePrefix),
-                    method=config.get(sectionName,
-                                      'interpolationMethod'),
-                    logger=self.logger)
+                config=config,
+                sourceDescriptor=obsDescriptor,
+                comparisonDescriptor=comparisonDescriptor,
+                mappingFilePrefix='map_obs_{}'.format(outFilePrefix),
+                method=config.get(sectionName,
+                                  'interpolationMethod'),
+                logger=self.logger)
         # }}}
     # }}}
 

--- a/mpas_analysis/shared/constants/constants.py
+++ b/mpas_analysis/shared/constants/constants.py
@@ -46,10 +46,10 @@ abrevMonthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug",
 m3ps_to_Sv = 1e-6
 
 # conversion factor from radians to degrees
-rad_to_deg = 180./np.pi
+rad_to_deg = 180. / np.pi
 
 # conversion factor from degrees to radians
-deg_to_rad = np.pi/180.
+deg_to_rad = np.pi / 180.
 
 # seconds in a year
 sec_per_year = 86400. * 365.

--- a/mpas_analysis/shared/grid/grid.py
+++ b/mpas_analysis/shared/grid/grid.py
@@ -176,7 +176,7 @@ class MpasMeshDescriptor(MeshDescriptor):  # {{{
         for iVertex in range(maxVertices):
             cellIndices = numpy.arange(nCells)
             # repeat the last vertex wherever iVertex > nEdgesOnCell
-            localVertexIndices = numpy.minimum(nEdgesOnCell-1, iVertex)
+            localVertexIndices = numpy.minimum(nEdgesOnCell - 1, iVertex)
             vertexIndices = verticesOnCell[cellIndices, localVertexIndices] - 1
             grid_corner_lat[cellIndices, iVertex] = latVertex[vertexIndices]
             grid_corner_lon[cellIndices, iVertex] = lonVertex[vertexIndices]
@@ -269,7 +269,7 @@ class LatLonGridDescriptor(MeshDescriptor):  # {{{
 
         if 'history' in ds.attrs:
             descriptor.history = '\n'.join([ds.attrs['history'],
-                                           ' '.join(sys.argv[:])])
+                                            ' '.join(sys.argv[:])])
         else:
             descriptor.history = sys.argv[:]
         return descriptor  # }}}
@@ -296,8 +296,8 @@ class LatLonGridDescriptor(MeshDescriptor):  # {{{
 
         descriptor.latCorner = latCorner
         descriptor.lonCorner = lonCorner
-        descriptor.lon = 0.5*(lonCorner[0:-1] + lonCorner[1:])
-        descriptor.lat = 0.5*(latCorner[0:-1] + latCorner[1:])
+        descriptor.lon = 0.5 * (lonCorner[0:-1] + lonCorner[1:])
+        descriptor.lat = 0.5 * (latCorner[0:-1] + latCorner[1:])
         descriptor.units = units
         descriptor.history = sys.argv[:]
         descriptor._set_coords('lat', 'lon', 'lat', 'lon')
@@ -323,7 +323,7 @@ class LatLonGridDescriptor(MeshDescriptor):  # {{{
         nLat = len(self.lat)
         nLon = len(self.lon)
 
-        grid_size = nLat*nLon
+        grid_size = nLat * nLon
 
         _create_scrip(outFile, grid_size=grid_size, grid_corners=4,
                       grid_rank=2, units=self.units, meshName=self.meshName)
@@ -361,8 +361,8 @@ class LatLonGridDescriptor(MeshDescriptor):  # {{{
         self.dimSize = [len(self.lat), len(self.lon)]
 
         # set the name of the grid
-        dLat = self.lat[1]-self.lat[0]
-        dLon = self.lon[1]-self.lon[0]
+        dLat = self.lat[1] - self.lat[0]
+        dLon = self.lon[1] - self.lon[0]
         lonRange = self.lonCorner[-1] - self.lonCorner[0]
         latRange = self.latCorner[-1] - self.latCorner[0]
         if 'degree' in self.units:
@@ -372,7 +372,7 @@ class LatLonGridDescriptor(MeshDescriptor):  # {{{
             if numpy.abs(latRange - 180.) > 1e-10:
                 self.regional = True
         elif 'rad' in self.units:
-            if numpy.abs(lonRange - 2.*numpy.pi) > 1e-10:
+            if numpy.abs(lonRange - 2. * numpy.pi) > 1e-10:
                 self.regional = True
             if numpy.abs(latRange - numpy.pi) > 1e-10:
                 self.regional = True
@@ -462,7 +462,7 @@ class LatLon2DGridDescriptor(MeshDescriptor):  # {{{
 
         if 'history' in ds.attrs:
             descriptor.history = '\n'.join([ds.attrs['history'],
-                                           ' '.join(sys.argv[:])])
+                                            ' '.join(sys.argv[:])])
         else:
             descriptor.history = sys.argv[:]
         return descriptor  # }}}
@@ -486,7 +486,7 @@ class LatLon2DGridDescriptor(MeshDescriptor):  # {{{
 
         nLat, nLon = self.lat.shape
 
-        grid_size = nLat*nLon
+        grid_size = nLat * nLon
 
         _create_scrip(outFile, grid_size=grid_size, grid_corners=4,
                       grid_rank=2, units=self.units, meshName=self.meshName)
@@ -523,8 +523,8 @@ class LatLon2DGridDescriptor(MeshDescriptor):  # {{{
         self.dimSize = self.lat.shape
 
         # set the name of the grid
-        dLat = self.lat[1, 0]-self.lat[0, 0]
-        dLon = self.lon[0, 1]-self.lon[0, 0]
+        dLat = self.lat[1, 0] - self.lat[0, 0]
+        dLon = self.lon[0, 1] - self.lon[0, 0]
         if 'degree' in self.units:
             units = 'degree'
         elif 'rad' in self.units:
@@ -620,7 +620,7 @@ class ProjectionGridDescriptor(MeshDescriptor):  # {{{
         # Update history attribute of netCDF file
         if 'history' in ds.attrs:
             descriptor.history = '\n'.join([ds.attrs['history'],
-                                           ' '.join(sys.argv[:])])
+                                            ' '.join(sys.argv[:])])
         else:
             descriptor.history = sys.argv[:]
         return descriptor  # }}}
@@ -680,7 +680,7 @@ class ProjectionGridDescriptor(MeshDescriptor):  # {{{
         nx = len(self.x)
         ny = len(self.y)
 
-        grid_size = nx*ny
+        grid_size = nx * ny
 
         _create_scrip(outFile, grid_size=grid_size, grid_corners=4,
                       grid_rank=2, units='degrees', meshName=self.meshName)
@@ -874,28 +874,28 @@ class PointCollectionDescriptor(MeshDescriptor):  # {{{
 def interp_extrap_corner(inField):  # {{{
     '''Interpolate/extrapolate a 1D field from grid centers to grid corners'''
 
-    outField = numpy.zeros(len(inField)+1)
-    outField[1:-1] = 0.5*(inField[0:-1] + inField[1:])
+    outField = numpy.zeros(len(inField) + 1)
+    outField[1:-1] = 0.5 * (inField[0:-1] + inField[1:])
     # extrapolate the ends
-    outField[0] = 1.5*inField[0] - 0.5*inField[1]
-    outField[-1] = 1.5*inField[-1] - 0.5*inField[-2]
+    outField[0] = 1.5 * inField[0] - 0.5 * inField[1]
+    outField[-1] = 1.5 * inField[-1] - 0.5 * inField[-2]
     return outField  # }}}
 
 
 def interp_extrap_corners_2d(inField):  # {{{
     '''Interpolate/extrapolate a 1D field from grid centers to grid corners'''
 
-    temp = numpy.zeros((inField.shape[0], inField.shape[1]+1))
-    temp[:, 1:-1] = 0.5*(inField[:, 0:-1] + inField[:, 1:])
+    temp = numpy.zeros((inField.shape[0], inField.shape[1] + 1))
+    temp[:, 1:-1] = 0.5 * (inField[:, 0:-1] + inField[:, 1:])
     # extrapolate the ends
-    temp[:, 0] = 1.5*inField[:, 0] - 0.5*inField[:, 1]
-    temp[:, -1] = 1.5*inField[:, -1] - 0.5*inField[:, -2]
+    temp[:, 0] = 1.5 * inField[:, 0] - 0.5 * inField[:, 1]
+    temp[:, -1] = 1.5 * inField[:, -1] - 0.5 * inField[:, -2]
 
-    outField = numpy.zeros((inField.shape[0]+1, inField.shape[1]+1))
-    outField[1:-1, :] = 0.5*(temp[0:-1, :] + temp[1:, :])
+    outField = numpy.zeros((inField.shape[0] + 1, inField.shape[1] + 1))
+    outField[1:-1, :] = 0.5 * (temp[0:-1, :] + temp[1:, :])
     # extrapolate the ends
-    outField[0, :] = 1.5*temp[0, :] - 0.5*temp[1, :]
-    outField[-1, :] = 1.5*temp[-1, :] - 0.5*temp[-2, :]
+    outField[0, :] = 1.5 * temp[0, :] - 0.5 * temp[1, :]
+    outField[-1, :] = 1.5 * temp[-1, :] - 0.5 * temp[-2, :]
 
     return outField  # }}}
 
@@ -959,7 +959,7 @@ def _create_scrip(outFile, grid_size, grid_corners, grid_rank, units,
 
 def _unwrap_corners(inField):
     '''Turn a 2D array of corners into an array of rectangular mesh elements'''
-    outField = numpy.zeros(((inField.shape[0]-1)*(inField.shape[1]-1), 4))
+    outField = numpy.zeros(((inField.shape[0] - 1) * (inField.shape[1] - 1), 4))
     # corners are counterclockwise
     outField[:, 0] = inField[0:-1, 0:-1].flat
     outField[:, 1] = inField[0:-1, 1:].flat

--- a/mpas_analysis/shared/html/image_xml.py
+++ b/mpas_analysis/shared/html/image_xml.py
@@ -206,17 +206,17 @@ def _generate_thumbnails(imageFileName, directory):
         thumbnailHeight = 180
 
     # first, make a thumbnail with the same aspect ratio
-    factor = image.size[1]/float(thumbnailHeight)
-    size = [int(dim/factor + 0.5) for dim in image.size]
+    factor = image.size[1] / float(thumbnailHeight)
+    size = [int(dim / factor + 0.5) for dim in image.size]
     thumbnail = image.resize(size, Image.ANTIALIAS)
     thumbnail.save('{}/{}'.format(thumbnailDir, imageFileName))
 
     # second, make a thumbnail with a fixed size
-    widthFactor = image.size[0]/float(fixedWidth)
-    heightFactor = image.size[1]/float(fixedHeight)
+    widthFactor = image.size[0] / float(fixedWidth)
+    heightFactor = image.size[1] / float(fixedHeight)
 
     factor = min(widthFactor, heightFactor)
-    size = [int(dim/factor + 0.5) for dim in image.size]
+    size = [int(dim / factor + 0.5) for dim in image.size]
     thumbnail = image.resize(size, Image.ANTIALIAS)
 
     if widthFactor <= heightFactor:

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -185,7 +185,7 @@ class MainPage(object):
             controlRunText = ''
         else:
             controlRunText = '<br> Control: {}'.format(
-                    self.controlConfig.get('runs', 'mainRunName'))
+                self.controlConfig.get('runs', 'mainRunName'))
 
         componentsText = ''
 
@@ -220,8 +220,8 @@ class MainPage(object):
 
         with open(outFileName, mode='w') as mainFile:
             mainFile.write(
-                    pageText.encode('ascii',
-                                    'xmlcharrefreplace').decode('ascii'))
+                pageText.encode('ascii',
+                                'xmlcharrefreplace').decode('ascii'))
 
         # copy the css and js files as well as general images
         fileName = \
@@ -321,8 +321,8 @@ class ComponentPage(object):
 
             # get template text
             fileName = pkg_resources.resource_filename(
-                    __name__,
-                    "templates/component_{}.html".format(templateName))
+                __name__,
+                "templates/component_{}.html".format(templateName))
 
             with open(fileName, 'r') as templateFile:
                 self.templates[templateName] = templateFile.read()
@@ -364,7 +364,7 @@ class ComponentPage(object):
                                                              'componentName',
                                                              xmlFileName)
         componentSubdirectory = ComponentPage._get_required_xml_text(
-                xmlRoot, 'componentSubdirectory', xmlFileName)
+            xmlRoot, 'componentSubdirectory', xmlFileName)
 
         imageFileName = ComponentPage._get_required_xml_text(xmlRoot,
                                                              'imageFileName',
@@ -431,7 +431,7 @@ class ComponentPage(object):
             controlRunText = ''
         else:
             controlRunText = '<br> Control: {}'.format(
-                    self.controlConfig.get('runs', 'mainRunName'))
+                self.controlConfig.get('runs', 'mainRunName'))
 
         quickLinkText = ''
         galleriesText = ''
@@ -454,8 +454,8 @@ class ComponentPage(object):
 
         with open(outFileName, mode='w') as componentFile:
             componentFile.write(
-                    pageText.encode('ascii',
-                                    'xmlcharrefreplace').decode('ascii'))
+                pageText.encode('ascii',
+                                'xmlcharrefreplace').decode('ascii'))
 
     def get_first_image(self):
         """

--- a/mpas_analysis/shared/interpolation/interp_1d.py
+++ b/mpas_analysis/shared/interpolation/interp_1d.py
@@ -38,7 +38,7 @@ def interp_1d(ds, inInterpDim, inInterpCoord, outInterpDim,
     # Xylar Asay-Davis
 
     indices, weight0 = _compute_weights_and_indices(
-            ds, inInterpDim, inInterpCoord, outInterpDim, outInterpCoord)
+        ds, inInterpDim, inInterpCoord, outInterpDim, outInterpCoord)
 
     # conert coords to normal data variables
     coords = list(ds.coords)
@@ -84,9 +84,9 @@ def _compute_weights_and_indices(ds, inInterpDim, inInterpCoord, outInterpDim,
 
     allOutDims.append(outInterpDim)
 
-    allOutDims.extend(outDims[outAxis+1:])
+    allOutDims.extend(outDims[outAxis + 1:])
 
-    for axis in range(inAxis+1, len(inDims)):
+    for axis in range(inAxis + 1, len(inDims)):
         dim = inDims[axis]
         if dim not in allOutDims:
             allOutDims.append(dim)
@@ -122,29 +122,29 @@ def _compute_weights_and_indices(ds, inInterpDim, inInterpCoord, outInterpDim,
     index0 = indices[inInterpDim]
     index0[:] = -1
 
-    weight0 = numpy.nan*numpy.ones(outSizes)
+    weight0 = numpy.nan * numpy.ones(outSizes)
 
     for outIndex in range(outInterpSize):
-        outInd = [slice(None)]*xOut.ndim
+        outInd = [slice(None)] * xOut.ndim
         outInd[outAxis] = outIndex
         outInd = tuple(outInd)
         x = numpy.array(xOut[outInd])
-        for inIndex in range(inInterpSize-1):
-            ind0 = [slice(None)]*xIn.ndim
+        for inIndex in range(inInterpSize - 1):
+            ind0 = [slice(None)] * xIn.ndim
             ind0[inAxis] = inIndex
             ind0 = tuple(ind0)
             x0 = numpy.array(xIn[ind0])
-            ind1 = [slice(None)]*xIn.ndim
-            ind1[inAxis] = inIndex+1
+            ind1 = [slice(None)] * xIn.ndim
+            ind1[inAxis] = inIndex + 1
             ind1 = tuple(ind1)
             x1 = numpy.array(xIn[ind1])
             dx = x1 - x0
-            frac = (x - x0)/dx
+            frac = (x - x0) / dx
             valid = numpy.isfinite(frac)
             mask = numpy.zeros(valid.shape, bool)
             mask[valid] = numpy.logical_and(frac[valid] >= 0.,
                                             frac[valid] < 1.)
-            if inIndex == inInterpSize-2:
+            if inIndex == inInterpSize - 2:
                 mask = numpy.logical_or(mask, x == x1)
             if numpy.count_nonzero(mask) == 0:
                 continue
@@ -165,7 +165,6 @@ def _compute_weights_and_indices(ds, inInterpDim, inInterpCoord, outInterpDim,
 
 
 def _interp_1d_array(da, indices, weight0, inInterpDim):  # {{{
-
     """
     iterpolate a data array in 1D with the given indices and weights
     """
@@ -178,13 +177,13 @@ def _interp_1d_array(da, indices, weight0, inInterpDim):  # {{{
         if dim in indices.keys():
             indices0[dim] = indices[dim]
             if dim == inInterpDim:
-                indices1[dim] = indices[dim]+1
+                indices1[dim] = indices[dim] + 1
             else:
                 indices1[dim] = indices[dim]
 
     da0 = da.isel(**indices0)
     da1 = da.isel(**indices1)
-    da = weight0*da0 + (1. - weight0)*da1
+    da = weight0 * da0 + (1. - weight0) * da1
     return da  # }}}
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -80,12 +80,12 @@ class Remapper(object):
             raise TypeError("sourceDescriptor of type "
                             "PointCollectionDescriptor is not supported.")
         if not isinstance(sourceDescriptor,
-                          (MpasMeshDescriptor,  LatLonGridDescriptor,
+                          (MpasMeshDescriptor, LatLonGridDescriptor,
                            ProjectionGridDescriptor)):
             raise TypeError("sourceDescriptor is not of a recognized type.")
 
         if not isinstance(destinationDescriptor,
-                          (MpasMeshDescriptor,  LatLonGridDescriptor,
+                          (MpasMeshDescriptor, LatLonGridDescriptor,
                            ProjectionGridDescriptor,
                            PointCollectionDescriptor)):
             raise TypeError(
@@ -299,9 +299,9 @@ class Remapper(object):
 
         if isinstance(self.sourceDescriptor, LatLonGridDescriptor):
             regridArgs.extend(['--rgr lat_nm={}'.format(
-                                   self.sourceDescriptor.latVarName),
-                               '--rgr lon_nm={}'.format(
-                                   self.sourceDescriptor.lonVarName)])
+                self.sourceDescriptor.latVarName),
+                '--rgr lon_nm={}'.format(
+                self.sourceDescriptor.lonVarName)])
 
         if len(regridArgs) > 0:
             args.extend(['-R', ' '.join(regridArgs)])
@@ -483,8 +483,8 @@ class Remapper(object):
 
         self.frac_b = dsMapping['frac_b'].values
 
-        col = dsMapping['col'].values-1
-        row = dsMapping['row'].values-1
+        col = dsMapping['col'].values - 1
+        row = dsMapping['row'].values - 1
         S = dsMapping['S'].values
         self.matrix = csr_matrix((S, (row, col)), shape=(n_b, n_a))
 
@@ -600,7 +600,7 @@ class Remapper(object):
                   renormalizationThreshold is not None)
         if masked:
             inMask = numpy.array(numpy.logical_not(inField.mask), float)
-            outField = self.matrix.dot(inMask*inField)
+            outField = self.matrix.dot(inMask * inField)
             outMask = self.matrix.dot(inMask)
             mask = outMask > renormalizationThreshold
         else:

--- a/mpas_analysis/shared/interpolation/utility.py
+++ b/mpas_analysis/shared/interpolation/utility.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function, \
 import numpy
 import xarray
 
+
 def add_periodic_lon(ds, lonDim, degrees=True):
     '''
     Add a single grid point that is a periodic image to the end of the data set
@@ -25,7 +26,7 @@ def add_periodic_lon(ds, lonDim, degrees=True):
     if degrees:
         period = 360.
     else:
-        period = 2.*numpy.pi
+        period = 2. * numpy.pi
 
     if numpy.abs(lonRange - period) < 1e-10:
         # already periodic

--- a/mpas_analysis/shared/io/mpas_reader.py
+++ b/mpas_analysis/shared/io/mpas_reader.py
@@ -146,10 +146,10 @@ def subset_variables(ds, variableList):  # {{{
 
     if len(ds.data_vars.keys()) == 0:
         raise ValueError(
-                'Empty dataset is returned.\n'
-                'Variables {}\n'
-                'are not found within the dataset '
-                'variables: {}.'.format(variableList, allvars))
+            'Empty dataset is returned.\n'
+            'Variables {}\n'
+            'are not found within the dataset '
+            'variables: {}.'.format(variableList, allvars))
 
     return ds  # }}}
 
@@ -236,7 +236,7 @@ def _parse_dataset_time(ds, inTimeVariableName, calendar,
 
         dsOut.coords[outTimeVariableName] = (outTimeVariableName,
                                              [starts[i] +
-                                                 (ends[i] - starts[i])/2
+                                                 (ends[i] - starts[i]) / 2
                                                  for i in range(len(starts))])
 
     else:
@@ -251,7 +251,8 @@ def _parse_dataset_time(ds, inTimeVariableName, calendar,
 
         # this is an array of date strings like 'xtime'
         # convert to string
-        timeStrings = [''.join(xtime.astype('U')).strip() for xtime in timeVar.values]
+        timeStrings = [''.join(xtime.astype('U')).strip()
+                       for xtime in timeVar.values]
         days = string_to_days_since_date(dateString=timeStrings,
                                          referenceDate=referenceDate,
                                          calendar=calendar)

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -455,7 +455,7 @@ class StreamsFile:
             # there is no date in the template, so we can't exclude any files
             # based on date
             return fileList
-        dateEndOffset = len(template) - (template.rfind('$')+2)
+        dateEndOffset = len(template) - (template.rfind('$') + 2)
 
         outFileList = []
         for fileName in fileList:

--- a/mpas_analysis/shared/io/write_netcdf.py
+++ b/mpas_analysis/shared/io/write_netcdf.py
@@ -36,7 +36,7 @@ def write_netcdf(ds, fileName, fillValues=netCDF4.default_fillvals):  # {{{
     # -------
     # Xylar Asay-Davis
 
-# 
+#
     encodingDict = {}
     variableNames = list(ds.data_vars.keys()) + list(ds.coords.keys())
     for variableName in variableNames:

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -18,7 +18,7 @@ import xarray
 from functools import partial
 
 from mpas_analysis.shared.timekeeping.utility import \
-    string_to_days_since_date,  string_to_datetime, days_to_datetime, \
+    string_to_days_since_date, string_to_datetime, days_to_datetime, \
     datetime_to_days
 
 """
@@ -170,10 +170,10 @@ def subset_variables(ds, variableList):  # {{{
 
     if len(ds.data_vars.keys()) == 0:
         raise ValueError(
-                'Empty dataset is returned.\n'
-                'Variables {}\n'
-                'are not found within the dataset '
-                'variables: {}.'.format(variableList, allvars))
+            'Empty dataset is returned.\n'
+            'Variables {}\n'
+            'are not found within the dataset '
+            'variables: {}.'.format(variableList, allvars))
 
     return ds  # }}}
 
@@ -464,7 +464,7 @@ def _parse_dataset_time(ds, inTimeVariableName, calendar,
 
         dsOut.coords[outTimeVariableName] = (outTimeVariableName,
                                              [starts[i] +
-                                                 (ends[i] - starts[i])/2
+                                                 (ends[i] - starts[i]) / 2
                                                  for i in range(len(starts))])
 
     else:
@@ -480,7 +480,8 @@ def _parse_dataset_time(ds, inTimeVariableName, calendar,
         if timeVar.dtype == '|S64':
             # this is an array of date strings like 'xtime'
             # convert to string
-            timeStrings = [''.join(str(xtime.astype('U'))).strip() for xtime in timeVar.values]
+            timeStrings = [''.join(str(xtime.astype('U'))).strip()
+                           for xtime in timeVar.values]
             days = string_to_days_since_date(dateString=timeStrings,
                                              referenceDate=referenceDate,
                                              calendar=calendar)
@@ -567,8 +568,8 @@ def process_chunking(ds, chunking):  # {{{
 
     else:
         raise ValueError(
-                'Chunking parameter choice is not understood '
-                'for {} of type {}\n'.format(chunking, type(chunking)))
+            'Chunking parameter choice is not understood '
+            'for {} of type {}\n'.format(chunking, type(chunking)))
 
     return ds  # }}}
 

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -53,7 +53,6 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                              firstYearXTicks=None, yearStrideXTicks=None,
                              maxXTicks=20, obsMean=None, obsUncertainty=None,
                              obsLegend=None, legendLocation='lower left'):
-
     """
     Plots the list of time series data sets and stores the result in an image
     file.
@@ -156,7 +155,7 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
         if maxPoints is not None and maxPoints[dsIndex] is not None:
             nTime = mean.sizes['Time']
             if maxPoints[dsIndex] < nTime:
-                stride = int(round(nTime/float(maxPoints[dsIndex])))
+                stride = int(round(nTime / float(maxPoints[dsIndex])))
                 mean = mean.isel(Time=slice(0, None, stride))
 
         if legendText is None:
@@ -193,7 +192,7 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
         # end
         start = np.amin(minDays)
         end = np.amax(maxDays)
-        obsTimes = np.linspace(start, end, obsCount+2)[1:-1]
+        obsTimes = np.linspace(start, end, obsCount + 2)[1:-1]
         obsSymbols = ['o', '^', 's', 'D', '*']
         obsColors = ['b', 'g', 'c', 'm', 'r']
         for iObs in range(obsCount):
@@ -209,12 +208,12 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
                              capsize=0,
                              label=obsLegend[iObs])
                 # plot a box around the error bar to make it more visible
-                boxHalfWidth = 0.01*(end - start)
+                boxHalfWidth = 0.01 * (end - start)
                 boxHalfHeight = obsUncertainty[iObs]
                 boxX = obsTimes[iObs] + \
-                    boxHalfWidth*np.array([-1, 1, 1, -1, -1])
+                    boxHalfWidth * np.array([-1, 1, 1, -1, -1])
                 boxY = obsMean[iObs] + \
-                    boxHalfHeight*np.array([-1, -1, 1, 1, -1])
+                    boxHalfHeight * np.array([-1, -1, 1, 1, -1])
 
                 plt.plot(boxX, boxY, '{}-'.format(color), linewidth=3)
                 labelCount += 1
@@ -239,7 +238,7 @@ def timeseries_analysis_plot(config, dsvalues, N, title, xlabel, ylabel,
 
     # Add a y=0 line if y ranges between positive and negative values
     yaxLimits = ax.get_ylim()
-    if yaxLimits[0]*yaxLimits[1] < 0:
+    if yaxLimits[0] * yaxLimits[1] < 0:
         x = ax.get_xlim()
         plt.plot(x, np.zeros(np.size(x)), 'k-', linewidth=1.2, zorder=1)
 
@@ -260,7 +259,6 @@ def timeseries_analysis_plot_polar(config, dsvalues, N, title,
                                    markers=None, lineWidths=None,
                                    legendText=None, titleFontSize=None,
                                    figsize=(15, 6), dpi=None):
-
     """
     Plots the list of time series data sets on a polar plot and stores
     the result in an image file.
@@ -342,7 +340,7 @@ def timeseries_analysis_plot_polar(config, dsvalues, N, title,
         else:
             linewidth = lineWidths[dsIndex]
 
-        plt.polar((mean['Time']/365.0)*np.pi*2.0, mean, color=color,
+        plt.polar((mean['Time'] / 365.0) * np.pi * 2.0, mean, color=color,
                   linestyle=linestyle, marker=marker, linewidth=linewidth,
                   label=label)
 
@@ -357,10 +355,10 @@ def timeseries_analysis_plot_polar(config, dsvalues, N, title,
     majorTickLocs[0] = 0.0
     minorTickLocs[0] = (constants.daysInMonth[0] * np.pi) / 365.0
     for month in range(1, 12):
-        majorTickLocs[month] = majorTickLocs[month-1] + \
-            ((constants.daysInMonth[month-1] * np.pi * 2.0) / 365.0)
-        minorTickLocs[month] = minorTickLocs[month-1] + \
-            (((constants.daysInMonth[month-1] +
+        majorTickLocs[month] = majorTickLocs[month - 1] + \
+            ((constants.daysInMonth[month - 1] * np.pi * 2.0) / 365.0)
+        minorTickLocs[month] = minorTickLocs[month - 1] + \
+            (((constants.daysInMonth[month - 1] +
                constants.daysInMonth[month]) * np.pi) / 365.0)
 
     ax.set_xticks(majorTickLocs)
@@ -405,7 +403,6 @@ def plot_polar_comparison(
         figsize=None,
         dpi=None,
         vertical=False):
-
     """
     Plots a data set around either the north or south pole.
 
@@ -576,7 +573,6 @@ def plot_global_comparison(
         dpi=None,
         lineWidth=1,
         lineColor='black'):
-
     """
     Plots a data set as a longitude/latitude map.
 
@@ -730,7 +726,6 @@ def plot_polar_projection_comparison(
         lineWidth=0.5,
         lineColor='black',
         vertical=False):
-
     """
     Plots a data set as a longitude/latitude map.
 
@@ -874,8 +869,8 @@ def plot_polar_projection_comparison(
     landColorMap = cols.LinearSegmentedColormap.from_list('land', colorList)
 
     # locations of centers for contour plots
-    xCenter = 0.5*(x[1:] + x[0:-1])
-    yCenter = 0.5*(y[1:] + y[0:-1])
+    xCenter = 0.5 * (x[1:] + x[0:-1])
+    yCenter = 0.5 * (y[1:] + y[0:-1])
 
     ax = plt.subplot(subplots[0])
     plot_panel(ax, modelTitle, modelArray, **dictModelRef)
@@ -939,7 +934,6 @@ def plot_vertical_section_comparison(
         comparisonContourLineColor=None,
         labelContours=False,
         contourLabelPrecision=1):
-
     """
     Plots vertical section plots in a three-panel format, comparing model data
     (in modelArray) to some reference dataset (in refArray), which can be
@@ -1199,14 +1193,58 @@ def plot_vertical_section_comparison(
         originalFieldName = modelTitle
 
     plot_vertical_section(
+        config,
+        xArray,
+        depthArray,
+        modelArray,
+        colorMapSectionName,
+        suffix='Result',
+        colorbarLabel=cbarLabel,
+        title=title,
+        xlabel=xlabel,
+        ylabel=ylabel,
+        fileout=None,
+        titleFontSize=plotTitleFontSize,
+        titleY=titleY,
+        axisFontSize=axisFontSize,
+        xLim=xLim,
+        yLim=yLim,
+        lineWidth=lineWidth,
+        lineStyle=lineStyle,
+        lineColor=lineColor,
+        secondXAxisData=secondXAxisData,
+        secondXAxisLabel=secondXAxisLabel,
+        thirdXAxisData=thirdXAxisData,
+        thirdXAxisLabel=thirdXAxisLabel,
+        numUpperTicks=numUpperTicks,
+        upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
+        invertYAxis=invertYAxis,
+        xArrayIsTime=xArrayIsTime,
+        N=None,
+        firstYearXTicks=firstYearXTicks,
+        yearStrideXTicks=yearStrideXTicks,
+        maxXTicks=maxXTicks, calendar=calendar,
+        backgroundColor=backgroundColor,
+        plotAsContours=compareAsContours,
+        contourComparisonFieldArray=contourComparisonFieldArray,
+        comparisonFieldName=comparisonFieldName,
+        originalFieldName=originalFieldName,
+        comparisonContourLineStyle=comparisonContourLineStyle,
+        comparisonContourLineColor=comparisonContourLineColor,
+        labelContours=labelContours,
+        contourLabelPrecision=contourLabelPrecision)
+
+    if not singlePanel:
+        plt.subplot(3, 1, 2)
+        plot_vertical_section(
             config,
             xArray,
             depthArray,
-            modelArray,
+            refArray,
             colorMapSectionName,
             suffix='Result',
             colorbarLabel=cbarLabel,
-            title=title,
+            title=refTitle,
             xlabel=xlabel,
             ylabel=ylabel,
             fileout=None,
@@ -1222,100 +1260,56 @@ def plot_vertical_section_comparison(
             secondXAxisLabel=secondXAxisLabel,
             thirdXAxisData=thirdXAxisData,
             thirdXAxisLabel=thirdXAxisLabel,
-            numUpperTicks=numUpperTicks,
             upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
+            numUpperTicks=numUpperTicks,
             invertYAxis=invertYAxis,
             xArrayIsTime=xArrayIsTime,
             N=None,
             firstYearXTicks=firstYearXTicks,
             yearStrideXTicks=yearStrideXTicks,
-            maxXTicks=maxXTicks, calendar=calendar,
+            maxXTicks=maxXTicks,
+            calendar=calendar,
             backgroundColor=backgroundColor,
-            plotAsContours=compareAsContours,
-            contourComparisonFieldArray=contourComparisonFieldArray,
-            comparisonFieldName=comparisonFieldName,
-            originalFieldName=originalFieldName,
-            comparisonContourLineStyle=comparisonContourLineStyle,
-            comparisonContourLineColor=comparisonContourLineColor,
             labelContours=labelContours,
             contourLabelPrecision=contourLabelPrecision)
 
-    if not singlePanel:
-        plt.subplot(3, 1, 2)
-        plot_vertical_section(
-                config,
-                xArray,
-                depthArray,
-                refArray,
-                colorMapSectionName,
-                suffix='Result',
-                colorbarLabel=cbarLabel,
-                title=refTitle,
-                xlabel=xlabel,
-                ylabel=ylabel,
-                fileout=None,
-                titleFontSize=plotTitleFontSize,
-                titleY=titleY,
-                axisFontSize=axisFontSize,
-                xLim=xLim,
-                yLim=yLim,
-                lineWidth=lineWidth,
-                lineStyle=lineStyle,
-                lineColor=lineColor,
-                secondXAxisData=secondXAxisData,
-                secondXAxisLabel=secondXAxisLabel,
-                thirdXAxisData=thirdXAxisData,
-                thirdXAxisLabel=thirdXAxisLabel,
-                upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
-                numUpperTicks=numUpperTicks,
-                invertYAxis=invertYAxis,
-                xArrayIsTime=xArrayIsTime,
-                N=None,
-                firstYearXTicks=firstYearXTicks,
-                yearStrideXTicks=yearStrideXTicks,
-                maxXTicks=maxXTicks,
-                calendar=calendar,
-                backgroundColor=backgroundColor,
-                labelContours=labelContours,
-                contourLabelPrecision=contourLabelPrecision)
-
         plt.subplot(3, 1, 3)
         plot_vertical_section(
-                config,
-                xArray,
-                depthArray,
-                diffArray,
-                colorMapSectionName,
-                suffix='Difference',
-                colorbarLabel=cbarLabel,
-                title=diffTitle,
-                xlabel=xlabel,
-                ylabel=ylabel,
-                fileout=None,
-                titleFontSize=plotTitleFontSize,
-                titleY=titleY,
-                axisFontSize=axisFontSize,
-                xLim=xLim,
-                yLim=yLim,
-                lineWidth=lineWidth,
-                lineStyle=lineStyle,
-                lineColor=lineColor,
-                secondXAxisData=secondXAxisData,
-                secondXAxisLabel=secondXAxisLabel,
-                thirdXAxisData=thirdXAxisData,
-                thirdXAxisLabel=thirdXAxisLabel,
-                upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
-                numUpperTicks=numUpperTicks,
-                invertYAxis=invertYAxis,
-                xArrayIsTime=xArrayIsTime,
-                N=None,
-                firstYearXTicks=firstYearXTicks,
-                yearStrideXTicks=yearStrideXTicks,
-                maxXTicks=maxXTicks,
-                calendar=calendar,
-                backgroundColor=backgroundColor,
-                labelContours=labelContours,
-                contourLabelPrecision=contourLabelPrecision)
+            config,
+            xArray,
+            depthArray,
+            diffArray,
+            colorMapSectionName,
+            suffix='Difference',
+            colorbarLabel=cbarLabel,
+            title=diffTitle,
+            xlabel=xlabel,
+            ylabel=ylabel,
+            fileout=None,
+            titleFontSize=plotTitleFontSize,
+            titleY=titleY,
+            axisFontSize=axisFontSize,
+            xLim=xLim,
+            yLim=yLim,
+            lineWidth=lineWidth,
+            lineStyle=lineStyle,
+            lineColor=lineColor,
+            secondXAxisData=secondXAxisData,
+            secondXAxisLabel=secondXAxisLabel,
+            thirdXAxisData=thirdXAxisData,
+            thirdXAxisLabel=thirdXAxisLabel,
+            upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
+            numUpperTicks=numUpperTicks,
+            invertYAxis=invertYAxis,
+            xArrayIsTime=xArrayIsTime,
+            N=None,
+            firstYearXTicks=firstYearXTicks,
+            yearStrideXTicks=yearStrideXTicks,
+            maxXTicks=maxXTicks,
+            calendar=calendar,
+            backgroundColor=backgroundColor,
+            labelContours=labelContours,
+            contourLabelPrecision=contourLabelPrecision)
 
     if singlePanel:
         if thirdXAxisData is not None and refArray is None:
@@ -1339,7 +1333,6 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
             xLim=None,
             yLim=None,
             invertYAxis=False):  # {{{
-
     """
     Plots a 1D line plot with error bars if available.
 
@@ -1432,9 +1425,9 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
         plt.plot(xArray, fieldArray, color=color, linestyle=linestyle,
                  marker=marker, linewidth=linewidth, label=label)
         if errArray is not None:
-            plt.fill_between(xArray, fieldArray, fieldArray+errArray,
+            plt.fill_between(xArray, fieldArray, fieldArray + errArray,
                              facecolor=color, alpha=0.2)
-            plt.fill_between(xArray, fieldArray, fieldArray-errArray,
+            plt.fill_between(xArray, fieldArray, fieldArray - errArray,
                              facecolor=color, alpha=0.2)
     plt.grid()
     plt.axhline(0.0, linestyle='-', color='k')  # horizontal lines
@@ -1512,7 +1505,6 @@ def plot_vertical_section(
         comparisonContourLineColor=None,
         labelContours=False,
         contourLabelPrecision=1):  # {{{
-
     """
     Plots a data set as a x distance (latitude, longitude,
     or spherical distance) vs depth map (vertical section).
@@ -1851,9 +1843,9 @@ def plot_vertical_section(
             mean = pd.Series.rolling(depthSlice.to_series(), N,
                                      center=True).mean()
             mean = xr.DataArray.from_series(mean)
-            mean = mean[int(N/2.0):-int(round(N/2.0)-1)]
+            mean = mean[int(N / 2.0):-int(round(N / 2.0) - 1)]
             movingAverageDepthSlices.append(mean)
-        xArray = xArray[int(N/2.0):-int(round(N/2.0)-1)]
+        xArray = xArray[int(N / 2.0):-int(round(N / 2.0) - 1)]
         fieldArray = xr.DataArray(movingAverageDepthSlices)
 
     colormapDict = setup_colormap(config, colorMapSectionName, suffix=suffix)
@@ -1864,8 +1856,8 @@ def plot_vertical_section(
             # interpFieldArray contains the values at centers of grid cells,
             # for pcolormesh plots (using bilinear interpolation)
             interpFieldArray = \
-                    0.5 * (0.5*(fieldArray[1:, 1:] + fieldArray[0:-1, 1:]) +
-                           0.5*(fieldArray[1:, 0:-1] + fieldArray[0:-1, 0:-1]))
+                0.5 * (0.5 * (fieldArray[1:, 1:] + fieldArray[0:-1, 1:]) +
+                       0.5 * (fieldArray[1:, 0:-1] + fieldArray[0:-1, 0:-1]))
 
             plotHandle = plt.pcolormesh(x, y, interpFieldArray,
                                         cmap=colormapDict['colormap'],
@@ -1989,8 +1981,8 @@ def plot_vertical_section(
         elif stride == 1:
             stride = 2
         ax2.set_xticks(x.flatten()[:num_x:stride])
-        formatString = "{{0:.{0:d}f}}$\degree$".format(
-            upperXAxisTickLabelPrecision)
+        formatString = "{{0:.{:d}f}}{}".format(
+            upperXAxisTickLabelPrecision, r'$\degree$')
         ax2.set_xticklabels([formatString.format(member)
                              for member in secondXAxisData[::stride]])
 
@@ -2015,7 +2007,6 @@ def plot_vertical_section(
 
 
 def setup_colormap(config, configSectionName, suffix=''):
-
     '''
     Set up a colormap from the registry
 
@@ -2070,7 +2061,7 @@ def setup_colormap(config, configSectionName, suffix=''):
     else:
         raise ValueError('config section {} option colormapType{} is not '
                          '"indexed" or "continuous"'.format(
-                                 configSectionName, suffix))
+                             configSectionName, suffix))
 
     option = 'contourLevels{}'.format(suffix)
     if config.has_option(configSectionName, option):
@@ -2131,19 +2122,19 @@ def plot_xtick_format(calendar, minDays, maxDays, maxXTicks, yearStride=None):
     start = days_to_datetime(np.amin(minDays), calendar=calendar)
     end = days_to_datetime(np.amax(maxDays), calendar=calendar)
 
-    if yearStride is not None or end.year - start.year > maxXTicks/2:
+    if yearStride is not None or end.year - start.year > maxXTicks / 2:
         if yearStride is None:
             yearStride = 1
         else:
             maxXTicks = None
         major = [date_to_days(year=year, calendar=calendar)
-                 for year in np.arange(start.year, end.year+1, yearStride)]
+                 for year in np.arange(start.year, end.year + 1, yearStride)]
         formatterFun = partial(_date_tick, calendar=calendar,
                                includeMonth=False)
     else:
         # add ticks for months
         major = []
-        for year in range(start.year, end.year+1):
+        for year in range(start.year, end.year + 1):
             for month in range(1, 13):
                 major.append(date_to_days(year=year, month=month,
                                           calendar=calendar))
@@ -2159,7 +2150,6 @@ def plot_xtick_format(calendar, minDays, maxDays, maxXTicks, yearStride=None):
 
 
 def _setup_colormap_and_norm(config, configSectionName, suffix=''):
-
     '''
     Set up a colormap from the registry
 
@@ -2212,8 +2202,8 @@ def _setup_colormap_and_norm(config, configSectionName, suffix=''):
 
     try:
         ticks = config.getExpression(
-                configSectionName, 'colorbarTicks{}'.format(suffix),
-                usenumpyfunc=True)
+            configSectionName, 'colorbarTicks{}'.format(suffix),
+            usenumpyfunc=True)
     except(configparser.NoOptionError):
         ticks = None
 
@@ -2221,7 +2211,6 @@ def _setup_colormap_and_norm(config, configSectionName, suffix=''):
 
 
 def _setup_indexed_colormap(config, configSectionName, suffix=''):
-
     '''
     Set up a colormap from the registry
 
@@ -2263,8 +2252,8 @@ def _setup_indexed_colormap(config, configSectionName, suffix=''):
 
     try:
         levels = config.getExpression(
-                configSectionName, 'colorbarLevels{}'.format(suffix),
-                usenumpyfunc=True)
+            configSectionName, 'colorbarLevels{}'.format(suffix),
+            usenumpyfunc=True)
     except(configparser.NoOptionError):
         levels = None
 
@@ -2272,11 +2261,11 @@ def _setup_indexed_colormap(config, configSectionName, suffix=''):
         # set under/over values based on the first/last indices in the colormap
         underColor = colormap(indices[0])
         overColor = colormap(indices[-1])
-        if len(levels)+1 == len(indices):
+        if len(levels) + 1 == len(indices):
             # we have 2 extra values for the under/over so make the colormap
             # without these values
             indices = indices[1:-1]
-        elif len(levels)-1 != len(indices):
+        elif len(levels) - 1 != len(indices):
             # indices list must be either one element shorter
             # or one element longer than colorbarLevels list
             raise ValueError('length mismatch between indices and '
@@ -2290,8 +2279,8 @@ def _setup_indexed_colormap(config, configSectionName, suffix=''):
 
     try:
         ticks = config.getExpression(
-                configSectionName, 'colorbarTicks{}'.format(suffix),
-                usenumpyfunc=True)
+            configSectionName, 'colorbarTicks{}'.format(suffix),
+            usenumpyfunc=True)
     except(configparser.NoOptionError):
         ticks = levels
 
@@ -2371,7 +2360,7 @@ def _register_custom_colormaps():
     for cIndex in range(3):
         colorList[:, cIndex] = np.interp(
             np.linspace(-1., 1., colorCount),
-            x, colorArray[:, cIndex+1])
+            x, colorArray[:, cIndex + 1])
 
     colorMap = cols.LinearSegmentedColormap.from_list(
         name, colorList, N=255)
@@ -2405,7 +2394,7 @@ def _register_custom_colormaps():
     for cIndex in range(3):
         colorList[:, cIndex] = np.interp(
             np.linspace(-1., 1., colorCount),
-            x, colorArray[:, cIndex+1])
+            x, colorArray[:, cIndex + 1])
 
     colorMap = cols.LinearSegmentedColormap.from_list(
         name, colorList, N=255)
@@ -2441,7 +2430,7 @@ def _register_custom_colormaps():
     for cIndex in range(3):
         colorList[:, cIndex] = np.interp(
             np.linspace(-1., 1., colorCount),
-            x, colorArray[:, cIndex+1])
+            x, colorArray[:, cIndex + 1])
 
     colorMap = cols.LinearSegmentedColormap.from_list(
         name, colorList, N=255)
@@ -2470,7 +2459,7 @@ def _register_custom_colormaps():
     # https://sciviscolor.org/home/colormaps/
 
     for mapName in ['3wave-yellow-grey-blue', '3Wbgy5',
-                    '4wave-grey-red-green-mgreen',  '5wave-yellow-brown-blue',
+                    '4wave-grey-red-green-mgreen', '5wave-yellow-brown-blue',
                     'blue-1', 'blue-3', 'blue-6', 'blue-8', 'blue-orange-div',
                     'brown-2', 'brown-5', 'brown-8', 'green-1', 'green-4',
                     'green-7', 'green-8', 'orange-5', 'orange-6',
@@ -2499,7 +2488,7 @@ def _read_xml_colormap(xmlFile, mapName):
             colorDict['red'].append((x, color[0], color[0]))
             colorDict['green'].append((x, color[1], color[1]))
             colorDict['blue'].append((x, color[2], color[2]))
-        cmap = LinearSegmentedColormap(mapName,  colorDict, 256)
+        cmap = LinearSegmentedColormap(mapName, colorDict, 256)
 
         plt.register_cmap(mapName, cmap)
 
@@ -2514,14 +2503,14 @@ def _plot_color_gradients():
 
     nrows = len(cmap_list)
 
-    fig, axes = plt.subplots(figsize=(7.2, 0.25*nrows), nrows=nrows)
+    fig, axes = plt.subplots(figsize=(7.2, 0.25 * nrows), nrows=nrows)
     fig.subplots_adjust(top=0.99, bottom=0.01, left=0.35, right=0.99)
 
     for ax, name in zip(axes, cmap_list):
         ax.imshow(gradient, aspect='auto', cmap=plt.get_cmap(name))
         pos = list(ax.get_position().bounds)
         x_text = pos[0] - 0.01
-        y_text = pos[1] + pos[3]/2.
+        y_text = pos[1] + pos[3] / 2.
         fig.text(x_text, y_text, name, va='center', ha='right', fontsize=10)
 
     # Turn off *all* ticks & spines, not just the ones with colormaps.

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -99,12 +99,12 @@ def compute_region_masks(geojsonFileName, meshFileName, maskFileName,
         if processCount == 1:
             mask = _contains(shape, cellPoints)
         else:
-            nChunks = int(numpy.ceil(nCells/chunkSize))
+            nChunks = int(numpy.ceil(nCells / chunkSize))
             chunks = []
             indices = [0]
             for iChunk in range(nChunks):
-                start = iChunk*chunkSize
-                end = min((iChunk+1)*chunkSize, nCells)
+                start = iChunk * chunkSize
+                end = min((iChunk + 1) * chunkSize, nCells)
                 chunks.append(cellPoints[start:end])
                 indices.append(end)
 
@@ -119,8 +119,8 @@ def compute_region_masks(geojsonFileName, meshFileName, maskFileName,
             mask = numpy.zeros((nCells,), bool)
             for iChunk, maskChunk in \
                     enumerate(pool.imap(partial_func, chunks)):
-                mask[indices[iChunk]:indices[iChunk+1]] = maskChunk
-                bar.update(iChunk+1)
+                mask[indices[iChunk]:indices[iChunk + 1]] = maskChunk
+                bar.update(iChunk + 1)
             bar.finish()
             pool.terminate()
 

--- a/mpas_analysis/shared/time_series/anomaly.py
+++ b/mpas_analysis/shared/time_series/anomaly.py
@@ -23,7 +23,6 @@ def compute_moving_avg_anomaly_from_start(timeSeriesFileName, variableList,
                                           startDate, endDate, calendar,
                                           movingAveragePoints=12,
                                           alter_dataset=None):  # {{{
-
     '''
     Compute the rolling mean of the anomaly of a quantity from the beginning
     of the simulation (such that the rolling mean starts at zero by definition)

--- a/mpas_analysis/shared/time_series/moving_average.py
+++ b/mpas_analysis/shared/time_series/moving_average.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import, division, print_function, \
 
 
 def compute_moving_avg(ds, movingAveragePoints=12):  # {{{
-
     '''
     Compute the rolling mean of a data set
 

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -136,8 +136,8 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         for variable in variableList:
             if variable not in self.allVariables:
                 raise ValueError(
-                        '{} is not available in timeSeriesStatsMonthly '
-                        'output:\n{}'.format(variable, self.allVariables))
+                    '{} is not available in timeSeriesStatsMonthly '
+                    'output:\n{}'.format(variable, self.allVariables))
 
             if variable not in self.variableList:
                 self.variableList.append(variable)
@@ -178,8 +178,8 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         endDate = config.get(self.section, 'endDate')
         streamName = 'timeSeriesStatsMonthlyOutput'
         self.inputFiles = self.historyStreams.readpath(
-                streamName, startDate=startDate, endDate=endDate,
-                calendar=self.calendar)
+            streamName, startDate=startDate, endDate=endDate,
+            calendar=self.calendar)
 
         if len(self.inputFiles) == 0:
             raise IOError('No files were found in stream {} between {} and '
@@ -188,8 +188,8 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         self.runMessage = '\nComputing MPAS time series from first year ' \
                           'plus files:\n' \
                           '    {} through\n    {}'.format(
-                                  os.path.basename(self.inputFiles[0]),
-                                  os.path.basename(self.inputFiles[-1]))
+                              os.path.basename(self.inputFiles[0]),
+                              os.path.basename(self.inputFiles[-1]))
 
         # Make sure first year of data is included for computing anomalies
         if config.has_option('timeSeries', 'anomalyRefYear'):
@@ -201,9 +201,9 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
 
         anomalyEndDate = '{:04d}-12-31_23:59:59'.format(anomalyYear)
         firstYearInputFiles = self.historyStreams.readpath(
-                streamName, startDate=anomalyStartDate,
-                endDate=anomalyEndDate,
-                calendar=self.calendar)
+            streamName, startDate=anomalyStartDate,
+            endDate=anomalyEndDate,
+            calendar=self.calendar)
         for fileName in firstYearInputFiles:
             if fileName not in self.inputFiles:
                 self.inputFiles.append(fileName)
@@ -271,12 +271,12 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
 
                     fileNames = sorted(self.inputFiles)
                     inYears, inMonths = get_files_year_month(
-                            fileNames, self.historyStreams,
-                            'timeSeriesStatsMonthlyOutput')
+                        fileNames, self.historyStreams,
+                        'timeSeriesStatsMonthlyOutput')
 
                     inYears = numpy.array(inYears)
                     inMonths = numpy.array(inMonths)
-                    totalMonths = 12*inYears + inMonths
+                    totalMonths = 12 * inYears + inMonths
 
                     dates = [bytes.decode(name) for name in
                              ds.xtime_startMonthly.values]
@@ -284,7 +284,7 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
 
                     lastYear = int(lastDate[0:4])
                     lastMonth = int(lastDate[5:7])
-                    lastTotalMonths = 12*lastYear + lastMonth
+                    lastTotalMonths = 12 * lastYear + lastMonth
 
                     inputFiles = []
                     for index, inputFile in enumerate(fileNames):
@@ -299,7 +299,7 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
                     # so we need ot delete it.
                     self.logger.warning('Warning: deleting file {} because '
                                         'some variables were missing'.format(
-                                                self.outputFile))
+                                            self.outputFile))
                     os.remove(self.outputFile)
 
         variableList = self.variableList + ['xtime_startMonthly',

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -202,9 +202,9 @@ def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
     endYear = yearsInDataSet[-1]
 
     firstProcessed = True
-    for firstYear in range(startYear, endYear+1, yearsPerCacheUpdate):
-        years = range(firstYear, numpy.minimum(endYear+1,
-                                               firstYear+yearsPerCacheUpdate))
+    for firstYear in range(startYear, endYear + 1, yearsPerCacheUpdate):
+        years = range(firstYear, numpy.minimum(endYear + 1,
+                                               firstYear + yearsPerCacheUpdate))
 
         mask = numpy.zeros(len(yearsInDataSet), bool)
         for year in years:

--- a/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
+++ b/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
@@ -67,7 +67,7 @@ class MpasRelativeDelta(relativedelta):
                                   seconds=self.seconds + other.seconds,
                                   calendar=self.calendar)
 
-        year = other.year+self.years
+        year = other.year + self.years
 
         month = other.month
         if self.months != 0:
@@ -91,10 +91,10 @@ class MpasRelativeDelta(relativedelta):
 
         days = self.days
         if self.calendar == 'gregorian_noleap' and isleap(year):
-            if month == 2 and day+days >= 29:
+            if month == 2 and day + days >= 29:
                 # skip forward over the leap day
                 days += 1
-            elif month == 3 and day+days <= 0:
+            elif month == 3 and day + days <= 0:
                 # skip backward over the leap day
                 days -= 1
 

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -488,7 +488,7 @@ def _round_datetime(date):
                              hour=hour, minute=minute,
                              second=second)
 
-    add_seconds = int(1e-6*microsecond+0.5)
+    add_seconds = int(1e-6 * microsecond + 0.5)
 
     return date + datetime.timedelta(0, add_seconds)
 

--- a/mpas_analysis/test/__init__.py
+++ b/mpas_analysis/test/__init__.py
@@ -110,5 +110,3 @@ class TestCase(unittest.TestCase):
             yield
             assert len(w) > 0
             assert all(message in str(wi.message) for wi in w)
-
-

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -148,7 +148,7 @@ class TestClimatology(TestCase):
         defaultMappingFileName = '{}/{}'.format(self.test_dir, fileBase)
         explicitMappingFileName = '{}/{}'.format(explicitMappingPath, fileBase)
 
-        for mappingFileName, setName in [(defaultMappingFileName,  False),
+        for mappingFileName, setName in [(defaultMappingFileName, False),
                                          (explicitMappingFileName, True)]:
 
             remapper = self.setup_mpas_remapper(config)
@@ -179,7 +179,7 @@ class TestClimatology(TestCase):
         defaultMappingFileName = '{}/{}'.format(self.test_dir, fileBase)
         explicitMappingFileName = '{}/{}'.format(explicitMappingPath, fileBase)
 
-        for mappingFileName, setName in [(defaultMappingFileName,  False),
+        for mappingFileName, setName in [(defaultMappingFileName, False),
                                          (explicitMappingFileName, True)]:
 
             remapper = self.setup_obs_remapper(config, fieldName)

--- a/mpas_analysis/test/test_interpolate.py
+++ b/mpas_analysis/test/test_interpolate.py
@@ -83,9 +83,9 @@ class TestInterp(TestCase):
         # a square 61x61 cell map with 100 km resolution and
         xMax = 3000e3
         res = 100e3
-        nx = 2*int(xMax/res)+1
+        nx = 2 * int(xMax / res) + 1
         x = numpy.linspace(-xMax, xMax, nx)
-        meshName = '{}km_Antarctic_stereo'.format(int(res*1e-3))
+        meshName = '{}km_Antarctic_stereo'.format(int(res * 1e-3))
         descriptor = ProjectionGridDescriptor.create(projection, x, x,
                                                      meshName)
         return descriptor

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -61,16 +61,16 @@ class TestMpasClimatologyTask(TestCase):
 
     def setup_subtask(self, mpasClimatologyTask):
         parentTask = AnalysisTask(
-                config=mpasClimatologyTask.config, taskName='fake',
-                componentName=mpasClimatologyTask.componentName,
-                tags=['climatology'])
+            config=mpasClimatologyTask.config, taskName='fake',
+            componentName=mpasClimatologyTask.componentName,
+            tags=['climatology'])
         climatologyName = 'ssh'
         variableList = ['timeMonthly_avg_ssh']
         seasons = [mpasClimatologyTask.seasons[0]]
 
         remapSubtask = RemapMpasClimatologySubtask(
-                mpasClimatologyTask, parentTask, climatologyName,
-                variableList, seasons, comparisonGridNames=['latlon'])
+            mpasClimatologyTask, parentTask, climatologyName,
+            variableList, seasons, comparisonGridNames=['latlon'])
 
         remapSubtask.setup_and_check()
         return remapSubtask
@@ -186,7 +186,7 @@ class TestMpasClimatologyTask(TestCase):
             assert(os.path.exists(fileName))
 
             fileName = remapSubtask.get_remapped_file_name(
-                    season=season, comparisonGridName='latlon')
+                season=season, comparisonGridName='latlon')
             assert(os.path.exists(fileName))
 
     def test_subtask_get_file_name(self):
@@ -199,6 +199,6 @@ class TestMpasClimatologyTask(TestCase):
                'mpaso_JFM_000201_000203_climo.nc'.format(str(self.test_dir)))
 
         fileName = remapSubtask.get_remapped_file_name(
-                season='JFM', comparisonGridName='latlon')
+            season='JFM', comparisonGridName='latlon')
         assert(fileName == '{}/clim/mpas/remapped/ssh_oQU240_to_0.5x0.5degree/'
                'mpaso_JFM_000201_000203_climo.nc'.format(str(self.test_dir)))

--- a/mpas_analysis/test/test_remap_obs_clim_subtask.py
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask.py
@@ -120,10 +120,10 @@ class TestRemapObsClimSubtask(TestCase):
         parent = AnalysisTask(config, 'taskName', 'ocean')
         obsFileName = '{}/mld_4.0x4.0degree.nc'.format(str(self.datadir))
         remapObsTask = RemapObservedMLDClimatology(
-                parentTask=parent,
-                seasons=['ANN'], fileName=obsFileName,
-                outFilePrefix='mld',
-                comparisonGridNames=['latlon', 'antarctic'])
+            parentTask=parent,
+            seasons=['ANN'], fileName=obsFileName,
+            outFilePrefix='mld',
+            comparisonGridNames=['latlon', 'antarctic'])
 
         remapObsTask.setup_and_check()
         return remapObsTask
@@ -143,8 +143,8 @@ class TestRemapObsClimSubtask(TestCase):
             for season in remapSubtask.seasons:
                 for stage in ['original', 'climatology', 'remapped']:
                     fileName = remapSubtask.get_file_name(
-                            season=season, stage=stage,
-                            comparisonGridName=comparisonGridName)
+                        season=season, stage=stage,
+                        comparisonGridName=comparisonGridName)
                     assert(os.path.exists(fileName))
 
     def test_subtask_get_file_name(self):
@@ -152,9 +152,9 @@ class TestRemapObsClimSubtask(TestCase):
 
         for comparisonGridName in ['latlon', 'antarctic', None]:
             fileName = remapSubtask.get_file_name(
-                    stage='original', comparisonGridName=comparisonGridName)
+                stage='original', comparisonGridName=comparisonGridName)
             assert(fileName == '{}/clim/obs/mld_4.0x4.0degree.nc'.format(
-                    str(self.test_dir)))
+                str(self.test_dir)))
 
         stage = 'climatology'
         for comparisonGridName in ['latlon', 'antarctic', None]:
@@ -162,7 +162,7 @@ class TestRemapObsClimSubtask(TestCase):
                                                   season='JFM',
                                                   comparisonGridName='latlon')
             assert(fileName == '{}/clim/obs/mld_4.0x4.0degree_JFM.nc'.format(
-                    str(self.test_dir)))
+                str(self.test_dir)))
 
         stage = 'remapped'
         fileName = remapSubtask.get_file_name(stage=stage, season='JFM',
@@ -174,4 +174,4 @@ class TestRemapObsClimSubtask(TestCase):
                                               comparisonGridName='antarctic')
         assert(fileName == '{}/clim/obs/remapped/mld_4.0x4.0degree_to_'
                '6000.0x6000.0km_10.0km_Antarctic_stereo_JFM.nc'.format(
-                       str(self.test_dir)))
+                   str(self.test_dir)))

--- a/mpas_analysis/test/test_remap_obs_clim_subtask/remap_mld_obs.py
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask/remap_mld_obs.py
@@ -24,8 +24,8 @@ obsDescriptor = LatLonGridDescriptor.read(fileName=inputFileName,
 comparisonLatRes = 4.
 comparisonLonRes = 4.
 
-nLat = int((constants.latmax-constants.latmin)/comparisonLatRes)+1
-nLon = int((constants.lonmax-constants.lonmin)/comparisonLonRes)+1
+nLat = int((constants.latmax - constants.latmin) / comparisonLatRes) + 1
+nLon = int((constants.lonmax - constants.lonmin) / comparisonLonRes) + 1
 lat = numpy.linspace(constants.latmin, constants.latmax, nLat)
 lon = numpy.linspace(constants.lonmin, constants.lonmax, nLon)
 

--- a/mpas_analysis/test/test_timekeeping.py
+++ b/mpas_analysis/test/test_timekeeping.py
@@ -120,19 +120,19 @@ class TestTimekeeping(TestCase):
             date1 = string_to_datetime('1996-01-15')
             delta = string_to_relative_delta('0005-00-00',
                                              calendar=calendar)
-            date2 = date1-delta
+            date2 = date1 - delta
             self.assertEqual(date2, string_to_datetime('1991-01-15'))
 
             date1 = string_to_datetime('1996-01-15')
             delta = string_to_relative_delta('0000-02-00',
                                              calendar=calendar)
-            date2 = date1-delta
+            date2 = date1 - delta
             self.assertEqual(date2, string_to_datetime('1995-11-15'))
 
             date1 = string_to_datetime('1996-01-15')
             delta = string_to_relative_delta('0000-00-20',
                                              calendar=calendar)
-            date2 = date1-delta
+            date2 = date1 - delta
             self.assertEqual(date2, string_to_datetime('1995-12-26'))
 
     def test_MpasRelativeDeltaOps(self):
@@ -173,8 +173,8 @@ class TestTimekeeping(TestCase):
 
         for calendar in ['gregorian', 'gregorian_noleap']:
 
-            delta1 = string_to_relative_delta('0000-01-00',  calendar=calendar)
-            delta2 = string_to_relative_delta('0000-00-01',  calendar=calendar)
+            delta1 = string_to_relative_delta('0000-01-00', calendar=calendar)
+            delta2 = string_to_relative_delta('0000-00-01', calendar=calendar)
             deltaSum = string_to_relative_delta('0000-01-01',
                                                 calendar=calendar)
             # test MpasRelativeDelta + MpasRelativeDelta
@@ -185,7 +185,7 @@ class TestTimekeeping(TestCase):
             # test MpasRelativeDelta(date1, date2)
             date1 = string_to_datetime('0002-02-02')
             date2 = string_to_datetime('0001-01-01')
-            delta = string_to_relative_delta('0001-01-01',  calendar=calendar)
+            delta = string_to_relative_delta('0001-01-01', calendar=calendar)
             self.assertEqual(MpasRelativeDelta(dt1=date1, dt2=date2,
                                                calendar=calendar),
                              delta)
@@ -193,15 +193,15 @@ class TestTimekeeping(TestCase):
             # test MpasRelativeDelta + datetime.datetime (an odd order but
             # it's allowed...)
             date1 = string_to_datetime('0001-01-01')
-            delta = string_to_relative_delta('0001-01-01',  calendar=calendar)
+            delta = string_to_relative_delta('0001-01-01', calendar=calendar)
             date2 = string_to_datetime('0002-02-02')
             self.assertEqual(delta + date1, date2)
 
             # test multiplication/division by scalars
-            delta1 = string_to_relative_delta('0001-01-01',  calendar=calendar)
-            delta2 = string_to_relative_delta('0002-02-02',  calendar=calendar)
-            self.assertEqual(2*delta1, delta2)
-            self.assertEqual(delta2/2, delta1)
+            delta1 = string_to_relative_delta('0001-01-01', calendar=calendar)
+            delta2 = string_to_relative_delta('0002-02-02', calendar=calendar)
+            self.assertEqual(2 * delta1, delta2)
+            self.assertEqual(delta2 / 2, delta1)
 
         # make sure there's an error when we try to add MpasRelativeDeltas
         # with different calendars

--- a/preprocess_observations/compute_woce_transects.py
+++ b/preprocess_observations/compute_woce_transects.py
@@ -26,7 +26,7 @@ def process_transect(url, stations, outFileName, transectName, inDir, outDir):
         f.extractall('{}/stations/'.format(inDir))
 
     inFileList = sorted(glob.glob('{}/stations/{}_*.nc'.format(
-            inDir, transectName)))
+        inDir, transectName)))
 
     pressureValues = set()
     fileNames = {}
@@ -80,14 +80,14 @@ def process_transect(url, stations, outFileName, transectName, inDir, outDir):
     # average over casts
     validMask = nValues > 0
     pressure = numpy.ma.masked_array(
-            numpy.divide(pressure, nValues, where=validMask),
-            mask=(nValues == 0))
+        numpy.divide(pressure, nValues, where=validMask),
+        mask=(nValues == 0))
     temperature = numpy.ma.masked_array(
-            numpy.divide(temperature, nValues, where=validMask),
-            mask=(nValues == 0))
+        numpy.divide(temperature, nValues, where=validMask),
+        mask=(nValues == 0))
     salinity = numpy.ma.masked_array(
-            numpy.divide(salinity, nValues, where=validMask),
-            mask=(nValues == 0))
+        numpy.divide(salinity, nValues, where=validMask),
+        mask=(nValues == 0))
 
     Lat = numpy.tile(latitude.reshape(nStations, 1), (1, nDepths))
     Lon = numpy.tile(longitude.reshape(nStations, 1), (1, nDepths))
@@ -145,10 +145,10 @@ def process_transect(url, stations, outFileName, transectName, inDir, outDir):
                                                 'units': 'PSU'}})
 
     potDensity = xarray.DataArray.from_dict(
-            {'dims': ('nPoints', 'nz'),
-             'data': potDensity,
-             'attrs': {'long_name': 'potential denisty',
-                       'units': 'kg m^{-3}'}})
+        {'dims': ('nPoints', 'nz'),
+         'data': potDensity,
+         'attrs': {'long_name': 'potential denisty',
+                   'units': 'kg m^{-3}'}})
 
     dsTransect = xarray.Dataset({'lon': longitude,
                                  'lat': latitude,

--- a/preprocess_observations/mds.py
+++ b/preprocess_observations/mds.py
@@ -1,13 +1,3 @@
-# This software is open source software available under the BSD-3 license.
-#
-# Copyright (c) 2018 Los Alamos National Security, LLC. All rights reserved.
-# Copyright (c) 2018 Lawrence Livermore National Security, LLC. All rights
-# reserved.
-# Copyright (c) 2018 UT-Battelle, LLC. All rights reserved.
-#
-# Additional copyright and license information can be found in the LICENSE file
-# distributed with this code, or at
-# https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
 import sys
 import re
 import glob

--- a/preprocess_observations/preprocess_SOSE_data.py
+++ b/preprocess_observations/preprocess_SOSE_data.py
@@ -46,7 +46,7 @@ from mds import rdmds
 
 def get_bottom_indices(cellFraction):
     nx, ny, nz = cellFraction.shape
-    botIndices = -1*numpy.ones((nx, ny), int)
+    botIndices = -1 * numpy.ones((nx, ny), int)
     for zIndex in range(nz):
         mask = cellFraction[:, :, zIndex] > 0.
         botIndices[mask] = zIndex
@@ -57,7 +57,7 @@ def get_monthly_average_3d(filePrefix, cellFraction, botIndices):
     field, itrs, metadata = rdmds(filePrefix, rec=[0], returnmeta=True)
     nz, ny, nx = field.shape
     # print nx, ny, nz
-    yearCount = metadata['nrecords'][0]//12
+    yearCount = metadata['nrecords'][0] // 12
     dims = [12, nx, ny, nz]
 
     mask3D = cellFraction <= 0.
@@ -69,19 +69,19 @@ def get_monthly_average_3d(filePrefix, cellFraction, botIndices):
     for month in range(12):
         first = True
         for year in range(yearCount):
-            print('{:04d}-{:02d}'.format(year+2005, month+1))
-            recordIndex = year*12 + month
+            print('{:04d}-{:02d}'.format(year + 2005, month + 1))
+            recordIndex = year * 12 + month
             field = rdmds(filePrefix, rec=[recordIndex])
             field = field.transpose(2, 1, 0)
 
             field = numpy.ma.masked_array(field, mask=mask3D)
             if first:
-                monthlyClimatologies[month, :, :, :] = field/float(yearCount)
+                monthlyClimatologies[month, :, :, :] = field / float(yearCount)
                 first = False
             else:
                 monthlyClimatologies[month, :, :, :] = \
                     monthlyClimatologies[month, :, :, :] + \
-                    field/float(yearCount)
+                    field / float(yearCount)
         botMonthlyClimatologies[month, :, :] = \
             numpy.ma.masked_array(field[xIndices, yIndices, botIndices],
                                   mask=mask2D)
@@ -96,7 +96,7 @@ def get_monthly_average_2d(filePrefix, botIndices):
     field, itrs, metadata = rdmds(filePrefix, rec=[0], returnmeta=True)
     ny, nx = field.shape
     # print nx, ny, nz
-    yearCount = metadata['nrecords'][0]//12
+    yearCount = metadata['nrecords'][0] // 12
     dims = [12, nx, ny]
 
     mask2D = botIndices == -1
@@ -106,19 +106,19 @@ def get_monthly_average_2d(filePrefix, botIndices):
     for month in range(12):
         first = True
         for year in range(yearCount):
-            print('{:04d}-{:02d}'.format(year+2005, month+1))
-            recordIndex = year*12 + month
+            print('{:04d}-{:02d}'.format(year + 2005, month + 1))
+            recordIndex = year * 12 + month
             field = rdmds(filePrefix, rec=[recordIndex])
             field = field.transpose(1, 0)
 
             field = numpy.ma.masked_array(field, mask=mask2D)
             if first:
-                monthlyClimatologies[month, :, :] = field/float(yearCount)
+                monthlyClimatologies[month, :, :] = field / float(yearCount)
                 first = False
             else:
                 monthlyClimatologies[month, :, :] = \
                     monthlyClimatologies[month, :, :] + \
-                    field/float(yearCount)
+                    field / float(yearCount)
 
     monthlyClimatologies = monthlyClimatologies.transpose(0, 2, 1)
     return monthlyClimatologies
@@ -177,12 +177,12 @@ def sose_pt_to_nc(inPrefix, outFileName, lon, lat, z, cellFraction,
                      'data_vars': {'theta':
                                    {'dims': ('Time', 'lat', 'lon', 'z'),
                                     'data': field,
-                                    'attrs': {'units': '$\degree$C',
+                                    'attrs': {'units': r'$\degree$C',
                                               'description': description}},
                                    'botTheta':
                                    {'dims': ('Time', 'lat', 'lon'),
                                     'data': botField,
-                                    'attrs': {'units': '$\degree$C',
+                                    'attrs': {'units': r'$\degree$C',
                                               'description': botDescription}}}}
 
         dsT = xarray.Dataset.from_dict(dictonary)
@@ -667,12 +667,12 @@ def compute_vel_mag(prefix, inGridName, inDir):
                 with xarray.open_dataset(vFileName) as dsV:
                     dsVelMag = dsU.drop(['zonalVel', 'botZonalVel'])
                     dsVelMag['velMag'] = numpy.sqrt(
-                            dsU.zonalVel**2 + dsV.meridVel**2)
+                        dsU.zonalVel**2 + dsV.meridVel**2)
                     dsVelMag.velMag.attrs['units'] = 'm s$^{-1}$'
                     dsVelMag.velMag.attrs['description'] = description
 
                     dsVelMag['botVelMag'] = numpy.sqrt(
-                            dsU.botZonalVel**2 + dsV.botMeridVel**2)
+                        dsU.botZonalVel**2 + dsV.botMeridVel**2)
                     dsVelMag.botVelMag.attrs['units'] = 'm s$^{-1}$'
                     dsVelMag.botVelMag.attrs['description'] = botDescription
 

--- a/preprocess_observations/preprocess_Schmidtko_data.py
+++ b/preprocess_observations/preprocess_Schmidtko_data.py
@@ -70,16 +70,16 @@ def text_to_netcdf(inDir, outDir):
     inPT = gsw.pt_from_CT(inSA, inCT)
     inPD = gsw.rho(inSA, inCT, 0.)
 
-    minLat = int(numpy.amin(inLat)*cellsPerLat)/cellsPerLat
-    maxLat = int(numpy.amax(inLat)*cellsPerLat)/cellsPerLat
-    deltaLat = 1./cellsPerLat
-    outLat = numpy.arange(minLat-deltaLat, maxLat+2*deltaLat, deltaLat)
+    minLat = int(numpy.amin(inLat) * cellsPerLat) / cellsPerLat
+    maxLat = int(numpy.amax(inLat) * cellsPerLat) / cellsPerLat
+    deltaLat = 1. / cellsPerLat
+    outLat = numpy.arange(minLat - deltaLat, maxLat + 2 * deltaLat, deltaLat)
 
-    deltaLon = 1./cellsPerLon
+    deltaLon = 1. / cellsPerLon
     outLon = numpy.arange(0., 360., deltaLon)
 
-    xIndices = numpy.array(cellsPerLon*inLon + 0.5, int)
-    yIndices = numpy.array(cellsPerLat*(inLat - outLat[0]) + 0.5, int)
+    xIndices = numpy.array(cellsPerLon * inLon + 0.5, int)
+    yIndices = numpy.array(cellsPerLat * (inLat - outLat[0]) + 0.5, int)
 
     Lon, Lat = numpy.meshgrid(outLon, outLat)
 
@@ -101,7 +101,7 @@ def text_to_netcdf(inDir, outDir):
     PT = numpy.ma.masked_all(Lon.shape)
     PT[yIndices, xIndices] = inPT
     ds['botTheta'] = (('lat', 'lon'), PT)
-    ds.botTheta.attrs['units'] = '$\degree$C'
+    ds.botTheta.attrs['units'] = r'$\degree$C'
     ds.botTheta.attrs['description'] = \
         'potential temperature at sea floor'
 
@@ -109,7 +109,7 @@ def text_to_netcdf(inDir, outDir):
     # neglect difference between std of PT and CT
     PT_std[yIndices, xIndices] = inCT_std
     ds['botThetaStd'] = (('lat', 'lon'), PT_std)
-    ds.botThetaStd.attrs['units'] = '$\degree$C'
+    ds.botThetaStd.attrs['units'] = r'$\degree$C'
     ds.botThetaStd.attrs['description'] = \
         'standard deviation in potential temperature at sea floor'
 
@@ -142,7 +142,7 @@ def remap(inDir, outDir):
 
     inGridName = 'SouthernOcean_0.25x0.125degree'
     inFileName = '{}/Schmidtko_et_al_2014_bottom_PT_S_PD_{}.nc'.format(
-            inDir, inGridName)
+        inDir, inGridName)
 
     config = MpasAnalysisConfigParser()
     config.read('mpas_analysis/config.default')
@@ -157,7 +157,7 @@ def remap(inDir, outDir):
     outGridName = outDescriptor.meshName
 
     outFileName = '{}/Schmidtko_et_al_2014_bottom_PT_S_PD_{}.nc'.format(
-            outDir, outGridName)
+        outDir, outGridName)
 
     mappingFileName = '{}/map_{}_to_{}.nc'.format(inDir, inGridName,
                                                   outGridName)

--- a/preprocess_observations/remap_rignot.py
+++ b/preprocess_observations/remap_rignot.py
@@ -31,8 +31,8 @@ config.read('config.default')
 
 ds = xarray.open_dataset(inFileName)
 ds = subset_variables(ds, ['melt_actual', 'xaxis', 'yaxis'])
-lx = numpy.abs(1e-3*(ds.xaxis.values[-1]-ds.xaxis.values[0]))
-ly = numpy.abs(1e-3*(ds.yaxis.values[-1]-ds.yaxis.values[0]))
+lx = numpy.abs(1e-3 * (ds.xaxis.values[-1] - ds.xaxis.values[0]))
+ly = numpy.abs(1e-3 * (ds.yaxis.values[-1] - ds.yaxis.values[0]))
 
 maskedMeltRate = numpy.ma.masked_array(ds.melt_actual,
                                        mask=(ds.melt_actual.values == 0.))
@@ -50,7 +50,7 @@ projection = pyproj.Proj('+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0 '
 
 inDescriptor = ProjectionGridDescriptor(projection)
 
-inDescriptor.read(inFileName,  xVarName='xaxis', yVarName='yaxis',
+inDescriptor.read(inFileName, xVarName='xaxis', yVarName='yaxis',
                   meshName=inGridName)
 
 outDescriptor = get_Antarctic_stereographic_comparison_descriptor(config)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if not isrelease:
             ["git", "describe", "--always", "--match", "v[0-9]*"],
             stdout=subprocess.PIPE)
         (version, stderr) = pipe.communicate()
-    except:
+    except BaseException:
         warnings.warn("WARNING: Couldn't get git revision, using generic "
                       "version string")
 

--- a/utility_scripts/make_mpas_to_Antarctic_stereo_mapping.py
+++ b/utility_scripts/make_mpas_to_Antarctic_stereo_mapping.py
@@ -29,7 +29,8 @@ from mpas_analysis.configuration import MpasAnalysisConfigParser
 inGridName = 'oQU240'
 
 # replace with the path to the desired mesh or restart file
-inGridFileName = '/media/xylar/extra_data/analysis/edison/G-QU240-master-intel/run/mpaso.rst.0001-01-06_00000.nc'
+inGridFileName = '/media/xylar/extra_data/analysis/edison/' \
+                 'G-QU240-master-intel/run/mpaso.rst.0001-01-06_00000.nc'
 
 config = MpasAnalysisConfigParser()
 config.read('mpas_analysis/config.default')

--- a/utility_scripts/make_mpas_to_lat_lon_mapping.py
+++ b/utility_scripts/make_mpas_to_lat_lon_mapping.py
@@ -29,7 +29,8 @@ from mpas_analysis.configuration import MpasAnalysisConfigParser
 inGridName = 'oQU240'
 
 # replace with the path to the desired mesh or restart file
-inGridFileName = '/media/xylar/extra_data/analysis/edison/G-QU240-master-intel/run/mpaso.rst.0001-01-06_00000.nc'
+inGridFileName = '/media/xylar/extra_data/analysis/edison/' \
+                 'G-QU240-master-intel/run/mpaso.rst.0001-01-06_00000.nc'
 
 config = MpasAnalysisConfigParser()
 config.read('mpas_analysis/config.default')


### PR DESCRIPTION
Several small PEP8 issues have crept into the code over time.  Given our experimentation, first with stickler CI and now with pep8speaks, it seems useful to clean up these issues.

The code can be cleaned up automatically for the most part with:
```
autopep8 -r --in-place --aggressive --max-line-length 80 .
```
However,
* some lines are too long and are better left that way (e.g long URLs or function/class/variable names), see https://www.python.org/dev/peps/pep-0008/#a-foolish-consistency-is-the-hobgoblin-of-little-minds
* some imports cannot be at the top of files and need to be after other commands (e.g. in `docs/conf.py`)
so some errors/warnings are expected.
