### PR TITLE
Add MPAS-Analysis version and git hashtag to webpage

### DIFF
--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -17,7 +17,10 @@ from os import makedirs
 from shutil import copyfile
 from lxml import etree
 from collections import OrderedDict
+import subprocess
+import os
 
+import mpas_analysis
 from mpas_analysis.shared.io.utility import build_config_full_path
 
 
@@ -201,9 +204,17 @@ class MainPage(object):
             componentsText = componentsText + \
                 _replace_tempate_text(self.componentTemplate, replacements)
 
+        githash = _get_git_hash()
+        if githash is None:
+            githash = ''
+        else:
+            githash = 'Git Hash: {}'.format(githash)
+
         replacements = {'@runName': runName,
                         '@controlRunText': controlRunText,
-                        '@components': componentsText}
+                        '@components': componentsText,
+                        '@version': mpas_analysis.__version__,
+                        '@gitHash': githash}
 
         pageText = _replace_tempate_text(self.pageTemplate, replacements)
 
@@ -579,3 +590,21 @@ def _replace_tempate_text(template, replacements):
     for src, target in replacements.items():
         output = output.replace(src, target)
     return output
+
+
+def _get_git_hash():
+    """
+    get the hashtag of the git commit (if any) that MPAS-Analysis is being run
+    from
+    """
+    with open(os.devnull, 'w') as devnull:
+        try:
+            githash = subprocess.check_output(['git', 'log',
+                                               '--pretty=format:"%h"',
+                                               '-n', '1'],
+                                              stderr=devnull)
+        except subprocess.CalledProcessError:
+            return None
+
+    githash = githash.decode('utf-8').strip('\n').replace('"', '')
+    return githash

--- a/mpas_analysis/shared/html/templates/main_page.html
+++ b/mpas_analysis/shared/html/templates/main_page.html
@@ -43,7 +43,13 @@
 @components
 
     <div class="provenance-title">
-    <h2>Provenance: MPAS-Analysis Configuration File</h2>
+    <h2>Provenance</h2>
+
+    <p>MPAS-Analysis version: @version</p>
+
+    <p>@gitHash</p>
+
+    <h3>MPAS-Analysis Configuration File</h3>
     </div>
 
     <div class="gallery-link component">
@@ -52,6 +58,8 @@
       </a>
       <div class="desc">Configuration File</div>
     </div>
+
+
 
 </body>
 </html>


### PR DESCRIPTION
The git hashtag is skipped if not in a github repo.

closes #565 