### PR TITLE
Add subprocessCounts and daskTasks to ocean time series tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ environment with the following packages:
  * bottleneck
  * basemap
  * lxml
- * nco >= 4.7.9
+ * nco = 4.7.9
  * pyproj
  * pillow
  * cmocean
@@ -61,7 +61,7 @@ These can be installed via the conda command:
 ``` bash
 conda config --add channels conda-forge
 conda create -n mpas-analysis numpy scipy matplotlib netCDF4 \
-    xarray dask bottleneck basemap lxml nco pyproj pillow \
+    xarray dask bottleneck basemap lxml nco=4.7.9 pyproj pillow \
     cmocean progressbar2 requests setuptools shapely
 conda activate mpas-analysis
 ```

--- a/ci/requirements.yml
+++ b/ci/requirements.yml
@@ -12,7 +12,7 @@ dependencies:
   - netcdf4
   - hdf5
   - hdf4
-  - nco>=4.7.9
+  - nco=4.7.9
   - pyproj
   - pillow
   - cmocean

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1187,12 +1187,34 @@ movingAverageMonths = 1
 
 # yearStrideXTicks = 1
 
+# the number of threads dask is allowed to spawn for each process computing
+# a year of these time series
+# Decrease this number if timeSeriesAntarcticMelt subtasks are running
+# out of available threads
+daskThreads = 4
+
+# the number of subprocesses that each task gets counted as occupying
+# Increase this number if timeSeriesAntarcticMelt subtasks are running
+# out of memory, and fewer tasks will be allowed to run at once
+subprocessCount = 1
+
 
 [timeSeriesOceanRegions]
 ## options related to plotting time series of groups of ocean regions
 
 # the names of region groups to plot, each with its own section below
 regionGroups = ['Antarctic Regions']
+
+# the number of threads dask is allowed to spawn for each process computing
+# a year of these time series
+# Decrease this number if timeSeriesAntarcticMelt subtasks are running
+# out of available threads
+daskThreads = 12
+
+# the number of subprocesses that each task gets counted as occupying
+# Increase this number if timeSeriesAntarcticMelt subtasks are running
+# out of memory, and fewer tasks will be allowed to run at once
+subprocessCount = 3
 
 
 [timeSeriesAntarcticRegions]

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -317,6 +317,9 @@ class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
                                                      mpasMeshName,
                                                      self.outFileSuffix)
 
+        if os.path.exists(self.maskFileName):
+            # nothing to do so don't block a bunch of other processes
+            self.subprocessCount = 1
         # }}}
 
     def run_task(self):  # {{{
@@ -326,6 +329,9 @@ class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
         # Authors
         # -------
         # Xylar Asay-Davis
+
+        if os.path.exists(self.maskFileName):
+            return
 
         compute_region_masks(self.geojsonFileName, self.restartFileName,
                              self.maskFileName, self.featureList, self.logger,


### PR DESCRIPTION
Use them to limit the number of dask threads and "weight" each task
as couting as more than one subprocess

Update the task for computing region masks to set its subprocessCount
to 1 if the mask is already there (no need to block other work
if there's nothing to do).

closes #577 