### PR TITLE
Address depricated and future warnings from xarray and numpy

### DIFF
--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -479,8 +479,8 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
                     outputDirectory, timeSeriesName, startYear, endYear)
                 inFileNames.append(inFileName)
 
-            ds = xr.open_mfdataset(inFileNames, concat_dim='Time',
-                                   decode_times=False)
+            ds = xr.open_mfdataset(inFileNames, combine='nested',
+                                   concat_dim='Time', decode_times=False)
 
             ds['totalArea'] = ds['totalArea'].isel(Time=0)
 

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -1175,7 +1175,7 @@ class CombineMOCTimeSeriesSubtask(AnalysisTask):  # {{{
             return
 
         ds = xr.open_mfdataset(outputFileNames, concat_dim='Time',
-                               decode_times=False)
+                               combine='nested', decode_times=False)
 
         write_netcdf(ds, outputFileName)  # }}}
     # }}}

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -538,8 +538,8 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
                     outputDirectory, timeSeriesName, startYear, endYear)
                 inFileNames.append(inFileName)
 
-            ds = xarray.open_mfdataset(inFileNames, concat_dim='Time',
-                                       decode_times=False)
+            ds = xarray.open_mfdataset(inFileNames, combine='nested',
+                                       concat_dim='Time', decode_times=False)
 
             # a few variables have become time dependent and shouldn't be
             for var in ['totalArea', 'zbounds']:

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -690,6 +690,7 @@ class MpasClimatologySeasonSubtask(AnalysisTask):  # {{{
                 'timeSeriesStatsMonthlyOutput')
 
             with xarray.open_mfdataset(parentTask.inputFiles,
+                                       combine='nested',
                                        concat_dim='Time',
                                        chunks={'nCells': chunkSize},
                                        decode_cf=False, decode_times=False,
@@ -718,6 +719,7 @@ class MpasClimatologySeasonSubtask(AnalysisTask):  # {{{
                 weights.append(constants.daysInMonth[month-1])
 
             with xarray.open_mfdataset(fileNames, concat_dim='weight',
+                                       combine='nested',
                                        chunks={'nCells': chunkSize},
                                        decode_cf=False, decode_times=False,
                                        preprocess=_preprocess) as ds:

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -142,16 +142,11 @@ def open_multifile_dataset(fileNames, calendar, config,
                                  startDate=startDate,
                                  endDate=endDate)
 
-    kwargs = {'decode_times': False,
-              'concat_dim': 'Time'}
-
-    # get the number of files that can be open at the same time.  We want the
-    # "soft" limit because we'll get a crash if we exceed it.
-    softLimit = resource.getrlimit(resource.RLIMIT_NOFILE)[0]
-
     ds = xarray.open_mfdataset(fileNames,
                                preprocess=preprocess_partial,
-                               **kwargs)
+                               combine='nested',
+                               concat_dim='Time',
+                               decode_times=False)
 
     ds = mpas_xarray.remove_repeated_time_index(ds)
 

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -116,7 +116,8 @@ def open_multifile_dataset(fileNames, calendar,
 
     ds = xarray.open_mfdataset(fileNames,
                                preprocess=preprocess_partial,
-                               decode_times=False, concat_dim='Time')
+                               combine='nested', concat_dim='Time',
+                               decode_times=False)
 
     ds = remove_repeated_time_index(ds)
 

--- a/mpas_analysis/shared/plot/climatology_map.py
+++ b/mpas_analysis/shared/plot/climatology_map.py
@@ -561,7 +561,7 @@ def addcyclic(*arr, **kwargs):
         except IndexError:
             raise ValueError('The specified axis does not correspond to an '
                              'array dimension.')
-        return npsel.concatenate((a, a[slicer]), axis=axis)
+        return npsel.concatenate((a, a[tuple(slicer)]), axis=axis)
 
     def _addcyclic_lon(a):
         """addcyclic function for a single longitude array"""


### PR DESCRIPTION
Updates calls to `xarray.open_mfdataset()` to include a new argument, `combine='nested'`, needed for our usage. The desired coordinate (typically `'Time'`) doesn't always exist and needs to be specified. This change gets rid of a large number of deprication warnings.

Also, updates `addcyclic` to make multidimensional index a tuple, getting rid of several `FutureWarning`s in sea-ice tasks.

closes #628 