### PR TITLE
Optionally compute climatologies with xarray/dask

### DIFF
--- a/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
+++ b/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
@@ -51,13 +51,13 @@ baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_3/azamatm/E3SM_simulations
 mpasMeshName = oRRS18to6v3
 
 # names of namelist and streams files, either a path relative to baseDirectory
-# or an absolute path. 
+# or an absolute path.
 
 # NOTE: these are the NEW / correct file names, commented out here because this sample config points to a run using an older version of the code.
-# Specifically, the run this points to uses hash = c133017ece33ad10715d98685137ddbffe7b0cb8 
+# Specifically, the run this points to uses hash = c133017ece33ad10715d98685137ddbffe7b0cb8
 # (github branch `theta/hr-prod/initial` https://github.com/E3SM-Project/E3SM/tree/theta/hr-prod/initial)
-# When pointing to a run conducted with the most recent branch of the code, the first 4 lines here should be made active and the latter 4 deleted 
-#oceanNamelistFileName = mpaso_in	
+# When pointing to a run conducted with the most recent branch of the code, the first 4 lines here should be made active and the latter 4 deleted
+#oceanNamelistFileName = mpaso_in
 #oceanStreamsFileName = streams.ocean
 #seaIceNamelistFileName = mpassi_in
 #seaIceStreamsFileName = streams.seaice
@@ -101,6 +101,9 @@ generate = ['all', 'no_eke', 'no_BGC', 'no_icebergs', 'no_timeSeriesAntarcticMel
 [climatology]
 ## options related to producing climatologies, typically to compare against
 ## observations and previous runs
+
+# should climatologies be performed with ncclimo or with xarray/dask
+useNcclimo = False
 
 # the first year over which to average climatalogies
 startYear = 25

--- a/configs/alcf/config.20190301.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta
+++ b/configs/alcf/config.20190301.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta
@@ -93,6 +93,9 @@ generate = ['all', 'no_eke', 'no_BGC', 'no_icebergs']
 ## options related to producing climatologies, typically to compare against
 ## observations and previous runs
 
+# should climatologies be performed with ncclimo or with xarray/dask
+useNcclimo = False
+
 # the first year over which to average climatalogies
 startYear = 1
 # the last year over which to average climatalogies

--- a/configs/alcf/job_script.cooley.30to10.bash
+++ b/configs/alcf/job_script.cooley.30to10.bash
@@ -23,10 +23,10 @@ run_config_file="config.20190301.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta"
 # NOTE: the following section will OVERWRITE values specified within the config file named above
 
 # one parallel task per node by default
-parallel_task_count=8
+parallel_task_count=12
 
 # ncclimo can run with 1 (serial) or 12 (bck) threads
-ncclimo_mode=bck      
+ncclimo_mode=bck
 
 if [ ! -f $run_config_file ]; then
     echo "File $run_config_file not found!"

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -33,6 +33,7 @@ from collections import OrderedDict
 import progressbar
 import logging
 import xarray
+import time
 
 from mpas_analysis.shared.analysis_task import AnalysisFormatter
 
@@ -807,11 +808,22 @@ def main():
         # xarray version doesn't support file_cache_maxsize yet...
         pass
 
+    startTime = time.time()
+
     analyses = build_analysis_list(config, controlConfig)
     analyses = determine_analyses_to_generate(analyses, args.verbose)
 
+    setupDuration = time.time() - startTime
+
     if not args.setup_only and not args.html_only:
         run_analysis(config, analyses)
+        runDuration = time.time() - startTime
+        m, s = divmod(setupDuration, 60)
+        h, m = divmod(int(m), 60)
+        print('Total setup time: {}:{:02d}:{:05.2f}'.format(h, m, s))
+        m, s = divmod(runDuration, 60)
+        h, m = divmod(int(m), 60)
+        print('Total run time: {}:{:02d}:{:05.2f}'.format(h, m, s))
 
     if not args.setup_only:
         generate_html(config, analyses, controlConfig)

--- a/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
+++ b/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
@@ -318,7 +318,8 @@ class RemapMpasOHCClimatology(RemapMpasClimatologySubtask):  # {{{
         ohc = self._compute_ohc(climatology)
         refFileName = self.refYearClimatolgyTask.get_file_name(season)
         refYearClimo = xarray.open_dataset(refFileName)
-        refYearClimo = refYearClimo.isel(Time=0)
+        if 'Time' in refYearClimo.dims:
+            refYearClimo = refYearClimo.isel(Time=0)
         refOHC = self._compute_ohc(refYearClimo)
 
         climatology['deltaOHC'] = ohc - refOHC

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -251,7 +251,8 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             annualClimatology = xr.open_dataset(climatologyFileName)
             annualClimatology = subset_variables(annualClimatology,
                                                  variableList)
-            annualClimatology = annualClimatology.isel(Time=0)
+            if 'Time' in annualClimatology.dims:
+                annualClimatology = annualClimatology.isel(Time=0)
 
             annualClimatology.coords['refZMid'] = (('nVertLevels',), refZMid)
             annualClimatology.coords['binBoundaryMerHeatTrans'] = \

--- a/mpas_analysis/ocean/sose_transects.py
+++ b/mpas_analysis/ocean/sose_transects.py
@@ -337,6 +337,12 @@ class SoseTransectsObservations(TransectsObservations):  # {{{
                            observationsDirectory, prefix)
 
             dsLocal = xr.open_dataset(fileName)
+
+            lat = dsLocal.lat.values
+            mask = numpy.logical_and(lat >= minLat, lat <= maxLat)
+            indices = numpy.argwhere(mask)
+            dsLocal = dsLocal.isel(lat=slice(indices[0][0],
+                                             indices[-1][0]))
             dsLocal.load()
 
             if fieldName == 'zonalVel':
@@ -353,11 +359,6 @@ class SoseTransectsObservations(TransectsObservations):  # {{{
 
             dsLocal = dsLocal.sel(lon=longitudes, method=str('nearest'))
 
-            lat = dsLocal.lat.values
-            mask = numpy.logical_and(lat >= minLat, lat <= maxLat)
-            indices = numpy.argwhere(mask)
-            dsLocal = dsLocal.isel(lat=slice(indices[0][0], indices[-1][0]))
-
             if dsObs is None:
                 dsObs = dsLocal
             else:
@@ -368,9 +369,10 @@ class SoseTransectsObservations(TransectsObservations):  # {{{
 
         if 'zonalVel' in dsObs and 'meridVel' in dsObs:
             # compute the velocity magnitude
-            description = 'Monthly velocity magnitude climatologies from ' \
-                          '2005-2010 average of the Southern Ocean State ' \
-                          'Estimate (SOSE)'
+            print('  velMag')
+            description = 'Monthly velocity magnitude climatologies ' \
+                          'from 2005-2010 average of the Southern Ocean ' \
+                          'State Estimate (SOSE)'
             dsObs['velMag'] = numpy.sqrt(
                 dsObs.zonalVel**2 + dsObs.meridVel**2)
             dsObs.velMag.attrs['units'] = 'm s$^{-1}$'

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -296,7 +296,8 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
         climatologyFileName = self.mpasClimatologyTask.get_file_name(
             season='ANN')
         annualClimatology = xr.open_dataset(climatologyFileName)
-        annualClimatology = annualClimatology.isel(Time=0)
+        if 'Time' in annualClimatology.dims:
+            annualClimatology = annualClimatology.isel(Time=0)
 
         # rename some variables for convenience
         annualClimatology = annualClimatology.rename(
@@ -397,7 +398,8 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
         climatologyFileName = self.mpasClimatologyTask.get_file_name(
             season='ANN')
         annualClimatology = xr.open_dataset(climatologyFileName)
-        annualClimatology = annualClimatology.isel(Time=0)
+        if 'Time' in annualClimatology.dims:
+            annualClimatology = annualClimatology.isel(Time=0)
 
         if self.includeBolus:
             annualClimatology['avgNormalVelocity'] = \

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -520,12 +520,15 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
             climatology = xr.open_dataset(climatologyFileName)
             climatology = mpas_xarray.subset_variables(climatology,
                                                        self.variableList)
-            iselValues = {'Time': 0}
+            iselValues = {}
+            if 'Time' in climatology.dims:
+                iselValues['Time'] = 0
             if self.iselValues is not None:
                 iselValues.update(self.iselValues)
             # select only Time=0 and possibly only the desired vertical
             # slice
-            climatology = climatology.isel(**iselValues)
+            if len(iselValues.keys()) > 0:
+                climatology = climatology.isel(**iselValues)
 
             # add valid mask as a variable, useful for remapping later
             climatology['validMask'] = \

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -31,6 +31,7 @@ from mpas_analysis.shared.analysis_task import \
     update_time_bounds_from_file_names
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories
+from mpas_analysis.shared.constants import constants
 
 
 @pytest.mark.usefixtures("loaddatadir")
@@ -83,23 +84,33 @@ class TestMpasClimatologyTask(TestCase):
 
         return variableList, seasons
 
+    def verify_variables_for_season(self, mpasClimatologyTask, variableList,
+                                    season):
+        assert(season in mpasClimatologyTask.variableList.keys())
+        monthValues = constants.monthDictionary[season]
+        monthNames = [constants.abrevMonthNames[month-1] for month in
+                      monthValues]
+        assert(variableList == mpasClimatologyTask.variableList[season])
+        for monthName in monthNames:
+            assert(monthName in mpasClimatologyTask.variableList.keys())
+            assert(variableList ==
+                   mpasClimatologyTask.variableList[monthName])
+
     def test_add_variables(self):
         mpasClimatologyTask = self.setup_task()
         variableList, seasons = self.add_variables(mpasClimatologyTask)
 
-        assert(sorted(seasons) ==
-               sorted(list(mpasClimatologyTask.variableList.keys())))
-        assert(variableList == mpasClimatologyTask.variableList[seasons[0]])
+        for season in seasons:
+            self.verify_variables_for_season(mpasClimatologyTask, variableList,
+                                             season)
 
         # add a variable and season already in the list
         mpasClimatologyTask.add_variables(variableList=[variableList[0]],
                                           seasons=[seasons[-1]])
 
-        # make sure the lists still match (extra redundant varible and season
-        # weren't added)
-        assert(sorted(seasons) ==
-               sorted(list(mpasClimatologyTask.variableList.keys())))
-        assert(variableList == mpasClimatologyTask.variableList[seasons[-1]])
+        for season in seasons:
+            self.verify_variables_for_season(mpasClimatologyTask, variableList,
+                                             season)
 
     def test_get_file_name(self):
         mpasClimatologyTask = self.setup_task()


### PR DESCRIPTION
...instead of `ncclimo`.

The files produced with `xarray`/`dask` drop the `Time` dimension so various subsequent calls that drop the time dimension are no longer needed (except when `ncclimo` is still used).

set the config option
```
[climatology]
useNcclimo = False
```
to use xarray for climatologies.

This PR also reorganizes the way the SOSE transects are preprocessed (so that mapping files can be created for interpolating them).  With the reorganization, preprocessing is faster and uses significantly less memory.