### PR TITLE
Handle case where git command is not available

### DIFF
--- a/mpas_analysis/shared/html/image_xml.py
+++ b/mpas_analysis/shared/html/image_xml.py
@@ -175,13 +175,16 @@ def _provenance_command(root, history):  # {{{
 
     etree.SubElement(root, 'host').text = socket.gethostname()
 
-    p = subprocess.Popen(['git', 'describe', '--always', '--dirty'],
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    stdout, stderr = p.communicate()
-    stdout = stdout.decode('utf-8')
-    if p.returncode == 0:
-        githash = stdout.strip('\n')
-    else:
+    try:
+        p = subprocess.Popen(['git', 'describe', '--always', '--dirty'],
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        stdout = stdout.decode('utf-8')
+        if p.returncode == 0:
+            githash = stdout.strip('\n')
+        else:
+            githash = 'git hash unavailable'
+    except (IOError, OSError):
         githash = 'git hash unavailable'
 
     etree.SubElement(root, 'githash').text = githash  # }}}

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -647,7 +647,7 @@ def _get_git_hash():
                                                '--pretty=format:"%h"',
                                                '-n', '1'],
                                               stderr=devnull)
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, IOError, OSError):
             return None
 
     githash = githash.decode('utf-8').strip('\n').replace('"', '')


### PR DESCRIPTION
Tasks were failing during writing out the XML files used to generate web pages if the `git` command wasn't available.  It's quite conceivable that people would run on systems where `git` isn't available by default.