### PR TITLE
Fix linking of main and reference directories for a main vs. ref run

### DIFF
--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -675,15 +675,17 @@ def symlink_main_run(config, defaultConfig):
                                                relativePathSection=section)
         if not os.path.exists(destDirectory):
 
-            destBase, _ = os.path.split(destDirectory)
-
-            make_directories(destBase)
-
             sourceDirectory = build_config_full_path(
                 config=mainConfig, section='output',
                 relativePathOption=option, relativePathSection=section)
 
-            os.symlink(sourceDirectory, destDirectory)
+            if os.path.exists(sourceDirectory):
+
+                destBase, _ = os.path.split(destDirectory)
+
+                make_directories(destBase)
+
+                os.symlink(sourceDirectory, destDirectory)
 
     mainConfigFile = config.get('runs', 'mainRunConfigFile')
     if not os.path.exists(mainConfigFile):


### PR DESCRIPTION
Before this fix, if a main vs. ref run was performed with only a subset of the analysiss, the code would attempt to link directories from the main and/or ref runs that didn't exist, causing a crash.  This has been fixed.

closes #568