### PR TITLE
Add config to control xarray/dask climatology subtasks

### DIFF
--- a/configs/alcf/20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta.yrs41-50.conf
+++ b/configs/alcf/20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta.yrs41-50.conf
@@ -3,7 +3,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = 20190301.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta
+mainRunName = 20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta
 
 # config file for a control run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -23,7 +23,7 @@ mainRunName = 20190301.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta
 ## options related to executing parallel tasks
 
 # the number of parallel tasks (1 means tasks run in serial, the default)
-parallelTaskCount = 8
+parallelTaskCount = 12
 
 # the parallelism mode in ncclimo ("serial" or "bck")
 # Set this to "bck" (background parallelism) if running on a machine that can
@@ -45,7 +45,7 @@ baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_3/diagnostics
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /lus/theta-fs0/projects/OceanClimate_2/outputForExampleThetaAnalysisConfigs/20190301.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta/run
+baseDirectory = /lus/theta-fs0/projects/OceanClimate_2/sprice/20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta/run
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oRRS30to10v3wLI
@@ -62,10 +62,9 @@ seaIceStreamsFileName = streams.seaice
 ## etc.
 
 # directory where analysis should be written (**** MAKE SURE TO UPDATE WITH YOUR PREFERRED PATH ***)
-baseDirectory = /projects/OceanClimate_2/yourUsername/path/here
+baseDirectory = /projects/ClimateEnergy_3/yourUsername/path/here
 
-# a list of analyses to generate.  Valid names can be seen by running:
-#   mpas_analysis --list
+# a list of analyses to generate.  Valid names can be seen by running:#   mpas_analysis --list
 # This command also lists tags for each analysis.
 # Shortcuts exist to generate (or not generate) several types of analysis.
 # These include:
@@ -87,7 +86,7 @@ baseDirectory = /projects/OceanClimate_2/yourUsername/path/here
 # option:
 #    mpas_analysis config.analysis --generate \
 #         all,no_ocean,all_timeSeries
-generate = ['all', 'no_eke', 'no_BGC', 'no_icebergs', 'no_min', 'no_max']
+generate = ['all', 'no_BGC', 'no_icebergs', 'no_min', 'no_max' ]
 
 [climatology]
 ## options related to producing climatologies, typically to compare against
@@ -97,9 +96,20 @@ generate = ['all', 'no_eke', 'no_BGC', 'no_icebergs', 'no_min', 'no_max']
 useNcclimo = False
 
 # the first year over which to average climatalogies
-startYear = 1
+startYear = 41
 # the last year over which to average climatalogies
-endYear = 2
+endYear = 50
+
+# if useNcclimo = False, the number of threads dask is allowed to spawn for each# process computing a climatology for a given month or season
+# Decrease this number if mpasClimatology* subtasks are running
+# out of available threads
+daskThreads = 2
+
+# if useNcclimo = False, the number of subprocesses that each climatology
+# subtask gets counted as occupying.
+# Increase this number if mpasClimatology* subtasks are running
+# out of memory, and fewer tasks will be allowed to run at once
+subprocessCount = 2
 
 [timeSeries]
 ## options related to producing time series plots, often to compare against
@@ -109,7 +119,7 @@ endYear = 2
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
 startYear = 1
-endYear = 2
+endYear = 50
 
 [index]
 ## options related to producing nino index.
@@ -119,7 +129,7 @@ endYear = 2
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 2
+endYear = 50
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/docs/config/climatology.rst
+++ b/docs/config/climatology.rst
@@ -33,6 +33,9 @@ anomalies and to control remapping of climatologies to comparions grids::
   #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
   mpasInterpolationMethod = bilinear
 
+  # should climatologies be performed with ncclimo or with xarray/dask
+  useNcclimo = True
+
   # should remapping be performed with ncremap or with the Remapper class
   # directly in MPAS-Analysis
   useNcremap = True
@@ -40,6 +43,19 @@ anomalies and to control remapping of climatologies to comparions grids::
   # The minimum weight of a destination cell after remapping. Any cell with
   # weights lower than this threshold will therefore be masked out.
   renormalizationThreshold = 0.01
+
+  # if useNcclimo = False, the number of threads dask is allowed to spawn for
+  # each process computing a climatology for a given month or season
+  # Decrease this number if mpasClimatology* subtasks are running
+  # out of available threads
+  daskThreads = 2
+
+  # if useNcclimo = False, the number of subprocesses that each climatology
+  # subtask gets counted as occupying.
+  # Increase this number if mpasClimatology* subtasks are running
+  # out of memory, and fewer tasks will be allowed to run at once
+  subprocessCount = 1
+
 
 Start and End Year
 ------------------
@@ -63,11 +79,6 @@ specify a different year to use for computing anomalies::
 
   anomalyRefYear = 249
 
-Comparison Grids
-----------------
-
-See :ref:`config_comparison_grids`.
-
 .. _config_remapping:
 
 Remapping Options
@@ -82,11 +93,9 @@ is ``bilinear`` and these are the mapping files distributed from the
 slower to compute and should only be used if it is necessary (e.g. because
 remapped data will be checked for conservation).
 
-MPAS-Analysis typically uses the `NCO`_ tool ``ncremap`` to perform  to
-perform remapping.  However, ``ncreamp`` does not support the Antarctic
-stereographic grids used by some MPAS-Analysis tasks so a python remapping
-function is used for these grids.  The user can force all remapping to use
-the internal remapping function by specifying::
+MPAS-Analysis typically uses the `NCO`_ tool ``ncremap`` to perform remapping.
+However, a python remapping capability is also available.  The user can force
+remapping to use the python-based remapping by specifying::
 
   useNcremap = False
 
@@ -108,6 +117,26 @@ If noisy or unphysical values occur near maked regions on the comparison grid,
 it might be necessary to increase this threshold.  If too much data appears to
 be being masked out unnecessarily on the comparison grid, perhaps this value
 should be made smaller.
+
+
+Computing climatologies
+-----------------------
+
+MPAS-Analysis typically uses the `NCO`_ tool ``ncclimo`` to compute
+climatologies.  For some large data sets on a single node, ``ncclimo`` runs
+out of memory in ``bck`` mode but is painfully slow in ``serial`` mode and
+wastes extra nodes in ``mpi`` mode.  (See :ref: `config_execute` for more on
+configuring ``ncclimo``.)  For such cases, there is also an xarray/dask method
+of computing climatologies::
+
+  useNcremap = False
+
+
+Other Options
+-------------
+
+* :ref:`config_comparison_grids`
+* :ref:`dask_treads`
 
 .. _`Common Ocean Reference Experiments, CORE`: http://data1.gfdl.noaa.gov/nomads/forms/mom4/CORE.html
 .. _`ESMF_RegridWeightGen tool`: http://www.earthsystemmodeling.org/esmf_releases/public/ESMF_7_1_0r/ESMF_refdoc/node3.html#SECTION03020000000000000000

--- a/docs/config/dask_treads.rst
+++ b/docs/config/dask_treads.rst
@@ -1,0 +1,48 @@
+.. _dask_treads:
+
+Dask treads and subprocess count
+================================
+
+Several tasks and subtasks have config options ``daskThreads`` and
+``subprocessCount`` used to control threading within a subtask::
+
+  # The number of threads dask is allowed to spawn for each task/subtask.
+  # Decrease this number if tasks/subtasks are running out of available threads
+  daskThreads = 2
+
+  # The number of subprocesses that each task/subtask gets counted as
+  # occupying. Increase this number if tasks/subtasks are running out of
+  # memory, so that fewer tasks will be allowed to run at once
+  subprocessCount = 1
+
+Dask treads
+-----------
+
+Dask and xarray support thread-parallel operations on data sets.  They also
+support chunk-wise operation on data sets that can't fit in memory.  These
+capabilities are very powerful but also difficult to configure for general
+cases.  Dask is also not desigend by default with the idea that multiple tasks,
+each with multiple dask treads, might operate simultaneously.  As a result,
+it is possible to spawn huge numbers of dask treads in MPAS-Analysis that both
+slow down analysis and lead to errors when the node runs out of threads
+completely.
+
+To prevent this, many tasks or subtasks that use dask treading take the number
+of execution threads from a config option, typically in the config section for
+the parent task.  Typically, the number of ``daskThreads`` should be around
+the same as the number of cores on a node divided by the number of tasks
+that will run simultaneiously.  Since the number of running tasks is controlled
+by ``subprocessCount``, see below, this number might differ from
+``parallelTaskCount``.
+
+Subprocess count
+----------------
+
+Tasks or subtasks that use dask treading may consume too much memory or use
+too many threads to "count" as a single task.  That is, it might not be safe to
+run with ``parallelTaskCount`` simultaneious instances of the task/subtask and
+it would be better if it occupied the slot of multiple tasks in the pool of
+tasks.  MPAS-Analysis will treat a dask-based task or subtask as occupying
+the number of task slots given by the ``subprocessCount`` option.  For example,
+if ``parallelTaskCount = 8`` and ``subprocessCount = 2``, up to 4 tasks or
+subtasks would be allowed to run simultaneiously.

--- a/docs/tasks/regionalTSDiagrams.rst
+++ b/docs/tasks/regionalTSDiagrams.rst
@@ -190,17 +190,6 @@ anticipate adding several additional data sets in the near future.
 :ref:`sose`
 :ref:`woa18_t_s`
 
-Performance
------------
-The options ``daskThreads`` and ``subprocessCount`` are available to allow
-users to control performance.  The subtask for computing climatologies of
-SOSE and WOA18 data (and, in the future, other observational data sets) can
-be somewhat time consuming.  Allowing it to use more dask threads should
-speed it up a bit.  The option ``subprocessCount`` tells MPAS-Analysis how
-many of its parallel tasks to reserve for this task.  If memory errors occur
-with this task, it would be safer to increase ``subprocessCount`` so fewer
-other processes run at the same time as this one.
-
 Other Config Options
 --------------------
 
@@ -208,7 +197,7 @@ For more details on the remaining config options, see
  * :ref:`config_regions`
  * :ref:`config_seasons`
  * :ref:`config_colormaps`
-
+ * :ref:`dask_treads`
 
 Example Result
 --------------

--- a/docs/tasks/timeSeriesAntarcticMelt.rst
+++ b/docs/tasks/timeSeriesAntarcticMelt.rst
@@ -41,6 +41,17 @@ The following configuration options are available for this task::
 
   # yearStrideXTicks = 1
 
+  # the number of threads dask is allowed to spawn for each process computing
+  # a year of these time series
+  # Decrease this number if timeSeriesAntarcticMelt subtasks are running
+  # out of available threads
+  daskThreads = 4
+
+  # the number of subprocesses that each task gets counted as occupying
+  # Increase this number if timeSeriesAntarcticMelt subtasks are running
+  # out of memory, and fewer tasks will be allowed to run at once
+  subprocessCount = 1
+
 Ice Shelf and Region Names
 --------------------------
 
@@ -98,6 +109,7 @@ Other Options
 
 * :ref:`config_moving_average`
 * :ref:`config_time_axis_ticks`
+* :ref:`dask_treads`
 
 Observations
 ------------

--- a/docs/tasks/timeSeriesOceanRegions.rst
+++ b/docs/tasks/timeSeriesOceanRegions.rst
@@ -22,6 +22,16 @@ The following configuration options are available for this task::
   # the names of region groups to plot, each with its own section below
   regionGroups = ['Antarctic Regions']
 
+  # the number of threads dask is allowed to spawn for each process computing
+  # a year of these time series
+  # Decrease this number if timeSeriesOceanRegions subtasks are running
+  # out of available threads
+  daskThreads = 12
+
+  # the number of subprocesses that each task gets counted as occupying
+  # Increase this number if timeSeriesOceanRegions subtasks are running
+  # out of memory, and fewer tasks will be allowed to run at once
+  subprocessCount = 3
 
   [timeSeriesAntarcticRegions]
   ## options related to plotting time series of Antarctic regions
@@ -96,6 +106,10 @@ the NetCDF files as well as the text appended to subtaks names and file names.
 It should contain no spaces.  The ``"mpas"`` entry is the name of the
 corresponding field in the MPAS-Ocean ``timeSeriesStatsMonthlyOutput`` files.
 
+Other Options
+-------------
+
+* :ref:`dask_treads`
 
 Example Result
 --------------

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -215,6 +215,18 @@ useNcremap = True
 # weights lower than this threshold will therefore be masked out.
 renormalizationThreshold = 0.01
 
+# if useNcclimo = False, the number of threads dask is allowed to spawn for
+# each process computing a climatology for a given month or season
+# Decrease this number if mpasClimatology* subtasks are running
+# out of available threads
+daskThreads = 2
+
+# if useNcclimo = False, the number of subprocesses that each climatology
+# subtask gets counted as occupying.
+# Increase this number if mpasClimatology* subtasks are running
+# out of memory, and fewer tasks will be allowed to run at once
+subprocessCount = 1
+
 
 [timeSeries]
 ## options related to producing time series plots, often to compare against

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -469,9 +469,15 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
             outputDirectory, timeSeriesName, self.startYears[0],
             self.endYears[-1])
 
+        useExisting = False
         if os.path.exists(outputFileName):
             ds = xr.open_dataset(outputFileName, decode_times=False)
-        else:
+            if ds.sizes['Time'] > 0:
+                useExisting = True
+            else:
+                ds.close()
+
+        if not useExisting:
 
             inFileNames = []
             for startYear, endYear in zip(self.startYears, self.endYears):

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -260,11 +260,14 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
         if os.path.exists(self.outputFile):
             # make sure all the necessary variables are also present
             with xr.open_dataset(self.outputFile) as ds:
-                updateSubset = True
-                for variableName in self.variableList:
-                    if variableName not in ds.variables:
-                        updateSubset = False
-                        break
+                if ds.sizes['Time'] == 0:
+                    updateSubset = False
+                else:
+                    updateSubset = True
+                    for variableName in self.variableList:
+                        if variableName not in ds.variables:
+                            updateSubset = False
+                            break
 
                 if updateSubset:
                     # add only input files wiht times that aren't already in
@@ -301,8 +304,8 @@ class MpasTimeSeriesTask(AnalysisTask):  # {{{
                     # there is an output file but it has the wrong variables
                     # so we need ot delete it.
                     self.logger.warning('Warning: deleting file {} because '
-                                        'some variables were missing'.format(
-                                            self.outputFile))
+                                        'it is empty or some variables were '
+                                        'missing'.format(self.outputFile))
                     os.remove(self.outputFile)
 
         variableList = self.variableList + ['xtime_startMonthly',


### PR DESCRIPTION
With this merge, users can set the number of subprocesses that each subtask occupies (increasing this number will make sure we don't run out of memory) and separately control the number of dask threads used in these subtasks (more total dask threads, up to the available cpu count, should make the task run faster).