### PR TITLE
Support multiple subprocesses per task (12 for ncclimo in bck mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ environment with the following packages:
  * xarray >= 0.10.0
  * dask
  * bottleneck
- * basemap < 1.2.0 | > 1.2.0
+ * basemap
  * lxml
  * nco >= 4.7.9
  * pyproj
@@ -54,12 +54,13 @@ environment with the following packages:
  * requests
  * setuptools
  * shapely
+ * proj4 < 6.0.0
 
 These can be installed via the conda command:
 ``` bash
 conda create -n mpas_analysis -c conda-forge numpy scipy matplotlib netCDF4 \
-    xarray dask bottleneck "basemap<1.2.0|>1.2.0" lxml nco pyproj pillow \
-    cmocean progressbar2 requests setuptools shapely
+    xarray dask bottleneck basemap lxml nco pyproj pillow \
+    cmocean progressbar2 requests setuptools shapely proj4 < 6.0.0
 ```
 
 Then, get the code from:

--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -19,3 +19,4 @@ dependencies:
   - progressbar2
   - requests
   - shapely
+  - proj4 < 6.0.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,8 @@ on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
     os.environ['PROJ_LIB'] = '{}/{}/share/proj'.format(
             os.environ['CONDA_ENVS_PATH'], os.environ['CONDA_DEFAULT_ENV'])
+else:
+    os.environ['PROJ_LIB'] = '{}/share/proj'.format(os.environ['CONDA_PREFIX'])
 print(os.environ)
 from mpas_analysis.__main__ import add_task_and_subtasks
 from docs.parse_table import build_rst_table_from_xml, build_obs_pages_from_xml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -25,3 +25,4 @@ dependencies:
   - tabulate >= 0.8.2
   - m2r
   - shapely
+  - proj4 < 6.0.0

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -193,6 +193,9 @@ comparisonAntarcticStereoResolution = 10.
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
 mpasInterpolationMethod = bilinear
 
+# should climatologies be performed with ncclimo or with xarray/dask
+useNcclimo = True
+
 # should remapping be performed with ncremap or with the Remapper class
 # directly in MPAS-Analysis
 useNcremap = True

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -162,6 +162,10 @@ class AnalysisTask(Process):  # {{{
         self._runStatus = Value('i', AnalysisTask.UNSET)
         self._stackTrace = None
         self._logFileName = None
+
+        # the number of subprocesses run by this process, typically 1 but
+        # could be 12 for ncclimo in bck mode
+        self.subprocessCount = 1
         # }}}
 
     def setup_and_check(self):  # {{{

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -101,7 +101,7 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
             taskName = 'mpasClimatology{}'.format(suffix)
 
         self.allVariables = None
-        self.useNcclimo = self.config.getboolean('climatology', 'useNcclimo')
+        self.useNcclimo = config.getboolean('climatology', 'useNcclimo')
 
         # call the constructor from the base class (AnalysisTask)
         super(MpasClimatologyTask, self).__init__(
@@ -109,6 +109,10 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
             taskName=taskName,
             componentName=componentName,
             tags=tags)
+
+        if self.useNcclimo and \
+                (config.get('execute', 'ncclimoParallelMode') == 'bck'):
+            self.subprocessCount = 12
 
         # }}}
 

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -37,18 +37,14 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
     Attributes
     ----------
 
-    variableList : list of str
-        A list of variable names in ``timeSeriesStatsMonthly`` to be
-        included in the climatologies
+    variableList : dict of lists
+        A dictionary with seasons as keys and a list of variable names in
+        ``timeSeriesStatsMonthly`` to be included in the climatologies for each
+        season in the values.
 
     allVariables : list of str
         A list of all available variable names in ``timeSeriesStatsMonthly``
         used to raise an exception when an unavailable variable is requested
-
-    seasons : list of str
-        A list of seasons (keys in ``shared.constants.monthDictionary``)
-        over which the climatology should be computed or ``[]`` if only
-        monthly climatologies are needed.
 
     inputFiles : list of str
         A list of input files used to compute the climatologies.
@@ -87,8 +83,7 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         # -------
         # Xylar Asay-Davis
 
-        self.variableList = []
-        self.seasons = []
+        self.variableList = {}
 
         tags = ['climatology']
 
@@ -106,6 +101,7 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
             taskName = 'mpasClimatology{}'.format(suffix)
 
         self.allVariables = None
+        self.useNcclimo = self.config.getboolean('climatology', 'useNcclimo')
 
         # call the constructor from the base class (AnalysisTask)
         super(MpasClimatologyTask, self).__init__(
@@ -151,20 +147,20 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
                              'or add_variables() is being called in the wrong '
                              'place.')
 
+        if seasons is None:
+            seasons = list(constants.abrevMonthNames)
+
         for variable in variableList:
             if variable not in self.allVariables:
                 raise ValueError(
                     '{} is not available in timeSeriesStatsMonthly '
                     'output:\n{}'.format(variable, self.allVariables))
 
-            if variable not in self.variableList:
-                self.variableList.append(variable)
-
-        if seasons is not None:
             for season in seasons:
-                if season not in self.seasons:
-                    self.seasons.append(season)
-
+                if season not in self.variableList:
+                    self.variableList[season] = []
+                if variable not in self.variableList[season]:
+                    self.variableList[season].append(variable)
         # }}}
 
     def setup_and_check(self):  # {{{
@@ -225,7 +221,7 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         # -------
         # Xylar Asay-Davis
 
-        if len(self.variableList) == 0:
+        if len(self.variableList.keys()) == 0:
             # nothing to do
             return
 
@@ -234,8 +230,12 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
                              os.path.basename(self.inputFiles[0]),
                              os.path.basename(self.inputFiles[-1])))
 
-        seasonsToCheck = list(constants.abrevMonthNames)
-        for season in self.seasons:
+        if self.useNcclimo:
+            seasonsToCheck = list(constants.abrevMonthNames)
+        else:
+            seasonsToCheck = []
+
+        for season in self.variableList:
             if season not in seasonsToCheck:
                 seasonsToCheck.append(season)
 
@@ -251,18 +251,25 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
                 break
 
         if allExist:
-            # make sure all the necessary variables are also present
-            ds = xarray.open_dataset(self.get_file_name(seasonsToCheck[0]))
-
-            for variableName in self.variableList:
-                if variableName not in ds.variables:
-                    allExist = False
-                    break
+            for season in seasonsToCheck:
+                if season not in self.variableList:
+                    continue
+                # make sure all the necessary variables are also present
+                with xarray.open_dataset(self.get_file_name(season)) as ds:
+                    for variableName in self.variableList[season]:
+                        if variableName not in ds.variables:
+                            allExist = False
+                            break
 
         if not allExist:
-            self._compute_climatologies_with_ncclimo(
-                inDirectory=self.symlinkDirectory,
-                outDirectory=climatologyDirectory)
+            if self.useNcclimo:
+                self._compute_climatologies_with_ncclimo(
+                    inDirectory=self.symlinkDirectory,
+                    outDirectory=climatologyDirectory)
+            else:
+                self._compute_climatologies_with_xarray(
+                    inDirectory=self.symlinkDirectory,
+                    outDirectory=climatologyDirectory)
 
         # }}}
 
@@ -384,11 +391,10 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         ------
         OSError
             If ``ncclimo`` is not in the system path.
-
-        Author
-        ------
-        Xylar Asay-Davis
         '''
+        # Authors
+        # -------
+        # Xylar Asay-Davis
 
         if find_executable('ncclimo') is None:
             raise OSError('ncclimo not found. Make sure the latest nco '
@@ -399,8 +405,15 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
 
         parallelMode = self.config.get('execute', 'ncclimoParallelMode')
 
-        seasons = [season for season in self.seasons
+        seasons = [season for season in self.variableList
                    if season not in constants.abrevMonthNames]
+
+        variableList = []
+        for season in self.variableList:
+            variableList.extend(self.variableList[season])
+
+        # include each variable only once
+        variableList = sorted(list(set(variableList)))
 
         if len(seasons) == 0:
             seasons = ['none']
@@ -411,7 +424,7 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
                 '-a', 'sdd',
                 '-m', self.ncclimoModel,
                 '-p', parallelMode,
-                '-v', ','.join(self.variableList),
+                '-v', ','.join(variableList),
                 '--seasons={}'.format(','.join(seasons)),
                 '-s', '{:04d}'.format(self.startYear),
                 '-e', '{:04d}'.format(self.endYear),
@@ -448,6 +461,26 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
         if process.returncode != 0:
             raise subprocess.CalledProcessError(process.returncode,
                                                 ' '.join(args))
+
+        # }}}
+
+    def _compute_climatologies_with_xarray(self, inDirectory, outDirectory):
+        # {{{
+        '''
+        Uses xarray to compute seasonal and/or annual climatologies.
+
+        Parameters
+        ----------
+        inDirectory : str
+            The run directory containing timeSeriesStatsMonthly output
+
+        outDirectory : str
+            The output directory where climatologies will be written
+        '''
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+        pass
 
         # }}}
     # }}}

--- a/mpas_analysis/shared/grid/grid.py
+++ b/mpas_analysis/shared/grid/grid.py
@@ -726,7 +726,7 @@ class ProjectionGridDescriptor(MeshDescriptor):  # {{{
         # Xylar Asay-Davis
 
         Lon, Lat = pyproj.transform(self.projection, self.latLonProjection,
-                                    X, Y, radians=False)
+                                    X, Y)
 
         return (Lat, Lon)  # }}}
 

--- a/mpas_analysis/shared/plot/plotting.py
+++ b/mpas_analysis/shared/plot/plotting.py
@@ -28,7 +28,7 @@ import matplotlib.colors as cols
 import xarray as xr
 import pandas as pd
 from mpl_toolkits.basemap import Basemap
-from mpl_toolkits.basemap import addcyclic
+# from mpl_toolkits.basemap import addcyclic
 from matplotlib.ticker import FuncFormatter, FixedLocator
 import numpy as np
 from functools import partial
@@ -2147,6 +2147,55 @@ def plot_xtick_format(calendar, minDays, maxDays, maxXTicks, yearStride=None):
     plt.setp(ax.get_xticklabels(), rotation=30)
 
     plt.autoscale(enable=True, axis='x', tight=True)
+
+
+# function copied from basemap because the latest version of this funciton
+# is buggy but no new release seems imminent
+def addcyclic(*arr, **kwargs):
+    """
+    Adds cyclic (wraparound) points in longitude to one or several arrays,
+    the last array being longitudes in degrees. e.g.
+   ``data1out, data2out, lonsout = addcyclic(data1,data2,lons)``
+    ==============   ====================================================
+    Keywords         Description
+    ==============   ====================================================
+    axis             the dimension representing longitude (default -1,
+                     or right-most)
+    cyclic           width of periodic domain (default 360)
+    ==============   ====================================================
+    """
+    # get (default) keyword arguments
+    axis = kwargs.get('axis', -1)
+    cyclic = kwargs.get('cyclic', 360)
+    # define functions
+
+    def _addcyclic(a):
+        """addcyclic function for a single data array"""
+        npsel = np.ma if np.ma.is_masked(a) else np
+        slicer = [slice(None)] * np.ndim(a)
+        try:
+            slicer[axis] = slice(0, 1)
+        except IndexError:
+            raise ValueError('The specified axis does not correspond to an '
+                             'array dimension.')
+        return npsel.concatenate((a, a[slicer]), axis=axis)
+
+    def _addcyclic_lon(a):
+        """addcyclic function for a single longitude array"""
+        # select the right numpy functions
+        npsel = np.ma if np.ma.is_masked(a) else np
+        # get cyclic longitudes
+        clon = (np.take(a, [0], axis=axis)
+                + cyclic * np.sign(np.diff(np.take(a, [0, -1], axis=axis),
+                                           axis=axis)))
+        # ensure the values do not exceed cyclic
+        clonmod = npsel.where(clon <= cyclic, clon, np.mod(clon, cyclic))
+        return npsel.concatenate((a, clonmod), axis=axis)
+    # process array(s)
+    if len(arr) == 1:
+        return _addcyclic_lon(arr[-1])
+    else:
+        return list(map(_addcyclic, arr[:-1])) + [_addcyclic_lon(arr[-1])]
 
 
 def _setup_colormap_and_norm(config, configSectionName, suffix=''):

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -66,7 +66,7 @@ class TestMpasClimatologyTask(TestCase):
             tags=['climatology'])
         climatologyName = 'ssh'
         variableList = ['timeMonthly_avg_ssh']
-        seasons = [mpasClimatologyTask.seasons[0]]
+        seasons = list(mpasClimatologyTask.variableList.keys())
 
         remapSubtask = RemapMpasClimatologySubtask(
             mpasClimatologyTask, parentTask, climatologyName,
@@ -87,8 +87,9 @@ class TestMpasClimatologyTask(TestCase):
         mpasClimatologyTask = self.setup_task()
         variableList, seasons = self.add_variables(mpasClimatologyTask)
 
-        assert(variableList == mpasClimatologyTask.variableList)
-        assert(seasons == mpasClimatologyTask.seasons)
+        assert(sorted(seasons) ==
+               sorted(list(mpasClimatologyTask.variableList.keys())))
+        assert(variableList == mpasClimatologyTask.variableList[seasons[0]])
 
         # add a variable and season already in the list
         mpasClimatologyTask.add_variables(variableList=[variableList[0]],
@@ -96,8 +97,9 @@ class TestMpasClimatologyTask(TestCase):
 
         # make sure the lists still match (extra redundant varible and season
         # weren't added)
-        assert(variableList == mpasClimatologyTask.variableList)
-        assert(seasons == mpasClimatologyTask.seasons)
+        assert(sorted(seasons) ==
+               sorted(list(mpasClimatologyTask.variableList.keys())))
+        assert(variableList == mpasClimatologyTask.variableList[seasons[-1]])
 
     def test_get_file_name(self):
         mpasClimatologyTask = self.setup_task()
@@ -119,7 +121,7 @@ class TestMpasClimatologyTask(TestCase):
 
         mpasClimatologyTask.run(writeLogFile=False)
 
-        for season in mpasClimatologyTask.seasons:
+        for season in mpasClimatologyTask.variableList:
             fileName = mpasClimatologyTask.get_file_name(season=season)
             assert(os.path.exists(fileName))
 

--- a/mpas_analysis/test/test_mpas_climatology_task/config.QU240
+++ b/mpas_analysis/test/test_mpas_climatology_task/config.QU240
@@ -30,5 +30,6 @@ endYear = 2
 comparisonLatResolution = 0.5
 comparisonLonResolution = 0.5
 mpasInterpolationMethod = bilinear
+useNcclimo = True
 useNcremap = True
 renormalizationThreshold = 0.01

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(name='mpas_analysis',
       install_requires=['numpy', 'scipy', 'matplotlib', 'netCDF4', 'xarray',
                         'dask', 'bottleneck', 'basemap', 'lxml',
                         'pyproj', 'pillow', 'cmocean', 'progressbar2',
-                        'requests'],
+                        'requests', 'shapely'],
       entry_points={'console_scripts':
                     ['mpas_analysis = mpas_analysis.__main__:main',
                      'download_analysis_data = '


### PR DESCRIPTION
This requires each task to know how many subprocesses it has (1 for most tasks, 12 for ncclimo tasks).  In the future, tasks can also use `dask` or other methods to run multiple threads and the subprocess count can reflect this.

This should also prevent `ncclimo` from trying to run 12 threads while other tasks are running unless more than 12 parallel tasks are allowed via `parallelTaskCount`.