### PR TITLE
Fix main vs. ctrl bugs

### DIFF
--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -132,11 +132,9 @@ class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
         for comparisonGridName in comparisonGridNames:
             for season in seasons:
                 # make a new subtask for this season and comparison grid
-                subtask = PlotClimatologyMapSubtask(self, season,
-                                                    comparisonGridName,
-                                                    remapClimatologySubtask,
-                                                    remapObservationsSubtask,
-                                                    controlConfig)
+                subtask = PlotClimatologyMapSubtask(
+                    self, season, comparisonGridName, remapClimatologySubtask,
+                    remapObservationsSubtask, controlConfig=controlConfig)
 
                 subtask.set_plot_info(
                     outFileLabel=outFileLabel,

--- a/mpas_analysis/ocean/climatology_map_bgc.py
+++ b/mpas_analysis/ocean/climatology_map_bgc.py
@@ -187,7 +187,8 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
                     subtask = PlotClimatologyMapSubtask(
                         self, season, comparisonGridName,
                         remapClimatologySubtask, remapObservationsSubtask,
-                        controlConfig, subtaskName='plot{}_{}_{}'.format(
+                        controlConfig=controlConfig,
+                        subtaskName='plot{}_{}_{}'.format(
                             fieldName, season, comparisonGridName))
 
                     subtask.set_plot_info(

--- a/mpas_analysis/ocean/climatology_map_eke.py
+++ b/mpas_analysis/ocean/climatology_map_eke.py
@@ -136,11 +136,9 @@ class ClimatologyMapEKE(AnalysisTask):  # {{{
         for comparisonGridName in comparisonGridNames:
             for season in seasons:
                 # make a new subtask for this season and comparison grid
-                subtask = PlotClimatologyMapSubtask(self, season,
-                                                    comparisonGridName,
-                                                    remapClimatologySubtask,
-                                                    remapObservationsSubtask,
-                                                    controlConfig)
+                subtask = PlotClimatologyMapSubtask(
+                    self, season, comparisonGridName, remapClimatologySubtask,
+                    remapObservationsSubtask, controlConfig=controlConfig)
 
                 subtask.set_plot_info(
                     outFileLabel=outFileLabel,

--- a/mpas_analysis/ocean/climatology_map_mld.py
+++ b/mpas_analysis/ocean/climatology_map_mld.py
@@ -16,8 +16,7 @@ import numpy as np
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io.utility import build_config_full_path, \
-    build_obs_path
+from mpas_analysis.shared.io.utility import build_obs_path
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
@@ -130,11 +129,9 @@ class ClimatologyMapMLD(AnalysisTask):  # {{{
         for comparisonGridName in comparisonGridNames:
             for season in seasons:
                 # make a new subtask for this season and comparison grid
-                subtask = PlotClimatologyMapSubtask(self, season,
-                                                    comparisonGridName,
-                                                    remapClimatologySubtask,
-                                                    remapObservationsSubtask,
-                                                    controlConfig)
+                subtask = PlotClimatologyMapSubtask(
+                    self, season, comparisonGridName, remapClimatologySubtask,
+                    remapObservationsSubtask, controlConfig=controlConfig)
 
                 subtask.set_plot_info(
                     outFileLabel=outFileLabel,

--- a/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
+++ b/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
@@ -139,7 +139,7 @@ class ClimatologyMapOHCAnomaly(AnalysisTask):  # {{{
                     subtask = PlotClimatologyMapSubtask(
                         self, season, comparisonGridName,
                         remapClimatologySubtask, remapObservationsSubtask,
-                        controlConfig, subtaskName=subtaskName)
+                        controlConfig=controlConfig, subtaskName=subtaskName)
 
                     subtask.set_plot_info(
                         outFileLabel=outFileLabel,

--- a/mpas_analysis/ocean/climatology_map_ssh.py
+++ b/mpas_analysis/ocean/climatology_map_ssh.py
@@ -130,12 +130,10 @@ class ClimatologyMapSSH(AnalysisTask):  # {{{
         for comparisonGridName in comparisonGridNames:
             for season in seasons:
                 # make a new subtask for this season and comparison grid
-                subtask = PlotClimatologyMapSubtask(self, season,
-                                                    comparisonGridName,
-                                                    remapClimatologySubtask,
-                                                    remapObservationsSubtask,
-                                                    controlConfig,
-                                                    removeMean=True)
+                subtask = PlotClimatologyMapSubtask(
+                    self, season, comparisonGridName, remapClimatologySubtask,
+                    remapObservationsSubtask, controlConfig=controlConfig,
+                    removeMean=True)
 
                 subtask.set_plot_info(
                     outFileLabel=outFileLabel,

--- a/mpas_analysis/ocean/climatology_map_sss.py
+++ b/mpas_analysis/ocean/climatology_map_sss.py
@@ -128,11 +128,9 @@ class ClimatologyMapSSS(AnalysisTask):  # {{{
         for comparisonGridName in comparisonGridNames:
             for season in seasons:
                 # make a new subtask for this season and comparison grid
-                subtask = PlotClimatologyMapSubtask(self, season,
-                                                    comparisonGridName,
-                                                    remapClimatologySubtask,
-                                                    remapObservationsSubtask,
-                                                    controlConfig)
+                subtask = PlotClimatologyMapSubtask(
+                    self, season, comparisonGridName, remapClimatologySubtask,
+                    remapObservationsSubtask, controlConfig=controlConfig)
 
                 subtask.set_plot_info(
                     outFileLabel=outFileLabel,

--- a/mpas_analysis/ocean/climatology_map_sst.py
+++ b/mpas_analysis/ocean/climatology_map_sst.py
@@ -136,11 +136,9 @@ class ClimatologyMapSST(AnalysisTask):  # {{{
         for comparisonGridName in comparisonGridNames:
             for season in seasons:
                 # make a new subtask for this season and comparison grid
-                subtask = PlotClimatologyMapSubtask(self, season,
-                                                    comparisonGridName,
-                                                    remapClimatologySubtask,
-                                                    remapObservationsSubtask,
-                                                    controlConfig)
+                subtask = PlotClimatologyMapSubtask(
+                    self, season, comparisonGridName, remapClimatologySubtask,
+                    remapObservationsSubtask, controlConfig=controlConfig)
 
                 subtask.set_plot_info(
                     outFileLabel=outFileLabel,

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -671,7 +671,8 @@ class PlotRegionTimeSeriesSubtask(AnalysisTask):
             inFileName = '{}/{}/{}_{:04d}-{:04d}.nc'.format(
                 baseDirectory, timeSeriesName, timeSeriesName, startYear,
                 endYear)
-            dsRef = xarray.open_dataset()
+            dsRef = xarray.open_dataset(inFileName).isel(
+                nRegions=self.regionIndex)
 
         mainRunName = config.get('runs', 'mainRunName')
         movingAverageMonths = 1


### PR DESCRIPTION
Many tasks that have `PlotClimatologyMapSubtask`s were incorrectly passing `controlConfig` as the 6th argument, when it is now the 7th. Better to pass arguments by keyword to avoid this problem.

The reference data for the `timeSeriesOceanRegions` task was not being read correctly from a file.