### PR TITLE
Remove time variables from SSH Obs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ environment with the following packages:
 
  * numpy
  * scipy
- * matplotlib
+ * matplotlib >= 3.2.0
  * netCDF4
  * xarray >= 0.10.0
  * dask
  * bottleneck
- * basemap
+ * basemap < 1.2.0 | > 1.2.0
  * lxml
  * nco >= 4.7.0
  * pyproj
@@ -46,8 +46,8 @@ environment with the following packages:
 These can be installed via the conda command:
 ``` bash
 conda create -n mpas_analysis -c conda-forge numpy scipy matplotlib netCDF4 \
-    xarray dask bottleneck basemap lxml nco pyproj pillow cmocean \
-    progressbar2 requests setuptools shapely
+    xarray dask bottleneck "basemap<1.2.0|>1.2.0" lxml nco pyproj pillow \
+    cmocean progressbar2 requests setuptools shapely
 ```
 
 Then, get the code from:

--- a/mpas_analysis/ocean/climatology_map_ssh.py
+++ b/mpas_analysis/ocean/climatology_map_ssh.py
@@ -252,6 +252,7 @@ class RemapObservedSSHClimatology(RemapObservedClimatologySubtask):  # {{{
         dsObs = dsObs.rename({'time': 'Time'})
         dsObs.coords['month'] = dsObs['Time.month']
         dsObs.coords['year'] = dsObs['Time.year']
+        dsObs = dsObs.drop(['Time', 'time_bnds'])
 
         # scale the field to cm from m
         dsObs['zos'] = constants.cm_per_m * dsObs['zos']


### PR DESCRIPTION
This is needed to support weighted averages in time for climatologies  with latest xarray

closes #525 