### PR TITLE
Fix config copy to HTML

### DIFF
--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -299,7 +299,7 @@ class MainPage(object):
 
         for configFileName in self.customConfigFiles:
             copyfile(configFileName, '{}/{}'.format(htmlBaseDirectory,
-                                                    configFileName))
+                                                    os.path.basename(configFileName)))
 
 
 class ComponentPage(object):

--- a/mpas_analysis/shared/html/templates/config.html
+++ b/mpas_analysis/shared/html/templates/config.html
@@ -2,5 +2,6 @@
       <a target="_blank" href="@configName">
         <img class="component" src="config.png" alt="@configDesc">
       </a>
+      <div class="desc">@configDesc</div>
     </div>
 


### PR DESCRIPTION
Previously, if a path was used for a config file, MPAS-Analysis would attempt to copy the file with the same path.  Now, only the basename is used in the destination path.

Also, the template for config files has been altered to include the name (or description) of the file.