### PR TITLE
Use ncremap on projection grids

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ environment with the following packages:
  * bottleneck
  * basemap < 1.2.0 | > 1.2.0
  * lxml
- * nco >= 4.7.0
+ * nco >= 4.7.9
  * pyproj
  * pillow
  * cmocean

--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -6,13 +6,13 @@ dependencies:
   - numpy<1.16.0
   - scipy
   - lxml
-  - xarray
+  - xarray>=0.10.0
   - matplotlib
   - dask
   - netcdf4
   - hdf5
   - hdf4
-  - nco
+  - nco>=4.7.9
   - pyproj
   - pillow
   - cmocean

--- a/conda/recipe/meta.yaml
+++ b/conda/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
         - bottleneck
         - basemap <1.2.0|>1.2.0
         - lxml
-        - nco >=4.7.0
+        - nco >=4.7.9
         - pillow
         - cmocean
         - progressbar2
@@ -54,6 +54,5 @@ about:
 
 extra:
     recipe-maintainers:
-        - doutriaux1
         - xylar
 

--- a/mpas_analysis/ocean/compute_transects_subtask.py
+++ b/mpas_analysis/ocean/compute_transects_subtask.py
@@ -143,7 +143,7 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):  # {{{
         super(ComputeTransectsSubtask, self).__init__(
             mpasClimatologyTask, parentTask,
             climatologyName=climatologyName, variableList=variableList,
-            seasons=seasons, subtaskName=subtaskName)
+            seasons=seasons, subtaskName=subtaskName, useNcremap=False)
 
         self.obsDatasets = obsDatasets
         self.transectCollectionName = transectCollectionName

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -328,12 +328,6 @@ def remap_and_write_climatology(config, climatologyDataSet,
 
     useNcremap = config.getboolean('climatology', 'useNcremap')
 
-    if (isinstance(remapper.sourceDescriptor, ProjectionGridDescriptor) or
-            isinstance(remapper.destinationDescriptor,
-                       ProjectionGridDescriptor)):
-        # ncremap doesn't support projection grids
-        useNcremap = False
-
     if remapper.mappingFileName is None:
         # no remapping is needed
         remappedClimatology = climatologyDataSet

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -580,8 +580,7 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
         renormalizationThreshold = self.config.getfloat(
             'climatology', 'renormalizationThreshold')
 
-        # ncremap doesn't support grids other than lat/lon
-        if self.useNcremap and comparisonGridName == 'latlon':
+        if self.useNcremap:
             remapper.remap_file(inFileName=inFileName,
                                 outFileName=outFileName,
                                 overwrite=True,

--- a/mpas_analysis/shared/grid/grid.py
+++ b/mpas_analysis/shared/grid/grid.py
@@ -734,6 +734,8 @@ class ProjectionGridDescriptor(MeshDescriptor):  # {{{
         '''
         Set up a coords dict with x, y, lat and lon
         '''
+        self.xVarName = xVarName
+        self.yVarName = yVarName
         (X, Y) = numpy.meshgrid(self.x, self.y)
         (Lat, Lon) = self.project_to_lat_lon(X, Y)
 

--- a/mpas_analysis/shared/interpolation/remapper.py
+++ b/mpas_analysis/shared/interpolation/remapper.py
@@ -267,17 +267,9 @@ class Remapper(object):
             # a remapped file already exists, so nothing to do
             return
 
-        if isinstance(self.sourceDescriptor, (ProjectionGridDescriptor,
-                                              PointCollectionDescriptor)):
-            raise TypeError('Source grid is a projection grid, not supported '
-                            'by ncremap.\n'
-                            'Consider using Remapper.remap')
-        if isinstance(self.destinationDescriptor,
-                      (ProjectionGridDescriptor,
-                       PointCollectionDescriptor)):
-            raise TypeError('Destination grid is a projection grid, not '
-                            'supported by ncremap.\n'
-                            'Consider using Remapper.remap')
+        if isinstance(self.sourceDescriptor, (PointCollectionDescriptor)):
+            raise TypeError('Source grid is a point collection, which is not'
+                            'supported.')
 
         if find_executable('ncremap') is None:
             raise OSError('ncremap not found. Make sure the latest nco '
@@ -302,6 +294,25 @@ class Remapper(object):
                 self.sourceDescriptor.latVarName),
                 '--rgr lon_nm={}'.format(
                 self.sourceDescriptor.lonVarName)])
+        elif isinstance(self.sourceDescriptor, ProjectionGridDescriptor):
+            regridArgs.extend(['--rgr lat_nm={}'.format(
+                self.sourceDescriptor.yVarName),
+                '--rgr lon_nm={}'.format(
+                self.sourceDescriptor.xVarName)])
+
+        if isinstance(self.destinationDescriptor, LatLonGridDescriptor):
+            regridArgs.extend(['--rgr lat_nm_out={}'.format(
+                self.destinationDescriptor.latVarName),
+                '--rgr lon_nm_out={}'.format(
+                self.destinationDescriptor.lonVarName)])
+        elif isinstance(self.destinationDescriptor, ProjectionGridDescriptor):
+            regridArgs.extend(['--rgr lat_dmn_nm={}'.format(
+                self.destinationDescriptor.xVarName),
+                '--rgr lon_dmn_nm={}'.format(
+                self.destinationDescriptor.yVarName),
+                '--rgr lat_nm_out=lat', '--rgr lon_nm_out=lon'])
+        if isinstance(self.destinationDescriptor, PointCollectionDescriptor):
+            regridArgs.extend(['--rgr lat_nm_out=lat', '--rgr lon_nm_out=lon'])
 
         if len(regridArgs) > 0:
             args.extend(['-R', ' '.join(regridArgs)])


### PR DESCRIPTION
While the numpy-based regridder works fine for projeciton grids, it's not as fast as ncremap.

This merge depends on new features in NCO 4.7.9.  Requirements have been updated accordingly.

closes #520 