### PR TITLE
Add ncremap support to climatology depth slices and transects

### DIFF
--- a/mpas_analysis/ocean/compute_transects_subtask.py
+++ b/mpas_analysis/ocean/compute_transects_subtask.py
@@ -143,7 +143,7 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):  # {{{
         super(ComputeTransectsSubtask, self).__init__(
             mpasClimatologyTask, parentTask,
             climatologyName=climatologyName, variableList=variableList,
-            seasons=seasons, subtaskName=subtaskName, useNcremap=False)
+            seasons=seasons, subtaskName=subtaskName)
 
         self.obsDatasets = obsDatasets
         self.transectCollectionName = transectCollectionName
@@ -300,6 +300,8 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):  # {{{
 
         climatology['zMid'] = self.zMid
 
+        climatology = climatology.transpose('nVertLevels', 'nCells')
+
         return climatology  # }}}
 
     def customize_remapped_climatology(self, climatology, comparisonGridNames,
@@ -331,6 +333,14 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):  # {{{
         climatology['transectNumber'] = self.transectNumber
 
         climatology['x'] = self.x
+
+        if 'nCells' in climatology.dims:
+            climatology = climatology.rename({'nCells': 'nPoints'})
+
+        dims = ['nPoints', 'nVertLevels']
+        if 'nv' in climatology.dims:
+            dims.append('nv')
+        climatology = climatology.transpose(*dims)
 
         return climatology  # }}}
 

--- a/mpas_analysis/ocean/remap_depth_slices_subtask.py
+++ b/mpas_analysis/ocean/remap_depth_slices_subtask.py
@@ -94,7 +94,7 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):  # {{{
         # (RemapMpasClimatologySubtask)
         super(RemapDepthSlicesSubtask, self).__init__(
             mpasClimatologyTask, parentTask, climatologyName, variableList,
-            seasons, comparisonGridNames, iselValues, useNcremap=False)
+            seasons, comparisonGridNames, iselValues)
 
     def run_task(self):  # {{{
         """
@@ -224,6 +224,8 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):  # {{{
                 da.sum(dim='nVertLevels').where(self.verticalIndexMask)
 
         climatology = climatology.drop('verticalIndex')
+
+        climatology = climatology.transpose('depthSlice', 'nCells')
 
         return climatology  # }}}
 


### PR DESCRIPTION
This just requires transposing (and then transposing back) `nCells` and `nVertLevels` in both cases.

With this update, we can use `ncremap` for all the remapping rather than having special cases that are handled by the internal python remapper.  `ncremap` is expected to be faster and adds a bit more metadata.

closes #524 