### PR TITLE
Check for enough data in anomaly and Nino34 tasks; fix MOC time series with 1 year of data

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,24 @@
 [![Build Status](https://travis-ci.org/MPAS-Dev/MPAS-Analysis.svg?branch=develop)](https://travis-ci.org/MPAS-Dev/MPAS-Analysis)
 [![Documentation Status](http://readthedocs.org/projects/mpas-analysis/badge/?version=develop)](http://mpas-analysis.readthedocs.io/en/develop/?badge=develop)
 
-
 Analysis for simulations produced with Model for Prediction Across Scales
 (MPAS) components and the Energy Exascale Earth System Model (E3SM), which
 used those components.
 
 ![sea surface temperature](docs/_static/sst_example.png)
+
+## conda-forge
+
+### Current build status
+
+All platforms:
+[![noarch](https://img.shields.io/circleci/project/github/conda-forge/mpas-analysis-feedstock/master.svg?label=noarch)](https://circleci.com/gh/conda-forge/mpas-analysis-feedstock)
+
+### Current release info
+
+| Name | Downloads | Version | Platforms |
+| --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-mpas--analysis-green.svg)](https://anaconda.org/conda-forge/mpas-analysis) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/mpas-analysis.svg)](https://anaconda.org/conda-forge/mpas-analysis) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/mpas-analysis.svg)](https://anaconda.org/conda-forge/mpas-analysis) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/mpas-analysis.svg)](https://anaconda.org/conda-forge/mpas-analysis) |
 
 ## Documentation
 

--- a/mpas_analysis/ocean/compute_anomaly_subtask.py
+++ b/mpas_analysis/ocean/compute_anomaly_subtask.py
@@ -20,7 +20,11 @@ from mpas_analysis.shared import AnalysisTask
 
 from mpas_analysis.shared.io import write_netcdf
 
-from mpas_analysis.shared.timekeeping.utility import get_simulation_start_time
+from mpas_analysis.shared.timekeeping.utility import \
+    get_simulation_start_time, string_to_datetime
+
+from mpas_analysis.shared.timekeeping.MpasRelativeDelta import \
+    MpasRelativeDelta
 
 from mpas_analysis.shared.io.utility import build_config_full_path
 
@@ -133,6 +137,19 @@ class ComputeAnomalySubtask(AnalysisTask):
         #     self.namelist, self.runStreams, self.historyStreams,
         #     self.calendar
         super(ComputeAnomalySubtask, self).setup_and_check()
+
+        startDate = self.config.get('timeSeries', 'startDate')
+        endDate = self.config.get('timeSeries', 'endDate')
+
+        delta = MpasRelativeDelta(string_to_datetime(endDate),
+                                  string_to_datetime(startDate),
+                                  calendar=self.calendar)
+
+        months = delta.months + 12*delta.years
+
+        if months <= self.movingAveragePoints:
+            raise ValueError('Cannot meaninfully perform a rolling mean '
+                             'because the time series is too short.')
 
         self.mpasTimeSeriesTask.add_variables(variableList=self.variableList)
 

--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -27,7 +27,10 @@ from mpas_analysis.shared.io.utility import build_config_full_path, \
     build_obs_path
 
 from mpas_analysis.shared.timekeeping.utility import datetime_to_days, \
-    string_to_days_since_date
+    string_to_days_since_date, string_to_datetime
+
+from mpas_analysis.shared.timekeeping.MpasRelativeDelta import \
+    MpasRelativeDelta
 
 from mpas_analysis.shared.io import open_mpas_dataset
 
@@ -103,6 +106,19 @@ class IndexNino34(AnalysisTask):  # {{{
         #     self.namelist, self.runStreams, self.historyStreams,
         #     self.calendar
         super(IndexNino34, self).setup_and_check()
+
+        startDate = self.config.get('index', 'startDate')
+        endDate = self.config.get('index', 'endDate')
+
+        delta = MpasRelativeDelta(string_to_datetime(endDate),
+                                  string_to_datetime(startDate),
+                                  calendar=self.calendar)
+
+        months = delta.months + 12*delta.years
+
+        if months <= 12:
+            raise ValueError('Cannot meaninfully analyze El Nino climate '
+                             'index because the time series is too short.')
 
         self.variableList = \
             ['timeMonthly_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -1169,11 +1169,16 @@ class CombineMOCTimeSeriesSubtask(AnalysisTask):  # {{{
                 outputDirectory, startYear, endYear)
             outputFileNames.append(outputFileName)
 
+        outputFileName = '{}/mocTimeSeries_{:04d}-{:04d}.nc'.format(
+            outputDirectory, self.startYears[0], self.endYears[-1])
+
+        if outputFileName in outputFileNames:
+            # don't try to write to read from and write to the same file
+            return
+
         ds = xr.open_mfdataset(outputFileNames, concat_dim='Time',
                                decode_times=False)
 
-        outputFileName = '{}/mocTimeSeries_{:04d}-{:04d}.nc'.format(
-            outputDirectory, self.startYears[0], self.endYears[-1])
         write_netcdf(ds, outputFileName)  # }}}
     # }}}
 


### PR DESCRIPTION
The anomaly tasks cannot meaningfully run on a year or less of data.  They now all check during setup to see if there is sufficient data an fail with a warning if not.  (The reason for the failure is not given unless the --verbose tag is used.)

Add text telling users to get more info with the `--verbose` tag

Don't overwrite MOC time series if the yearly and total data are the same

Add conda-forge badges (unrelated but a convenient place to do this).

closes #545 
closes #543 