### PR TITLE
Add customDirectory for diagnostics

### DIFF
--- a/docs/config/diagnostics.rst
+++ b/docs/config/diagnostics.rst
@@ -18,12 +18,19 @@ interpolate MPAS data and observations to common reference grids::
   # mapping files and region files.
   baseDirectory = /path/to/diagnostics
 
+  # A second directory where custom diagonstics data such as mapping files and
+  # regions masks for unsupported grids can be found.  The structure of
+  # subdirectories in this directory must be the same as baseDirectory
+  customDirectory = none
+
   # Directory for mapping files (if they have been generated already). If mapping
   # files needed by the analysis are not found here, they will be generated and
-  # placed in the output mappingSubdirectory
+  # placed in the output mappingSubdirectory.  The user can supply an absolute
+  # path here to point to a path that is not within the baseDirectory above.
   mappingSubdirectory = mpas_analysis/maps
 
-  # Directory for region mask files
+  # Directory for region mask files. The user can supply an absolute path here to
+  # point to a path that is not within the baseDirectory above.
   regionMaskSubdirectory = mpas_analysis/region_masks
 
 Diagnostics Directories
@@ -34,6 +41,10 @@ The ``baseDirectory`` is the location where files were downloaded with the
 this data has already been downloaded to a shared location (see example config
 files in the subdirectories of the ``configs`` directory in the MPAS-Analysis
 repository).
+
+The ``customDirectory``, if it is not ``none`` is another directory where
+observations, mapping files and region masks may be stored.  This is useful for
+runs on non-standard grids or for testing out new observations.
 
 The remaining options point to the subdirectories for mapping files (see
 below) and region masks (see :ref:`config_colormaps`), respectively.

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -71,6 +71,11 @@ ncclimoParallelMode = serial
 # mapping files and region files.
 baseDirectory = /path/to/diagnostics
 
+# A second directory where custom diagonstics data such as mapping files and
+# regions masks for unsupported grids can be found.  The structure of
+# subdirectories in this directory must be the same as baseDirectory
+customDirectory = none
+
 # Directory for mapping files (if they have been generated already). If mapping
 # files needed by the analysis are not found here, they will be generated and
 # placed in the output mappingSubdirectory.  The user can supply an absolute

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -23,7 +23,7 @@ from geometric_features import FeatureCollection, read_feature_collection
 
 from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    get_files_year_month, make_directories, decode_strings
+    get_files_year_month, make_directories, decode_strings, get_region_mask
 from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
 from mpas_analysis.shared.timekeeping.utility import days_to_datetime
 from mpas_analysis.shared.regions import ComputeRegionMasksSubtask, \
@@ -95,11 +95,8 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
         hovmollerGalleryGroup = config.get('oceanRegionalProfiles',
                                            'hovmollerGalleryGroup')
 
-        regionMaskDirectory = build_config_full_path(config,
-                                                     'diagnostics',
-                                                     'regionMaskSubdirectory')
-        masksFile = '{}/{}.geojson'.format(regionMaskDirectory,
-                                           self.regionMaskSuffix)
+        masksFile = get_region_mask(config,
+                                    '{}.geojson'.format(self.regionMaskSuffix))
 
         parallelTaskCount = config.getWithDefault('execute',
                                                   'parallelTaskCount',
@@ -640,14 +637,10 @@ class PlotRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
         startYear = self.parentTask.startYear
         endYear = self.parentTask.endYear
 
-        regionMaskDirectory = build_config_full_path(config,
-                                                     'diagnostics',
-                                                     'regionMaskSubdirectory')
-
         regionMaskSuffix = config.get('oceanRegionalProfiles',
                                       'regionMaskSuffix')
-        regionMaskFile = '{}/{}.geojson'.format(regionMaskDirectory,
-                                                regionMaskSuffix)
+        regionMaskFile = get_region_mask(config,
+                                         '{}.geojson'.format(regionMaskSuffix))
 
         fcAll = read_feature_collection(regionMaskFile)
 

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -24,7 +24,7 @@ from mpas_analysis.shared.plot import plot_vertical_section_comparison, \
     timeseries_analysis_plot, savefig
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    make_directories, get_files_year_month
+    make_directories, get_files_year_month, get_region_mask
 
 from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
 
@@ -377,11 +377,9 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
 
         # Load basin region related variables and save them to dictionary
         mpasMeshName = config.get('input', 'mpasMeshName')
-        regionMaskDirectory = build_config_full_path(config, 'diagnostics',
-                                                     'regionMasksubDirectory')
 
-        dictRegion = _build_region_mask_dict(regionNames, regionMaskDirectory,
-                                             mpasMeshName, self.logger)
+        dictRegion = _build_region_mask_dict(config, regionNames, mpasMeshName,
+                                             self.logger)
 
         # Add Global regionCellMask=1 everywhere to make the algorithm
         # for the global moc similar to that of the regional moc
@@ -976,9 +974,7 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):  # {{{
             refTopDepth, refLayerThickness = _load_mesh(self.runStreams)
 
         mpasMeshName = config.get('input', 'mpasMeshName')
-        regionMaskDirectory = build_config_full_path(config, 'diagnostics',
-                                                     'regionMasksubDirectory')
-        dictRegion = _build_region_mask_dict(['Atlantic'], regionMaskDirectory,
+        dictRegion = _build_region_mask_dict(config, ['Atlantic'],
                                              mpasMeshName, self.logger)
         dictRegion = dictRegion['Atlantic']
 
@@ -1382,11 +1378,11 @@ def _load_mesh(runStreams):  # {{{
     # }}}
 
 
-def _build_region_mask_dict(regionNames, regionMaskDirectory, mpasMeshName,
-                            logger):  # {{{
+def _build_region_mask_dict(config, regionNames, mpasMeshName, logger):  # {{{
 
-    regionMaskFile = '{}/{}_SingleRegionAtlanticWTransportTransects_' \
-                     'masks.nc'.format(regionMaskDirectory, mpasMeshName)
+    regionMaskFile = get_region_mask(
+        config, '{}_SingleRegionAtlanticWTransportTransects_masks.nc'.format(
+            mpasMeshName))
 
     if not os.path.exists(regionMaskFile):
         raise IOError('Regional masking file {} for MOC calculation '

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -32,7 +32,7 @@ from mpas_analysis.shared.plot import timeseries_analysis_plot, savefig, \
 from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    make_directories, build_obs_path, decode_strings
+    make_directories, build_obs_path, decode_strings, get_region_mask
 
 from mpas_analysis.shared.html import write_image_xml
 
@@ -76,11 +76,7 @@ class TimeSeriesAntarcticMelt(AnalysisTask):  # {{{
             componentName='ocean',
             tags=['timeSeries', 'melt', 'landIceCavities'])
 
-        regionMaskDirectory = build_config_full_path(config,
-                                                     'diagnostics',
-                                                     'regionMaskSubdirectory')
-        self.iceShelfMasksFile = '{}/iceShelves.geojson'.format(
-            regionMaskDirectory)
+        self.iceShelfMasksFile = get_region_mask(config, 'iceShelves.geojson')
 
         iceShelvesToPlot = config.getExpression('timeSeriesAntarcticMelt',
                                                 'iceShelvesToPlot')

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -88,11 +88,25 @@ def get_remapper(config, sourceDescriptor, comparisonDescriptor,
             comparisonDescriptor.meshName,
             method)
 
-        mappingSubdirectory = build_config_full_path(config, 'diagnostics',
-                                                     'mappingSubdirectory')
+        tryCustom = config.get('diagnostics', 'customDirectory') != 'none'
+        if tryCustom:
+            # first see if mapping files are in the custom directory
+            mappingSubdirectory = build_config_full_path(
+                config, 'diagnostics', 'mappingSubdirectory',
+                baseDirectoryOption='customDirectory')
 
-        mappingFileName = '{}/{}'.format(mappingSubdirectory,
+            mappingFileName = '{}/{}'.format(mappingSubdirectory,
                                          mappingBaseName)
+        if not tryCustom or not os.path.exists(mappingFileName):
+            # second see if mapping files are in the base directory
+
+            mappingSubdirectory = build_config_full_path(
+                config, 'diagnostics', 'mappingSubdirectory',
+                baseDirectoryOption='baseDirectory')
+
+            mappingFileName = '{}/{}'.format(mappingSubdirectory,
+                                             mappingBaseName)
+
         if not os.path.exists(mappingFileName):
             # we don't have a mapping file yet, so get ready to create one
             # in the output subfolder if needed

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -106,7 +106,8 @@ def make_directories(path):  # {{{
 
 def build_config_full_path(config, section, relativePathOption,
                            relativePathSection=None,
-                           defaultPath=None):  # {{{
+                           defaultPath=None,
+                           baseDirectoryOption='baseDirectory'):  # {{{
     """
     Get a full path from a base directory and a relative path
 
@@ -129,6 +130,9 @@ def build_config_full_path(config, section, relativePathOption,
     defaultPath : str, optional
         the name of a path to return if the resulting path doesn't exist.
 
+    baseDirectoryOption : str, optional
+        the name of the option in ``section`` for the base directorys
+
     Returns
     -------
     fullPath : str
@@ -146,12 +150,60 @@ def build_config_full_path(config, section, relativePathOption,
     if os.path.isabs(subDirectory):
         fullPath = subDirectory
     else:
-        fullPath = '{}/{}'.format(config.get(section, 'baseDirectory'),
+        fullPath = '{}/{}'.format(config.get(section, baseDirectoryOption),
                                   subDirectory)
 
     if defaultPath is not None and not os.path.exists(fullPath):
         fullPath = defaultPath
     return fullPath  # }}}
+
+
+def get_region_mask(config, regionMaskFile):  # {{{
+    """
+    Get the full path for a region mask with a given file name
+
+    Parameters
+    ----------
+    config : MpasAnalysisConfigParser object
+        configuration from which to read the path
+
+    regionMaskFile : str
+        the file name of the region mask, typically a relative path
+
+    Returns
+    -------
+    fullFileName : str
+        The absolute path to the given fileName within the custom or base
+        diagnostics directories
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    if os.path.isabs(regionMaskFile):
+        fullFileName = regionMaskFile
+    else:
+        tryCustom = config.get('diagnostics', 'customDirectory') != 'none'
+        if tryCustom:
+            # first see if region mask file is in the custom directory
+            regionMaskDirectory = build_config_full_path(
+                config, 'diagnostics', 'regionMaskSubdirectory',
+                baseDirectoryOption='customDirectory')
+
+            fullFileName = '{}/{}'.format(regionMaskDirectory,
+                                          regionMaskFile)
+
+        if not tryCustom or not os.path.exists(fullFileName):
+            # no, so second see if mapping files are in the base directory
+
+            regionMaskDirectory = build_config_full_path(
+                config, 'diagnostics', 'regionMaskSubdirectory',
+                baseDirectoryOption='baseDirectory')
+
+            fullFileName = '{}/{}'.format(regionMaskDirectory,
+                                          regionMaskFile)
+
+    return fullFileName  # }}}
 
 
 def build_obs_path(config, component, relativePathOption,
@@ -197,9 +249,13 @@ def build_obs_path(config, component, relativePathOption,
         if os.path.isabs(obsSubdirectory):
             fullPath = '{}/{}'.format(obsSubdirectory, relativePath)
         else:
-            basePath = config.get('diagnostics', 'baseDirectory')
+            basePath = config.get('diagnostics', 'customDirectory')
             fullPath = '{}/{}/{}'.format(basePath, obsSubdirectory,
                                          relativePath)
+            if basePath == 'none' or not os.path.exists(fullPath):
+                basePath = config.get('diagnostics', 'baseDirectory')
+                fullPath = '{}/{}/{}'.format(basePath, obsSubdirectory,
+                                             relativePath)
 
     return fullPath  # }}}
 

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -24,7 +24,7 @@ from functools import partial
 from mpas_analysis.shared.analysis_task import AnalysisTask
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    make_directories
+    make_directories, get_region_mask
 from mpas_analysis.shared.io import write_netcdf
 
 from mpas_analysis.shared.mpas_xarray import mpas_xarray
@@ -300,12 +300,9 @@ class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
 
         # first, see if we have cached a mask file name in the region masks
         # directory
-        regionMaskDirectory = build_config_full_path(self.config,
-                                                     'diagnostics',
-                                                     'regionMaskSubdirectory')
-        self.maskFileName = '{}/{}_{}.nc'.format(regionMaskDirectory,
-                                                 mpasMeshName,
-                                                 self.outFileSuffix)
+
+        self.maskFileName = get_region_mask(
+            self.config, '{}_{}.nc'.format(mpasMeshName, self.outFileSuffix))
 
         if not os.path.exists(self.maskFileName):
             # no cached mask file, so let's see if there's already one in the

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -53,6 +53,7 @@ class TestClimatology(TestCase):
 
         config.add_section('diagnostics')
         config.set('diagnostics', 'baseDirectory', self.test_dir)
+        config.set('diagnostics', 'customDirectory', 'none')
         config.set('diagnostics', 'mappingSubdirectory', 'maps')
 
         config.add_section('input')

--- a/mpas_analysis/test/test_mpas_climatology_task/config.QU240
+++ b/mpas_analysis/test/test_mpas_climatology_task/config.QU240
@@ -7,6 +7,7 @@ ncclimoParallelMode = serial
 
 [diagnostics]
 baseDirectory = /dir/for/model/output
+customDirectory = none
 mappingSubdirectory = .
 
 [input]

--- a/mpas_analysis/test/test_remap_obs_clim_subtask/config.remap_obs
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask/config.remap_obs
@@ -1,5 +1,6 @@
 [diagnostics]
 baseDirectory = /dir/to/diagnostics
+customDirectory = none
 mappingSubdirectory = .
 
 [input]


### PR DESCRIPTION
This allows a user to supply their own observations, mapping files or region masks (without putting them in a shared diagnostics directory). This is appropriate when working with custom meshes or testing new observations or regions that aren't (yet) standard in MPAS-Analysis.

In the process of testing, I found bugs in `timeSeriesOceanRegions` that I have fixed here.  They relate to the names of subtasks, which were not unique when a second region group is defined.

closes #604 