### PR TITLE
Clarify error message when files are missing

### DIFF
--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -629,6 +629,12 @@ def update_time_bounds_from_file_names(config, section, componentName):  # {{{
         # this component likely doesn't have output in this run
         return
 
+    if len(inputFiles) == 0:
+        raise ValueError('No input files found for stream {} in {} between '
+                         '{} and {}'.format(streamName, componentName,
+                                            requestedStartYear,
+                                            requestedEndYear))
+
     years, months = get_files_year_month(sorted(inputFiles),
                                          historyStreams,
                                          streamName)


### PR DESCRIPTION
Previously, an unhelpful error message related to an invalid index resulted when no files were found in a given history stream. This merge attempts to replace that error message with a more helpful one saying which years could not be found in the given component and stream.