### PR TITLE
Add a cryosphere default config file

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -9,3 +9,14 @@ the output `baseDirectory`) and using them to run the analysis.
 To run tasks in parallel via a job queue, copy and modify the machine-specific
 job script or the default job script.
 
+## Analysis focused on polar regions
+
+For analysis such as E3SM cryosphere simulations that is focused on polar
+regions, include polarRegions.conf *before* your custom config file on the
+command line.
+
+Example:
+```
+python -m mpas_analysis configs/polarRegions.conf my_favorite.conf --generate=climatologyMapSSH --purge
+```
+

--- a/configs/alcf/20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta.yrs41-50.conf
+++ b/configs/alcf/20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta.yrs41-50.conf
@@ -143,36 +143,3 @@ endYear = 50
 # MOC takes into account the bolus velocity when GM is on.
 usePostprocessingScript = True
 
-[climatologyMapWoa]
-## options related to plotting climatology maps of Temperature and Salinity
-## fields at various levels, including the sea floor against control model
-## results and WOA climatological data
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface. Note that, for seasons='ANN', depths can be as deep as 5500 m,
-# otherwise use a maximum depth of 1500 m.
-depths = ['top', -50, -200, -400, -600, -800]
-
-[climatologyMapWoaTemperature]
-## options related to plotting climatology maps of potential temperature
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': -2., 'vmax': 2.}
-
-[climatologyMapWoaSalinity]
-## options related to plotting climatology maps of salinity
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
-
-[TSDiagramsForAntarcticRegions]
-## options related to plotting T/S diagrams of Antarctic regions
-
-# The minimum and maximum depth over which fields are plotted, default is
-# to take these values from the geojson feature's zmin and zmax properties.
-zmin = -1000
-zmax = 0

--- a/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -129,37 +129,3 @@ endYear = 9999
 # NOTE: this is a temporary option that will be removed once the online
 # MOC takes into account the bolus velocity when GM is on.
 usePostprocessingScript = True
-
-[climatologyMapWoa]
-## options related to plotting climatology maps of Temperature and Salinity
-## fields at various levels, including the sea floor against control model
-## results and WOA climatological data
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface. Note that, for seasons='ANN', depths can be as deep as 5500 m,
-# otherwise use a maximum depth of 1500 m.
-depths = ['top', -50, -200, -400, -600, -800]
-
-[climatologyMapWoaTemperature]
-## options related to plotting climatology maps of potential temperature
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': -2., 'vmax': 2.}
-
-[climatologyMapWoaSalinity]
-## options related to plotting climatology maps of salinity
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
-
-[TSDiagramsForAntarcticRegions]
-## options related to plotting T/S diagrams of Antarctic regions
-
-# The minimum and maximum depth over which fields are plotted, default is
-# to take these values from the geojson feature's zmin and zmax properties.
-zmin = -1000
-zmax = 0

--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -118,37 +118,3 @@ endYear = 10
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 10
-
-[climatologyMapWoa]
-## options related to plotting climatology maps of Temperature and Salinity
-## fields at various levels, including the sea floor against control model
-## results and WOA climatological data
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface. Note that, for seasons='ANN', depths can be as deep as 5500 m,
-# otherwise use a maximum depth of 1500 m.
-depths = ['top', -50, -200, -400, -600, -800]
-
-[climatologyMapWoaTemperature]
-## options related to plotting climatology maps of potential temperature
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': -2., 'vmax': 2.}
-
-[climatologyMapWoaSalinity]
-## options related to plotting climatology maps of salinity
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
-
-[TSDiagramsForAntarcticRegions]
-## options related to plotting T/S diagrams of Antarctic regions
-
-# The minimum and maximum depth over which fields are plotted, default is
-# to take these values from the geojson feature's zmin and zmax properties.
-zmin = -1000
-zmax = 0

--- a/configs/cori/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
+++ b/configs/cori/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
@@ -131,37 +131,3 @@ endYear = 10
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 10
-
-[climatologyMapWoa]
-## options related to plotting climatology maps of Temperature and Salinity
-## fields at various levels, including the sea floor against control model
-## results and WOA climatological data
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface. Note that, for seasons='ANN', depths can be as deep as 5500 m,
-# otherwise use a maximum depth of 1500 m.
-depths = ['top', -50, -200, -400, -600, -800]
-
-[climatologyMapWoaTemperature]
-## options related to plotting climatology maps of potential temperature
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': -2., 'vmax': 2.}
-
-[climatologyMapWoaSalinity]
-## options related to plotting climatology maps of salinity
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
-
-[TSDiagramsForAntarcticRegions]
-## options related to plotting T/S diagrams of Antarctic regions
-
-# The minimum and maximum depth over which fields are plotted, default is
-# to take these values from the geojson feature's zmin and zmax properties.
-zmin = -1000
-zmax = 0

--- a/configs/cori/config.20180511.GMPAS-IAF.T62_oEC60to30v3wLI.edison
+++ b/configs/cori/config.20180511.GMPAS-IAF.T62_oEC60to30v3wLI.edison
@@ -133,36 +133,3 @@ endYear = 30
 startYear = 1
 endYear = 30
 
-[climatologyMapWoa]
-## options related to plotting climatology maps of Temperature and Salinity
-## fields at various levels, including the sea floor against control model
-## results and WOA climatological data
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface. Note that, for seasons='ANN', depths can be as deep as 5500 m,
-# otherwise use a maximum depth of 1500 m.
-depths = ['top', -50, -200, -400, -600, -800]
-
-[climatologyMapWoaTemperature]
-## options related to plotting climatology maps of potential temperature
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': -2., 'vmax': 2.}
-
-[climatologyMapWoaSalinity]
-## options related to plotting climatology maps of salinity
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
-
-[TSDiagramsForAntarcticRegions]
-## options related to plotting T/S diagrams of Antarctic regions
-
-# The minimum and maximum depth over which fields are plotted, default is
-# to take these values from the geojson feature's zmin and zmax properties.
-zmin = -1000
-zmax = 0

--- a/configs/cori/config.20180514.G.oQU240wLI.edison
+++ b/configs/cori/config.20180514.G.oQU240wLI.edison
@@ -143,37 +143,3 @@ endYear = 9999
 # NOTE: this is a temporary option that will be removed once the online
 # MOC takes into account the bolus velocity when GM is on.
 usePostprocessingScript = True
-
-[climatologyMapWoa]
-## options related to plotting climatology maps of Temperature and Salinity
-## fields at various levels, including the sea floor against control model
-## results and WOA climatological data
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface. Note that, for seasons='ANN', depths can be as deep as 5500 m,
-# otherwise use a maximum depth of 1500 m.
-depths = ['top', -50, -200, -400, -600, -800]
-
-[climatologyMapWoaTemperature]
-## options related to plotting climatology maps of potential temperature
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': -2., 'vmax': 2.}
-
-[climatologyMapWoaSalinity]
-## options related to plotting climatology maps of salinity
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
-
-[TSDiagramsForAntarcticRegions]
-## options related to plotting T/S diagrams of Antarctic regions
-
-# The minimum and maximum depth over which fields are plotted, default is
-# to take these values from the geojson feature's zmin and zmax properties.
-zmin = -1000
-zmax = 0

--- a/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
+++ b/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
@@ -134,37 +134,3 @@ endYear = 30
 # For valid statistics, index times should include at least 30 years
 startYear = 1
 endYear = 9999
-
-[climatologyMapWoa]
-## options related to plotting climatology maps of Temperature and Salinity
-## fields at various levels, including the sea floor against control model
-## results and WOA climatological data
-
-# list of depths in meters (positive up) at which to analyze, 'top' for the
-# sea surface. Note that, for seasons='ANN', depths can be as deep as 5500 m,
-# otherwise use a maximum depth of 1500 m.
-depths = ['top', -50, -200, -400, -600, -800]
-
-[climatologyMapWoaTemperature]
-## options related to plotting climatology maps of potential temperature
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': -2., 'vmax': 2.}
-
-[climatologyMapWoaSalinity]
-## options related to plotting climatology maps of salinity
-## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
-
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
-
-[TSDiagramsForAntarcticRegions]
-## options related to plotting T/S diagrams of Antarctic regions
-
-# The minimum and maximum depth over which fields are plotted, default is
-# to take these values from the geojson feature's zmin and zmax properties.
-zmin = -1000
-zmax = 0

--- a/configs/cori/job_script.cori-haswell.bash
+++ b/configs/cori/job_script.cori-haswell.bash
@@ -42,7 +42,9 @@ if [ ! -f $run_config_file ]; then
     exit 1
 fi
 
-srun -N 1 -n 1 python -m mpas_analysis $run_config_file
+# For an E3SM cryosphere run, include configs/polarRegions.conf, or exclude
+# this extra config file for defalut parameters
+srun -N 1 -n 1 python -m mpas_analysis configs/polarRegions.conf $run_config_file
 
 # If running from the conda package, use this instead:
 #srun -N 1 -n 1 mpas_analysis $run_config_file

--- a/configs/cori/job_script.cori-knl.bash
+++ b/configs/cori/job_script.cori-knl.bash
@@ -42,8 +42,10 @@ if [ ! -f $run_config_file ]; then
     exit 1
 fi
 
-# if using the mpas_analysis conda package instead of the git repo, remove
-# "python -m"
+# For an E3SM cryosphere run, include configs/polarRegions.conf, or exclude
+# this extra config file for defalut parameters
+srun -N 1 -n 1 python -m mpas_analysis configs/polarRegions.conf $run_config_file
 
-srun -N 1 -n 1 python -m mpas_analysis $run_config_file
+# if using the mpas_analysis conda package instead of the git repo
+# srun -N 1 -n 1 mpas_analysis $run_config_file
 

--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -24,6 +24,7 @@ normArgsResult = {'vmin': -2., 'vmax': 2.}
 # A dictionary with keywords for the norm
 normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
 
+
 [TSDiagramsForAntarcticRegions]
 ## options related to plotting T/S diagrams of Antarctic regions
 
@@ -31,3 +32,60 @@ normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
 # to take these values from the geojson feature's zmin and zmax properties.
 zmin = -1000
 zmax = 0
+
+
+[soseTransects]
+## options related to plotting model vs. Southern Ocean State Estimate (SOSE)
+## transects.
+
+# longitudes of transects
+# Western Weddell 1, Filchner (318=42W), Western Weddell 2 (325=35W),
+# West Maud Rise, Fimbul (0), Amery (75E), Totten (117E),
+# George V coast, Merzt (145E), Wilkes (160E), Western Ross (184=176W),
+# Center Ross (187=173W), Eastern Ross (198=162W),
+# Amudsen, Thwaites (253=107W), Bellingshausen (280=80W),
+# West Antarctica (288=72W)
+# Note: Transects at XXX, XXX, XXX, XXX and XXX are chosen for comparison with
+#       Whitworth et al. (XXXX) doi: XXXX/XXXX
+longitudes = [318., 325., 0., 75., 117., 145., 160., 184., 187., 198., 253.,
+              280., 288.]
+
+[soseTemperatureTransects]
+# options related to plotting SOSE transects of potential temperature
+
+# whether the colormap is indexed or continuous
+colormapTypeResult = indexed
+# color indices into colormapName for filled contours
+colormapIndicesResult = [0, 14, 28, 57, 85, 113, 125, 142, 170, 180, 198, 227,
+                         240, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsResult = [-1.6, -1.2, -0.4, 0.0, 0.4, 0.6, 0.8, 1.0, 1.5, 2.0,
+                        3.0, 4.0, 6.0]
+
+# whether the colormap is indexed or continuous
+colormapTypeDifference = indexed
+# color indices into colormapName for filled contours
+colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227,
+                             255]
+# colormap levels/values for contour boundaries
+colorbarLevelsDifference = [-2, -1.5, -1.25, -1, -0.2, 0, 0.2, 1, 1.25, 1.5, 2]
+
+[soseSalinityTransects]
+## options related to plotting SOSE transects of salinity
+
+# whether the colormap is indexed or continuous
+colormapTypeResult = indexed
+# color indices into colormapName for filled contours
+colormapIndicesResult = [0, 20, 40, 80, 120, 140, 160, 180, 200, 220, 240, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsResult = [34.1, 34.2,  34.3,  34.4,  34.5, 34.55, 34.6, 34.65,
+                        34.68, 34.7, 35.0]
+
+# whether the colormap is indexed or continuous
+colormapTypeDifference = indexed
+# color indices into colormapName for filled contours
+colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227,
+                             255]
+# colormap levels/values for contour boundaries
+colorbarLevelsDifference = [-0.5, -0.2, -0.1, -0.05, -0.02, 0,  0.02, 0.05,
+                            0.1, 0.2, 0.5]

--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -89,3 +89,55 @@ colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227,
 # colormap levels/values for contour boundaries
 colorbarLevelsDifference = [-0.5, -0.2, -0.1, -0.05, -0.02, 0,  0.02, 0.05,
                             0.1, 0.2, 0.5]
+
+
+[woceTransects]
+## options related to plotting model vs. World Ocean Circulation Experiment
+## (WOCE) transects.
+
+# Horizontal bounds of the plot (in km), or an empty list for automatic bounds
+# The bounds are a 2-element list of the minimum and maximum distance along the
+# transect
+horizontalBounds = {'WOCE_A21': [630., 830.],
+                    'WOCE_A23': [0., 200.],
+                    'WOCE_A12': [4620., 4820.]}
+
+[woceTemperatureTransects]
+## options related to plotting WOCE transects of potential temperature
+
+# whether the colormap is indexed or continuous
+colormapTypeResult = indexed
+# color indices into colormapName for filled contours
+colormapIndicesResult = [0, 14, 28, 57, 85, 113, 125, 142, 170, 180, 198, 227,
+                         240, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsResult = [-1.6, -1.2, -0.4, 0.0, 0.4, 0.6, 0.8, 1.0, 1.5, 2.0,
+                        3.0, 4.0, 6.0]
+
+# whether the colormap is indexed or continuous
+colormapTypeDifference = indexed
+# color indices into colormapName for filled contours
+colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227,
+                             255]
+# colormap levels/values for contour boundaries
+colorbarLevelsDifference = [-2, -1.5, -1.25, -1, -0.2, 0, 0.2, 1, 1.25, 1.5, 2]
+
+[woceSalinityTransects]
+## options related to plotting WOCE transects of salinity
+
+# whether the colormap is indexed or continuous
+colormapTypeResult = indexed
+# color indices into colormapName for filled contours
+colormapIndicesResult = [0, 20, 40, 80, 120, 140, 160, 180, 200, 220, 240, 255]
+# colormap levels/values for contour boundaries
+colorbarLevelsResult = [34.1, 34.2,  34.3,  34.4,  34.5, 34.55, 34.6, 34.65,
+                        34.68, 34.7, 35.0]
+
+# whether the colormap is indexed or continuous
+colormapTypeDifference = indexed
+# color indices into colormapName for filled contours
+colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227,
+                             255]
+# colormap levels/values for contour boundaries
+colorbarLevelsDifference = [-0.5, -0.2, -0.1, -0.05, -0.02, 0,  0.02, 0.05,
+                            0.1, 0.2, 0.5]

--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -45,8 +45,8 @@ zmax = 0
 # Center Ross (187=173W), Eastern Ross (198=162W),
 # Amudsen, Thwaites (253=107W), Bellingshausen (280=80W),
 # West Antarctica (288=72W)
-# Note: Transects at XXX, XXX, XXX, XXX and XXX are chosen for comparison with
-#       Whitworth et al. (XXXX) doi: XXXX/XXXX
+# Note: Transects at 325, 145, 160, 184, 198 and 288 are chosen for comparison with
+#       Whitworth et al. (1998) doi: 10.1029/AR075p0001, Figs. 3, 7, 6, 5, 4, 10, respectively.
 longitudes = [318., 325., 0., 75., 117., 145., 160., 184., 187., 198., 253.,
               280., 288.]
 

--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -1,0 +1,33 @@
+[climatologyMapWoa]
+## options related to plotting climatology maps of Temperature and Salinity
+## fields at various levels, including the sea floor against control model
+## results and WOA climatological data
+
+# list of depths in meters (positive up) at which to analyze, 'top' for the
+# sea surface. Note that, for seasons='ANN', depths can be as deep as 5500 m,
+# otherwise use a maximum depth of 1500 m.
+depths = ['top', -50, -200, -400, -600, -800]
+
+[climatologyMapWoaTemperature]
+## options related to plotting climatology maps of potential temperature
+## at various levels, including the sea floor against control model results
+## and WOA18 climatological data
+
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': -2., 'vmax': 2.}
+
+[climatologyMapWoaSalinity]
+## options related to plotting climatology maps of salinity
+## at various levels, including the sea floor against control model results
+## and WOA18 climatological data
+
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
+
+[TSDiagramsForAntarcticRegions]
+## options related to plotting T/S diagrams of Antarctic regions
+
+# The minimum and maximum depth over which fields are plotted, default is
+# to take these values from the geojson feature's zmin and zmax properties.
+zmin = -1000
+zmax = 0

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -464,12 +464,12 @@ colormapName = balance
 # whether the colormap is indexed or continuous
 colormapType = indexed
 # color indices into colormapName for filled contours
-colormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+colormapIndices = [0, 28, 57, 85, 113, 125, 130, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-colorbarLevels = [-1, -0.5, -0.2, -0.05, 0, 0.05, 0.2, 0.5, 1]
+colorbarLevels = [-2.0, -1.0, -0.5, -0.25, -0.1, 0, 0.1, 0.25, 0.5, 1.0, 2.0]
 # contour line levels (use [] for automatic contour selection, 'none' for no
 # contour lines)
-contourLevels = np.arange(-1.0, 1.26, 0.25)
+contourLevels = np.arange(-5.0, 5.51, 0.5)
 
 # An optional first year for the tick marks on the x axis. Leave commented out
 # to start at the beginning of the time series.
@@ -498,12 +498,14 @@ colormapName = balance
 # whether the colormap is indexed or continuous
 colormapType = indexed
 # color indices into colormapName for filled contours
-colormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+#colormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+colormapIndices = [0, 28, 57, 85, 113, 125, 130, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-colorbarLevels = [-0.1, -0.02, -0.003, -0.001, 0, 0.001, 0.003, 0.02, 0.1]
+#colorbarLevels = [-0.1, -0.02, -0.003, -0.001, 0, 0.001, 0.003, 0.02, 0.1]
+colorbarLevels = [-1.0, -0.5, -0.2, -0.1, -0.02, 0, 0.02, 0.1, 0.2, 0.5, 1.0]
 # contour line levels (use [] for automatic contour selection, 'none' for no
 # contour lines)
-contourLevels = np.arange(-0.1, 0.11, 0.02)
+contourLevels = np.arange(-2., 2.01, 0.2)
 
 # An optional first year for the tick marks on the x axis. Leave commented out
 # to start at the beginning of the time series.
@@ -636,7 +638,7 @@ colormapNameResult = RdYlBu_r
 # whether the colormap is indexed or continuous
 colormapTypeResult = indexed
 # colormap indices for contour color
-colormapIndicesResult = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+colormapIndicesResult = [0, 20, 40, 80, 110, 140, 170, 200, 230, 242, 255]
 # colorbar levels/values for contour boundaries
 colorbarLevelsResult = [-20, -10, -5, -2, 2, 5, 10, 20, 30, 40]
 # contour line levels (use [] for automatic contour selection, 'none' for no
@@ -672,9 +674,9 @@ colormapNameResult = RdYlBu_r
 # whether the colormap is indexed or continuous
 colormapTypeResult = indexed
 # colormap indices for contour color
-colormapIndicesResult = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+colormapIndicesResult = [0, 20, 40, 80, 110, 140, 170, 200, 230, 242, 255]
 # colorbar levels/values for contour boundaries
-colorbarLevelsResult = [-10, -5, -2, 0, 5, 8, 10, 14, 18, 22]
+colorbarLevelsResult = [-5, -2, 0, 2, 5, 8, 10, 12, 14, 18]
 # contour line levels (use [] for automatic contour selection, 'none' for no
 # contour lines)
 contourLevelsResult = np.arange(-8, 20.1, 2)
@@ -1843,7 +1845,7 @@ normTypeResult = linear
 # A dictionary with keywords for the norm
 normArgsResult = {'vmin': -2., 'vmax': 30.}
 # place the ticks automatically by default
-# colorbarTicksResult = numpy.linspace(-2., 2., 9)
+# colorbarTicksResult = numpy.linspace(-2., 30., 9)
 
 # colormap for differences
 colormapNameDifference = balance
@@ -1852,9 +1854,9 @@ colormapTypeDifference = continuous
 # the type of norm used in the colormap
 normTypeDifference = linear
 # A dictionary with keywords for the norm
-normArgsDifference = {'vmin': -2., 'vmax': 2.}
+normArgsDifference = {'vmin': -5., 'vmax': 5.}
 # place the ticks automatically by default
-# colorbarTicksDifference = numpy.linspace(-2., 2., 9)
+# colorbarTicksDifference = numpy.linspace(-5., 5., 9)
 
 
 [climatologyMapArgoSalinity]
@@ -1882,7 +1884,7 @@ normTypeResult = linear
 # A dictionary with keywords for the norm
 normArgsResult = {'vmin': 30, 'vmax': 39.0}
 # place the ticks automatically by default
-# colorbarTicksResult = numpy.linspace(34.2, 35.2, 9)
+# colorbarTicksResult = numpy.linspace(30.0, 39.0, 9)
 
 # colormap for differences
 colormapNameDifference = balance
@@ -1891,9 +1893,9 @@ colormapTypeDifference = continuous
 # the type of norm used in the colormap
 normTypeDifference = linear
 # A dictionary with keywords for the norm
-normArgsDifference = {'vmin': -0.5, 'vmax': 0.5}
+normArgsDifference = {'vmin': -1.5, 'vmax': 1.5}
 # place the ticks automatically by default
-# colorbarTicksDifference = numpy.linspace(-0.5, 0.5, 9)
+# colorbarTicksDifference = numpy.linspace(-1.5, 1.5, 9)
 
 
 [climatologyMapSchmidtko]


### PR DESCRIPTION
This file `configs/polarRegions.conf` contains new "defaults" for E3SM cryosphere runs that should override the defaults in `mpas_analysis/config.default`

Also updates values in `config.default` for colormap indices and colorbar ranges for the MOC, Hovmoller temperature and salinity anomaly, and Argo bias plots.

Example usage (see `configs/README.md`):
```
python -m mpas_analysis configs/polarRegions.conf my_favorite.conf --generate=climatologyMapSSH --purge
```

If using the conda package, you'll need to download https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/develop/configs/polarRegions.conf and then run something like:
```
mpas_analysis polarRegions.conf my_favorite.conf --generate=climatologyMapSSH --purge
```