### PR TITLE
Fix copying properties in mask creation

### DIFF
--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -702,7 +702,6 @@ class PlotRegionTimeSeriesSubtask(AnalysisTask):
 
         controlConfig = self.controlConfig
         plotControl = controlConfig is not None
-        print(plotControl)
         if plotControl:
             controlRunName = controlConfig.get('runs', 'mainRunName')
             baseDirectory = build_config_full_path(


### PR DESCRIPTION
In cases where some features have a given property but others don't,
the property is assigned an empty string so there is one entry per
feature.

closes #619 