### PR TITLE
Set gallery thumbnail sizes

### DIFF
--- a/mpas_analysis/shared/html/image_xml.py
+++ b/mpas_analysis/shared/html/image_xml.py
@@ -132,11 +132,15 @@ def write_image_xml(config, filePrefix, componentName, componentSubdirectory,
         shutil.copyfile('{}/{}'.format(plotsDirectory, imageFileName),
                         '{}/{}'.format(componentDirectory, imageFileName))
 
-        imageSize, orientation = _generate_thumbnails(imageFileName,
-                                                      componentDirectory)
+        imageSize, thumbnailSize, orientation = _generate_thumbnails(
+            imageFileName, componentDirectory)
 
-        etree.SubElement(root, "imageSize").text = \
-            '{}x{}'.format(imageSize[0], imageSize[1])
+        etree.SubElement(root, "imageSize").text = '{}x{}'.format(imageSize[0],
+                                                                  imageSize[1])
+        etree.SubElement(root, "thumbnailWidth").text = '{}'.format(
+            thumbnailSize[0])
+        etree.SubElement(root, "thumbnailHeight").text = '{}'.format(
+            thumbnailSize[1])
         etree.SubElement(root, "orientation").text = orientation
 
     _provenance_command(root, history)
@@ -207,8 +211,8 @@ def _generate_thumbnails(imageFileName, directory):
 
     # first, make a thumbnail with the same aspect ratio
     factor = image.size[1] / float(thumbnailHeight)
-    size = [int(dim / factor + 0.5) for dim in image.size]
-    thumbnail = image.resize(size, Image.ANTIALIAS)
+    thumbnailSize = [int(dim / factor + 0.5) for dim in image.size]
+    thumbnail = image.resize(thumbnailSize, Image.ANTIALIAS)
     thumbnail.save('{}/{}'.format(thumbnailDir, imageFileName))
 
     # second, make a thumbnail with a fixed size
@@ -232,7 +236,7 @@ def _generate_thumbnails(imageFileName, directory):
 
     thumbnail.save('{}/fixed_{}'.format(thumbnailDir, imageFileName))
 
-    return imageSize, orientation
+    return imageSize, thumbnailSize, orientation
 
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/html/image_xml.py
+++ b/mpas_analysis/shared/html/image_xml.py
@@ -204,10 +204,10 @@ def _generate_thumbnails(imageFileName, directory):
 
     if imageSize[0] < imageSize[1]:
         orientation = 'vert'
-        thumbnailHeight = 480
+        thumbnailHeight = 320
     else:
         orientation = 'horiz'
-        thumbnailHeight = 180
+        thumbnailHeight = 120
 
     # first, make a thumbnail with the same aspect ratio
     factor = image.size[1] / float(thumbnailHeight)

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -409,7 +409,8 @@ class ComponentPage(object):
         images[imageFileName] = OrderedDict()
         image = images[imageFileName]
         for tag in ['thumbnailDescription', 'imageDescription',
-                    'imageCaption', 'imageSize', 'orientation']:
+                    'imageCaption', 'imageSize', 'thumbnailWidth',
+                    'thumbnailHeight', 'orientation']:
             node = xmlRoot.find(tag)
             if node is None or node.text is None:
                 image[tag] = ''
@@ -490,7 +491,8 @@ class ComponentPage(object):
         """fill in the template for a given image with the desired content"""
         replacements = {'@imageFileName': imageFileName}
         for tag in ['imageSize', 'imageDescription', 'imageCaption',
-                    'thumbnailDescription', 'orientation']:
+                    'thumbnailDescription', 'orientation', 'thumbnailWidth',
+                    'thumbnailHeight']:
             replacements['@{}'.format(tag)] = imageDict[tag]
 
         imageText = _replace_tempate_text(self.templates['image'],

--- a/mpas_analysis/shared/html/templates/component_gallery.html
+++ b/mpas_analysis/shared/html/templates/component_gallery.html
@@ -1,18 +1,3 @@
-<!--
-  - This software is open source software available under the BSD-3 license.
-  -
-  - Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
-  - Copyright (c) 2019 Lawrence Livermore National Security, LLC. All rights
-  - reserved.
-  - Copyright (c) 2019 UT-Battelle, LLC. All rights reserved.
-  -
-  - Additional copyright and license information can be found in the LICENSE
-  - file distributed with this code, or at
-  - https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-  -->
-
-
-
 
 @galleryTitle
 

--- a/mpas_analysis/shared/html/templates/component_group.html
+++ b/mpas_analysis/shared/html/templates/component_group.html
@@ -1,18 +1,3 @@
-<!--
-  - This software is open source software available under the BSD-3 license.
-  -
-  - Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
-  - Copyright (c) 2019 Lawrence Livermore National Security, LLC. All rights
-  - reserved.
-  - Copyright (c) 2019 UT-Battelle, LLC. All rights reserved.
-  -
-  - Additional copyright and license information can be found in the LICENSE
-  - file distributed with this code, or at
-  - https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-  -->
-
-
-
 
     <div class="gallery-title">
       <h2><a name="@analysisGroupLink"></a>@analysisGroupName</h2>

--- a/mpas_analysis/shared/html/templates/component_image.html
+++ b/mpas_analysis/shared/html/templates/component_image.html
@@ -1,7 +1,7 @@
 
       <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
         <a href="@imageFileName" itemprop="contentUrl" data-size="@imageSize">
-            <img class="@orientation" src="thumbnails/@imageFileName" itemprop="thumbnail" alt="@imageDescription" />
+            <img class="@orientation" src="thumbnails/@imageFileName" itemprop="thumbnail" alt="@imageDescription" width="@thumbnailWidth" height="@thumbnailHeight"/>
         </a>
         <figcaption itemprop="caption description">@imageCaption</figcaption>
         <div class="desc-small">@thumbnailDescription</div>

--- a/mpas_analysis/shared/html/templates/component_image.html
+++ b/mpas_analysis/shared/html/templates/component_image.html
@@ -1,18 +1,3 @@
-<!--
-  - This software is open source software available under the BSD-3 license.
-  -
-  - Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
-  - Copyright (c) 2019 Lawrence Livermore National Security, LLC. All rights
-  - reserved.
-  - Copyright (c) 2019 UT-Battelle, LLC. All rights reserved.
-  -
-  - Additional copyright and license information can be found in the LICENSE
-  - file distributed with this code, or at
-  - https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-  -->
-
-
-
 
       <figure itemprop="associatedMedia" itemscope itemtype="http://schema.org/ImageObject">
         <a href="@imageFileName" itemprop="contentUrl" data-size="@imageSize">

--- a/mpas_analysis/shared/html/templates/component_page.html
+++ b/mpas_analysis/shared/html/templates/component_page.html
@@ -4,32 +4,6 @@
   <meta charset="UTF-8">
   <title>@componentName Analysis</title>
 
-<!--
-Based on an example by Dmitry Semenov with the following license:
-
-Copyright (c) 2017 by Dmitry Semenov (https://codepen.io/dimsemenov/pen/ZYbPJM)
-
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
--->
-
-
 <link rel='stylesheet prefetch' href='https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/photoswipe.min.css'>
 <link rel='stylesheet prefetch' href='https://cdnjs.cloudflare.com/ajax/libs/photoswipe/4.1.1/default-skin/default-skin.min.css'>
 <link rel="stylesheet" href="../css/style.css">

--- a/mpas_analysis/shared/html/templates/component_quicklink.html
+++ b/mpas_analysis/shared/html/templates/component_quicklink.html
@@ -1,18 +1,3 @@
-<!--
-  - This software is open source software available under the BSD-3 license.
-  -
-  - Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
-  - Copyright (c) 2019 Lawrence Livermore National Security, LLC. All rights
-  - reserved.
-  - Copyright (c) 2019 UT-Battelle, LLC. All rights reserved.
-  -
-  - Additional copyright and license information can be found in the LICENSE
-  - file distributed with this code, or at
-  - https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-  -->
-
-
-
 
     <div class="gallery-link small">
       <a href="#@analysisGroupLink">

--- a/mpas_analysis/shared/html/templates/component_subtitle.html
+++ b/mpas_analysis/shared/html/templates/component_subtitle.html
@@ -1,17 +1,2 @@
-<!--
-  - This software is open source software available under the BSD-3 license.
-  -
-  - Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
-  - Copyright (c) 2019 Lawrence Livermore National Security, LLC. All rights
-  - reserved.
-  - Copyright (c) 2019 UT-Battelle, LLC. All rights reserved.
-  -
-  - Additional copyright and license information can be found in the LICENSE
-  - file distributed with this code, or at
-  - https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-  -->
-
-
-
 
       <h3>@subtitle</h3>

--- a/mpas_analysis/shared/html/templates/index.js
+++ b/mpas_analysis/shared/html/templates/index.js
@@ -1,18 +1,3 @@
-/*
-/ This software is open source software available under the BSD-3 license.
-/
-/ Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
-/ Copyright (c) 2019 Lawrence Livermore National Security, LLC. All rights
-/ reserved.
-/ Copyright (c) 2019 UT-Battelle, LLC. All rights reserved.
-/
-/ Additional copyright and license information can be found in the LICENSE file
-/ distributed with this code, or at
-/ https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-/ */
-
-
-
 
 var initPhotoSwipeFromDOM = function(gallerySelector) {
 

--- a/mpas_analysis/shared/html/templates/main_component.html
+++ b/mpas_analysis/shared/html/templates/main_component.html
@@ -1,18 +1,3 @@
-<!--
-  - This software is open source software available under the BSD-3 license.
-  -
-  - Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
-  - Copyright (c) 2019 Lawrence Livermore National Security, LLC. All rights
-  - reserved.
-  - Copyright (c) 2019 UT-Battelle, LLC. All rights reserved.
-  -
-  - Additional copyright and license information can be found in the LICENSE
-  - file distributed with this code, or at
-  - https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-  -->
-
-
-
 
     <div class="gallery-link component">
       <a target="_blank" href="@componentDir/index.html">

--- a/mpas_analysis/shared/html/templates/main_page.html
+++ b/mpas_analysis/shared/html/templates/main_page.html
@@ -1,18 +1,3 @@
-<!--
-  - This software is open source software available under the BSD-3 license.
-  -
-  - Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
-  - Copyright (c) 2019 Lawrence Livermore National Security, LLC. All rights
-  - reserved.
-  - Copyright (c) 2019 UT-Battelle, LLC. All rights reserved.
-  -
-  - Additional copyright and license information can be found in the LICENSE
-  - file distributed with this code, or at
-  - https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-  -->
-
-
-
 
 <!DOCTYPE html>
 <html >

--- a/mpas_analysis/shared/html/templates/style.css
+++ b/mpas_analysis/shared/html/templates/style.css
@@ -124,7 +124,6 @@ div.desc-small {
 }
 
 img.horiz {
-    width: auto;
     height: 120px;
 }
 
@@ -134,7 +133,6 @@ div.horiz {
 }
 
 img.vert {
-    width: auto;
     height: 320px;
 }
 


### PR DESCRIPTION
This should help with smoother loading of the very large ocean pages because thumbnail sizes are known even before they load.

Also, remove license headers from HTML templates -- they aren't useful.

closes #558