### PR TITLE
Shorten image gallery text for config file name

### DIFF
--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -234,8 +234,12 @@ class MainPage(object):
 
         configsText = ''
         for configFileName in self.customConfigFiles:
+            shortName = os.path.basename(configFileName)
+            if len(shortName) > 30:
+                shortName = shortName[0:30]
+
             replacements = {'@configName': os.path.basename(configFileName),
-                            '@configDesc': os.path.basename(configFileName)}
+                            '@configDesc': shortName}
 
             configsText = configsText + \
                 _replace_tempate_text(self.configTemplate, replacements)


### PR DESCRIPTION
Very long names for config files are now truncated so they don't look weird in the gallery on the main page.