### PR TITLE
Revert back to python 3.5 and drop latest ReadTheDocs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,9 +1,7 @@
 conda:
     file: docs/environment.yml
-build:
-    image: latest
 python:
-   version: 3.6
+   version: 3.5
    setup_py_install: false
 # Build PDF
 formats:


### PR DESCRIPTION
This is necessary because latest doesn't support autosummary correctly, see: https://github.com/rtfd/readthedocs.org/issues/4446