### PR TITLE
Separate shallow and deep color maps for some analysis tasks

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1406,7 +1406,7 @@ fieldList = ['temperature', 'salinity', 'potentialDensity', 'mixedLayerDepth',
 fileSuffix = 6000.0x6000.0km_10.0km_Antarctic_stereo_20180710
 
 # depth separating shallow from deep color maps
-shallowVsDeepColormapDepth = -500
+shallowVsDeepColormapDepth = -1000
 
 
 [climatologyMapSoseTemperatureShallow]
@@ -1704,7 +1704,7 @@ depths = ['top', -500, -1000]
 fieldList = ['temperature', 'salinity']
 
 # depth separating shallow from deep color maps
-shallowVsDeepColormapDepth = -500
+shallowVsDeepColormapDepth = -1000
 
 
 [climatologyMapWoaTemperatureShallow]

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1405,7 +1405,38 @@ fieldList = ['temperature', 'salinity', 'potentialDensity', 'mixedLayerDepth',
 # grid from the default
 fileSuffix = 6000.0x6000.0km_10.0km_Antarctic_stereo_20180710
 
-[climatologyMapSoseTemperature]
+# depth separating shallow from deep color maps
+shallowVsDeepColormapDepth = -500
+
+
+[climatologyMapSoseTemperatureShallow]
+## options related to plotting climatology maps of Antarctic
+## potential temperature at various levels, including the sea floor against
+## control model results and SOSE reanalysis data
+
+# colormap for model/observations
+colormapNameResult = RdYlBu_r
+# whether the colormap is indexed or continuous
+colormapTypeResult = continuous
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': -2., 'vmax': 10.}
+# place the ticks automatically by default
+# colorbarTicksResult = numpy.linspace(-2., 10., 9)
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = continuous
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the norm
+normArgsDifference = {'vmin': -5., 'vmax': 5.}
+# place the ticks automatically by default
+# colorbarTicksDifference = numpy.linspace(-5., 5., 9)
+
+[climatologyMapSoseTemperatureDeep]
 ## options related to plotting climatology maps of Antarctic
 ## potential temperature at various levels, including the sea floor against
 ## control model results and SOSE reanalysis data
@@ -1433,7 +1464,34 @@ normArgsDifference = {'vmin': -2., 'vmax': 2.}
 # colorbarTicksDifference = numpy.linspace(-2., 2., 9)
 
 
-[climatologyMapSoseSalinity]
+[climatologyMapSoseSalinityShallow]
+## options related to plotting climatology maps of Antarctic
+## salinity at various levels, including the sea floor against
+## control model results and SOSE reanalysis data
+
+# colormap for model/observations
+colormapNameResult = haline
+# whether the colormap is indexed or continuous
+colormapTypeResult = continuous
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': 32.2, 'vmax': 35.5}
+# place the ticks automatically by default
+# colorbarTicksResult = numpy.linspace(32.2, 35.5, 9)
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = continuous
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the norm
+normArgsDifference = {'vmin': -1.5, 'vmax': 1.5}
+# place the ticks automatically by default
+# colorbarTicksDifference = numpy.linspace(-1.5, 1.5, 9)
+
+[climatologyMapSoseSalinityDeep]
 ## options related to plotting climatology maps of Antarctic
 ## salinity at various levels, including the sea floor against
 ## control model results and SOSE reanalysis data
@@ -1447,7 +1505,7 @@ normTypeResult = linear
 # A dictionary with keywords for the norm
 normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
 # place the ticks automatically by default
-# colorbarTicksResult = numpy.linspace(34.2, 35.2, 9)
+# colorbarTicksResult = numpy.linspace(33.8, 35.0, 9)
 
 # colormap for differences
 colormapNameDifference = balance
@@ -1461,7 +1519,7 @@ normArgsDifference = {'vmin': -0.5, 'vmax': 0.5}
 # colorbarTicksDifference = numpy.linspace(-0.5, 0.5, 9)
 
 
-[climatologyMapSosePotentialDensity]
+[climatologyMapSosePotentialDensityShallow]
 ## options related to plotting climatology maps of Antarctic
 ## potential density at various levels, including the sea floor against
 ## control model results and SOSE reanalysis data
@@ -1475,7 +1533,34 @@ normTypeResult = linear
 # A dictionary with keywords for the norm
 normArgsResult = {'vmin': 1026.5, 'vmax': 1028.}
 # place the ticks automatically by default
-# colorbarTicksResult = numpy.linspace(1026., 1028., 9)
+# colorbarTicksResult = numpy.linspace(1026.5, 1028., 9)
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = continuous
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the norm
+normArgsDifference = {'vmin': -0.3, 'vmax': 0.3}
+# place the ticks automatically by default
+# colorbarTicksDifference = numpy.linspace(-0.3, 0.3, 9)
+
+[climatologyMapSosePotentialDensityDeep]
+## options related to plotting climatology maps of Antarctic
+## potential density at various levels, including the sea floor against
+## control model results and SOSE reanalysis data
+
+# colormap for model/observations
+colormapNameResult = Spectral_r
+# whether the colormap is indexed or continuous
+colormapTypeResult = continuous
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': 1027.2, 'vmax': 1028.2}
+# place the ticks automatically by default
+# colorbarTicksResult = numpy.linspace(1027.2, 1028.2, 9)
 
 # colormap for differences
 colormapNameDifference = balance

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1703,7 +1703,11 @@ depths = ['top', -500, -1000]
 # below
 fieldList = ['temperature', 'salinity']
 
-[climatologyMapWoaTemperature]
+# depth separating shallow from deep color maps
+shallowVsDeepColormapDepth = -500
+
+
+[climatologyMapWoaTemperatureShallow]
 ## options related to plotting climatology maps of potential temperature
 ## at various levels, including the sea floor against control model results
 ## and WOA18 climatological data
@@ -1716,6 +1720,33 @@ colormapTypeResult = continuous
 normTypeResult = linear
 # A dictionary with keywords for the norm
 normArgsResult = {'vmin': -2., 'vmax': 10.}
+# place the ticks automatically by default
+# colorbarTicksResult = numpy.linspace(-2., 10., 9)
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = continuous
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the norm
+normArgsDifference = {'vmin': -5., 'vmax': 5.}
+# place the ticks automatically by default
+# colorbarTicksDifference = numpy.linspace(-5., 5., 9)
+
+[climatologyMapWoaTemperatureDeep]
+## options related to plotting climatology maps of potential temperature
+## at various levels, including the sea floor against control model results
+## and WOA18 climatological data
+
+# colormap for model/observations
+colormapNameResult = RdYlBu_r
+# whether the colormap is indexed or continuous
+colormapTypeResult = continuous
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': -2., 'vmax': 2.}
 # place the ticks automatically by default
 # colorbarTicksResult = numpy.linspace(-2., 2., 9)
 
@@ -1731,7 +1762,7 @@ normArgsDifference = {'vmin': -2., 'vmax': 2.}
 # colorbarTicksDifference = numpy.linspace(-2., 2., 9)
 
 
-[climatologyMapWoaSalinity]
+[climatologyMapWoaSalinityShallow]
 ## options related to plotting climatology maps of salinity
 ## at various levels, including the sea floor against control model results
 ## and WOA18 climatological data
@@ -1743,9 +1774,36 @@ colormapTypeResult = continuous
 # the type of norm used in the colormap
 normTypeResult = linear
 # A dictionary with keywords for the norm
-normArgsResult = {'vmin': 32.5, 'vmax': 35.5}
+normArgsResult = {'vmin': 32.2, 'vmax': 35.5}
 # place the ticks automatically by default
-# colorbarTicksResult = numpy.linspace(34.2, 35.2, 9)
+# colorbarTicksResult = numpy.linspace(32.2, 35.5, 9)
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = continuous
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the norm
+normArgsDifference = {'vmin': -1.5, 'vmax': 1.5}
+# place the ticks automatically by default
+# colorbarTicksDifference = numpy.linspace(-1.5, 1.5, 9)
+
+[climatologyMapWoaSalinityDeep]
+## options related to plotting climatology maps of salinity
+## at various levels, including the sea floor against control model results
+## and WOA18 climatological data
+
+# colormap for model/observations
+colormapNameResult = haline
+# whether the colormap is indexed or continuous
+colormapTypeResult = continuous
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
+# place the ticks automatically by default
+# colorbarTicksResult = numpy.linspace(33.8, 35.0, 9)
 
 # colormap for differences
 colormapNameDifference = balance
@@ -1757,6 +1815,7 @@ normTypeDifference = linear
 normArgsDifference = {'vmin': -0.5, 'vmax': 0.5}
 # place the ticks automatically by default
 # colorbarTicksDifference = numpy.linspace(-0.5, 0.5, 9)
+
 
 
 [climatologyMapArgoTemperature]

--- a/mpas_analysis/ocean/climatology_map_sose.py
+++ b/mpas_analysis/ocean/climatology_map_sose.py
@@ -247,8 +247,8 @@ class ClimatologyMapSose(AnalysisTask):  # {{{
                 fieldDepths = [None]
 
             for comparisonGridName in comparisonGridNames:
-                for season in seasons:
-                    for depthIndex, depth in enumerate(fieldDepths):
+                for depthIndex, depth in enumerate(fieldDepths):
+                    for season in seasons:
 
                         subtaskName = 'plot{}_{}_{}'.format(upperFieldPrefix,
                                                             season,

--- a/mpas_analysis/ocean/climatology_map_woa.py
+++ b/mpas_analysis/ocean/climatology_map_woa.py
@@ -200,12 +200,12 @@ class ClimatologyMapWoa(AnalysisTask):  # {{{
                 diffTitleLabel = 'Main - Control'
 
             for comparisonGridName in comparisonGridNames:
-                for season in seasons:
-                    if season == 'ANN':
-                        remapObsSubtask = remapAnnObsSubtask
-                    else:
-                        remapObsSubtask = remapMonObsSubtask
-                    for depthIndex, depth in enumerate(depths):
+                for depthIndex, depth in enumerate(depths):
+                    for season in seasons:
+                        if season == 'ANN':
+                            remapObsSubtask = remapAnnObsSubtask
+                        else:
+                            remapObsSubtask = remapMonObsSubtask
 
                         subtaskName = 'plot{}_{}_{}_depth_{}'.format(
                                                             upperFieldPrefix,

--- a/mpas_analysis/ocean/climatology_map_woa.py
+++ b/mpas_analysis/ocean/climatology_map_woa.py
@@ -109,6 +109,18 @@ class ClimatologyMapWoa(AnalysisTask):  # {{{
 
         variableList = [field['mpas'] for field in fields]
 
+        shallowVsDeepColormapDepth = config.getfloat(
+            sectionName, 'shallowVsDeepColormapDepth')
+
+        shallow = []
+        for depth in depths:
+            if depth == 'top':
+                shallow.append(True)
+            elif depth == 'bot':
+                shallow.append(False)
+            else:
+                shallow.append(depth >= shallowVsDeepColormapDepth)
+
         remapMpasSubtask = RemapDepthSlicesSubtask(
             mpasClimatologyTask=mpasClimatologyTask,
             parentTask=self,
@@ -193,7 +205,7 @@ class ClimatologyMapWoa(AnalysisTask):  # {{{
                         remapObsSubtask = remapAnnObsSubtask
                     else:
                         remapObsSubtask = remapMonObsSubtask
-                    for depth in depths:
+                    for depthIndex, depth in enumerate(depths):
 
                         subtaskName = 'plot{}_{}_{}_depth_{}'.format(
                                                             upperFieldPrefix,
@@ -211,6 +223,21 @@ class ClimatologyMapWoa(AnalysisTask):  # {{{
                             depth=depth,
                             subtaskName=subtaskName)
 
+                        configSectionName = 'climatologyMapWoa{}'.format(
+                                upperFieldPrefix)
+
+                        # if available, use a separate color map for shallow
+                        # and deep
+                        if depth is not None:
+                            if shallow[depthIndex]:
+                                suffix = 'Shallow'
+                            else:
+                                suffix = 'Deep'
+                            testSectionName = '{}{}'.format(configSectionName,
+                                                            suffix)
+                            if config.has_section(testSectionName):
+                                configSectionName = testSectionName
+
                         subtask.set_plot_info(
                             outFileLabel=outFileLabel,
                             fieldNameInTitle=field['titleName'],
@@ -224,8 +251,7 @@ class ClimatologyMapWoa(AnalysisTask):  # {{{
                             groupSubtitle=None,
                             groupLink='{}_woa'.format(fieldPrefix),
                             galleryName=galleryName,
-                            configSectionName='climatologyMapWoa{}'.format(
-                                upperFieldPrefix))
+                            configSectionName=configSectionName)
 
                         self.add_subtask(subtask)
         # }}}


### PR DESCRIPTION
In the SOSE and WOA18 climatology maps and only for temperature, salinity and potential density,
not velocities, set up a different color map (with a different range) for shallow depths (above -500 m by default) and deeper depths.

closes #642 