### PR TITLE
Fix the WOCE insetis to use user-selected bounds

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1722,7 +1722,7 @@ horizontalResolution = 5
 
 # Horizontal bounds of the plot (in km), or an empty list for automatic bounds
 # The bounds are a 2-element list of the minimum and maximum distance along the
-# transect
+# transect.  Note: A21=Drake Passage; A23=South Atlantic; A12=Prime Meridian
 horizontalBounds = {'WOCE_A21': [],
                     'WOCE_A23': [],
                     'WOCE_A12': []}

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -399,6 +399,15 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         # we can do about that.
         lon_pm180 = numpy.mod(lon + 180., 360.) - 180.
 
+        if self.horizontalBounds is not None:
+            mask = numpy.logical_and(
+                remappedModelClimatology.x.values >= self.horizontalBounds[0],
+                remappedModelClimatology.x.values <= self.horizontalBounds[1])
+            inset_lon = lon_pm180[mask]
+            inset_lat = lat[mask]
+        else:
+            inset_lon = lon_pm180
+            inset_lat = lat
         fc = FeatureCollection()
         fc.add_feature(
             {"type": "Feature",
@@ -409,7 +418,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
                             "tags": ''},
              "geometry": {
                  "type": "LineString",
-                 "coordinates": list(map(list, zip(lon_pm180, lat)))}})
+                 "coordinates": list(map(list, zip(inset_lon, inset_lat)))}})
 
         # z is masked out with NaNs in some locations (where there is land) but
         # this makes pcolormesh unhappy so we'll zero out those locations


### PR DESCRIPTION
Before, they showed the full transect even if the user asked for only part of it.

Also, updated the WOCE comment to identify the 3 transects.

closes #599 