### PR TITLE
Isolate requests import

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All platforms:
 
 MPAS-Analysis is available as an anaconda package via the `conda-forge` channel:
 
-``` bash
+```
 conda config --add channels conda-forge
 conda create -n mpas-analysis mpas-analysis
 conda activate mpas-analysis
@@ -60,11 +60,11 @@ environment with the following packages:
  * geometric\_features
 
 These can be installed via the conda command:
-``` bash
+```
 conda config --add channels conda-forge
-conda create -n mpas-analysis numpy scipy matplotlib netCDF4 \
-    xarray dask bottleneck basemap lxml nco>=4.8.1 pyproj pillow \
-    cmocean progressbar2 requests setuptools shapely cartopy \
+conda create -n mpas-analysis python=3.7 numpy scipy "matplotlib>=3.0.2" \
+    netCDF4 "xarray>=0.10.0" dask bottleneck basemap lxml "nco>=4.8.1" pyproj \
+    pillow cmocean progressbar2 requests setuptools shapely cartopy \
     geometric_features
 conda activate mpas-analysis
 ```
@@ -78,13 +78,13 @@ Then, get the code from:
 If you installed the `mpas-analysis` package, download the data that is
 necessary to MPAS-Analysis by running:
 
-``` bash
+```
 download_analysis_data -o /path/to/mpas_analysis/diagnostics
 ```
 
 If you are using the git repository, run:
 
-``` bash
+```
 ./download_analysis_data.py -o /path/to/mpas_analysis/diagnostics
 ```
 
@@ -121,13 +121,13 @@ should see a warning that the data are being downloaded.
 **Note**: If you are having issues downloading the shape files (e.g., a time out error or forbidden error), follow these steps:
 
 1. Run the following in python on your local machine (i.e., one that has no trouble downloading these files):
-```python
+```
 import cartopy.io.shapereader as shpreader
 for name in ['ocean', 'coastline', 'land']:
     shpfilename = shpreader.natural_earth(resolution='110m',
                                           category='physical',
                                           name=name)
-    reader = shpreader.Reader(shpfilename)
+    shpreader.Reader(shpfilename)
 ```
 2. On your local machine, run `python -c "import cartopy; print(cartopy.config['data_dir'])"`. This will print out the directory in which the natural earth shapefiles are being placed locally.
 3. Copy these files onto the remote machine you are working on. Include folders `shapefiles/natural_earth/physical/*` where `*` is the set of shapefiles that were downloaded.
@@ -140,12 +140,12 @@ for name in ['ocean', 'coastline', 'land']:
 If you installed the `mpas-analysis` package, list the available analysis tasks
 by running:
 
-``` bash
+```
 mpas_analysis --list
 ```
 
 If using a git repository, run:
-``` bash
+```
 python -m mpas_analysis --list
 ```
 
@@ -228,13 +228,13 @@ To purge old analysis (delete the whole output directory) before running run
 the analysis, add the `--purge` flag.  If you installed `mpas-analysis` as
 a package, run:
 
-``` bash
+```
 mpas_analysis --purge <config.file>
 ```
 
 If you are running in the repo, use:
 
-``` bash
+```
 python -m mpas_analysis --purge <config.file>
 ```
 
@@ -300,7 +300,7 @@ within the `mpas_analysis/shared` directory.
    `build_analysis_list`, see below.
 
 A new analysis task can be added with:
-```python
+```
    analyses.append(<component>.MyTask(config, myArg='argValue'))
 ```
 This will add a new object of the `MyTask` class to a list of analysis tasks
@@ -314,7 +314,7 @@ to be generated and is set up properly.
 ## Generating Documentation
 
 To generate the `sphinx` documentation, run:
-```bash
+```
 conda env create -f docs/environment.yml
 conda activate mpas-analysis-docs
 python setup.py install

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -7,7 +7,7 @@ more details and examples, refer to the relevant chapters in the main part of
 the documentation.
 
 Top-level script: mpas_analysis
-===================================
+===============================
 
 .. currentmodule:: mpas_analysis.__main__
 
@@ -21,8 +21,17 @@ Top-level script: mpas_analysis
    update_generate
    run_analysis
    wait_for_task
-   download_analysis_data
+ 
+Downloading data
+================
 
+.. currentmodule:: mpas_analysis.download_data
+
+.. autosummary::
+   :toctree: generated/
+
+   download_analysis_data
+   download_natural_earth_110m
 
 Analysis tasks
 ==============

--- a/download_analysis_data.py
+++ b/download_analysis_data.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 
-from mpas_analysis.__main__ import download_analysis_data
+from mpas_analysis.download_data import download_analysis_data
 
 
 if __name__ == "__main__":

--- a/download_natural_earth_110m.py
+++ b/download_natural_earth_110m.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 
-from mpas_analysis.__main__ import download_natural_earth_110m
+from mpas_analysis.download_data import download_natural_earth_110m
 
 
 if __name__ == "__main__":

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -34,7 +34,6 @@ import progressbar
 import logging
 import xarray
 import time
-import cartopy.io.shapereader as shpreader
 
 from mpas_analysis.shared.analysis_task import AnalysisFormatter
 
@@ -57,8 +56,6 @@ from mpas_analysis import sea_ice
 from mpas_analysis.shared.climatology import MpasClimatologyTask, \
     RefYearMpasClimatologyTask
 from mpas_analysis.shared.time_series import MpasTimeSeriesTask
-
-from mpas_analysis.shared.io.download import download_files
 
 
 def update_time_bounds_in_config(config):  # {{{
@@ -857,47 +854,6 @@ def main():
 
     if not args.setup_only:
         generate_html(config, analyses, controlConfig)
-
-
-def download_analysis_data():
-    """
-    Entry point for downloading the input data set from public repository for
-    MPAS-Analysis to work. The input data set includes: pre-processed
-    observations data, MPAS mapping files and MPAS regional mask files
-    (which are used for the MOC computation), for a subset of MPAS meshes.
-    """
-
-    parser = argparse.ArgumentParser(
-        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument("-o", "--outDir", dest="outDir", required=True,
-                        help="Directory where MPAS-Analysis input data will"
-                             "be downloaded")
-    parser.add_argument("-d", "--dataset", dest="dataset", default='analysis',
-                        help="Directory where MPAS-Analysis input data will"
-                             "be downloaded")
-    args = parser.parse_args()
-
-    try:
-        os.makedirs(args.outDir)
-    except OSError:
-        pass
-
-    urlBase = 'https://web.lcrc.anl.gov/public/e3sm/diagnostics'
-    analysisFileList = pkg_resources.resource_string(
-        'mpas_analysis',
-        'obs/{}_input_files'.format(args.dataset)).decode('utf-8')
-
-    # remove any empty strings from the list
-    analysisFileList = list(filter(None, analysisFileList.split('\n')))
-    download_files(analysisFileList, urlBase, args.outDir, verify=True)
-
-
-def download_natural_earth_110m():
-    for name in ['ocean', 'coastline', 'land']:
-        shpfilename = shpreader.natural_earth(resolution='110m',
-                                              category='physical',
-                                              name=name)
-        reader = shpreader.Reader(shpfilename)
 
 
 if __name__ == "__main__":

--- a/mpas_analysis/download_data.py
+++ b/mpas_analysis/download_data.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+# This software is open source software available under the BSD-3 license.
+#
+# Copyright (c) 2019 Triad National Security, LLC. All rights reserved.
+# Copyright (c) 2019 Lawrence Livermore National Security, LLC. All rights
+# reserved.
+# Copyright (c) 2019 UT-Battelle, LLC. All rights reserved.
+#
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at
+# https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
+
+"""
+Entry points for downloading data (either for cartopy or for MPAS-Analysis
+itself)
+"""
+# Authors
+# -------
+# Xylar Asay-Davis, Phillip J. Wolfram, Milena Veneziani
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+
+import argparse
+import pkg_resources
+import os
+import cartopy.io.shapereader as shpreader
+
+from mpas_analysis.shared.io.download import download_files
+
+
+def download_analysis_data():
+    """
+    Entry point for downloading the input data set from public repository for
+    MPAS-Analysis to work. The input data set includes: pre-processed
+    observations data, MPAS mapping files and MPAS regional mask files
+    (which are used for the MOC computation), for a subset of MPAS meshes.
+    """
+
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawTextHelpFormatter)
+    parser.add_argument("-o", "--outDir", dest="outDir", required=True,
+                        help="Directory where MPAS-Analysis input data will"
+                             "be downloaded")
+    parser.add_argument("-d", "--dataset", dest="dataset", default='analysis',
+                        help="Directory where MPAS-Analysis input data will"
+                             "be downloaded")
+    args = parser.parse_args()
+
+    try:
+        os.makedirs(args.outDir)
+    except OSError:
+        pass
+
+    urlBase = 'https://web.lcrc.anl.gov/public/e3sm/diagnostics'
+    analysisFileList = pkg_resources.resource_string(
+        'mpas_analysis',
+        'obs/{}_input_files'.format(args.dataset)).decode('utf-8')
+
+    # remove any empty strings from the list
+    analysisFileList = list(filter(None, analysisFileList.split('\n')))
+    download_files(analysisFileList, urlBase, args.outDir, verify=True)
+
+
+def download_natural_earth_110m():
+    for name in ['ocean', 'coastline', 'land']:
+        shpfilename = shpreader.natural_earth(resolution='110m',
+                                              category='physical',
+                                              name=name)
+        shpreader.Reader(shpfilename)
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ setup(name='mpas_analysis',
       entry_points={'console_scripts':
                     ['mpas_analysis = mpas_analysis.__main__:main',
                      'download_analysis_data = '
-                     'mpas_analysis.__main__:download_analysis_data',
+                     'mpas_analysis.download_data:download_analysis_data',
                      'download_nautral_earth_110m = '
-                     'mpas_analysis.__main__:download_nautral_earth_110m']})
+                     'mpas_analysis.download_data:download_nautral_earth_110m']})


### PR DESCRIPTION
This merge breaks downloading data into a separate module `download_data`.  This prevents `requests` form being imported unless it is needed, since `requests` hangs on the b512 node on Anvil/Blues.

The merge also updates to docs:
* Updates the path to download_analysis_data in the docs.
* Adds missing docs for the `cartopy` download.
* Fix some issues with `README.md` that were causing it not to render right when converted to RST.