### PR TITLE
Add support for log norm for T-S Diagrams

### DIFF
--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -25,6 +25,13 @@ normArgsResult = {'vmin': -2., 'vmax': 2.}
 normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
 
 
+[regionalTSDiagrams]
+## options related to plotting T/S diagrams of ocean regions
+
+# the names of region groups to plot, each with its own section below
+regionGroups = ['Antarctic Regions', 'Ocean Basins']
+
+
 [TSDiagramsForAntarcticRegions]
 ## options related to plotting T/S diagrams of Antarctic regions
 

--- a/docs/config/climatology.rst
+++ b/docs/config/climatology.rst
@@ -136,7 +136,7 @@ Other Options
 -------------
 
 * :ref:`config_comparison_grids`
-* :ref:`dask_treads`
+* :ref:`dask_threads`
 
 .. _`Common Ocean Reference Experiments, CORE`: http://data1.gfdl.noaa.gov/nomads/forms/mom4/CORE.html
 .. _`ESMF_RegridWeightGen tool`: http://www.earthsystemmodeling.org/esmf_releases/public/ESMF_7_1_0r/ESMF_refdoc/node3.html#SECTION03020000000000000000

--- a/docs/config/dask_threads.rst
+++ b/docs/config/dask_threads.rst
@@ -27,7 +27,7 @@ it is possible to spawn huge numbers of dask threads in MPAS-Analysis that both
 slow down analysis and lead to errors when the node runs out of threads
 completely.
 
-To prevent this, many tasks or subtasks that use dask treading take the number
+To prevent this, many tasks or subtasks that use dask threading take the number
 of execution threads from a config option, typically in the config section for
 the parent task.  Typically, the number of ``daskThreads`` should be around
 the same as the number of cores on a node divided by the number of tasks
@@ -38,7 +38,7 @@ by ``subprocessCount``, see below, this number might differ from
 Subprocess count
 ----------------
 
-Tasks or subtasks that use dask treading may consume too much memory or use
+Tasks or subtasks that use dask threading may consume too much memory or use
 too many threads to "count" as a single task.  That is, it might not be safe to
 run with ``parallelTaskCount`` simultaneious instances of the task/subtask and
 it would be better if it occupied the slot of multiple tasks in the pool of

--- a/docs/config/dask_threads.rst
+++ b/docs/config/dask_threads.rst
@@ -1,7 +1,7 @@
-.. _dask_treads:
+.. _dask_threads:
 
-Dask treads and subprocess count
-================================
+Dask threads and subprocess count
+=================================
 
 Several tasks and subtasks have config options ``daskThreads`` and
 ``subprocessCount`` used to control threading within a subtask::
@@ -15,15 +15,15 @@ Several tasks and subtasks have config options ``daskThreads`` and
   # memory, so that fewer tasks will be allowed to run at once
   subprocessCount = 1
 
-Dask treads
------------
+Dask threads
+------------
 
 Dask and xarray support thread-parallel operations on data sets.  They also
 support chunk-wise operation on data sets that can't fit in memory.  These
 capabilities are very powerful but also difficult to configure for general
 cases.  Dask is also not desigend by default with the idea that multiple tasks,
-each with multiple dask treads, might operate simultaneously.  As a result,
-it is possible to spawn huge numbers of dask treads in MPAS-Analysis that both
+each with multiple dask threads, might operate simultaneously.  As a result,
+it is possible to spawn huge numbers of dask threads in MPAS-Analysis that both
 slow down analysis and lead to errors when the node runs out of threads
 completely.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -16,6 +16,7 @@ options that are most commonly modified.
 
    config/runs
    config/execute
+   config/dask_threads
    config/diagnostics
    config/input
    config/output

--- a/docs/tasks/regionalTSDiagrams.rst
+++ b/docs/tasks/regionalTSDiagrams.rst
@@ -4,7 +4,7 @@ regionalTSDiagrams
 ==================
 
 An analysis task for plotting T-S (potential temperature vs. salinity)
-diagrams of climatologis in ocean regions.
+diagrams of climatologies in ocean regions.
 
 Component and Tags::
 
@@ -20,7 +20,7 @@ The following configuration options are available for this task::
     ## options related to plotting T/S diagrams of ocean regions
 
     # the names of region groups to plot, each with its own section below
-    regionGroups = ['Antarctic Regions', 'Ocean Basins']
+    regionGroups = ['Ocean Basins']
 
     # a list of seasons to compute climatologies over
     seasons = ['ANN']
@@ -68,6 +68,8 @@ The following configuration options are available for this task::
     colormap = white_cmo_deep
     # The following is more appropriate if diagramType == 'scatter'
     # colormap = cmo.deep_r
+    # the type of norm used in the colormap {'linear', 'log'}
+    normType = log
 
     # The minimum and maximum depth over which fields are plotted, default is
     # to take these values from the geojson feature's zmin and zmax properties.
@@ -109,6 +111,8 @@ The following configuration options are available for this task::
     colormap = white_cmo_deep
     # The following is more appropriate if diagramType == 'scatter'
     # colormap = cmo.deep_r
+    # the type of norm used in the colormap {'linear', 'log'}
+    normType = log
 
     # The minimum and maximum depth over which fields are plotted.
     zmin = -1000
@@ -120,18 +124,18 @@ The following configuration options are available for this task::
 Region Groups
 -------------
 
-A list of groups of regions, each of which will get its own gallery group on
-the resulting analysis webpage.  These can be any name without punctuation.
+A list of groups of regions, each of which will get its own gallery on
+the resulting analysis web page.  These can be any name without punctuation.
 For each region group, there should be a corresponding
 ``TSDiagramsFor<RegionGroup>`` section of the config file, with any spaces
 removed from the name of the region group.  By default, the only region group
-is "Antarctic Regions".
+is "Ocean Basins".
 
 Region Mask
 -----------
 
 The ``regionMask`` is a geojson file produce from the ``geometric_features``
-packge.  It should include any number of ocean regions, each of which includes
+package.  It should include any number of ocean regions, each of which includes
 properties ``zmin`` and ``zmax``.  Examples of how to create such a set of
 features can be found in `antarctic_ocean_regions`_.
 
@@ -160,15 +164,22 @@ Diagram Type
 ------------
 
 By default, a "volumetric" diagram is produced, where the volume of ocean water
-in a reigon is binned in T and S space, and the volume of each bin is plotted.
+in a region is binned in T and S space, and the volume of each bin is plotted.
 This allows for more quantitative comparison with observation- and model-based
 climatologies.
 
 If ``diagramType`` is set to ``scatter``, a point cloud is plotted instead,
 shaded by depth.  We anticipate that this will useful for plotting data sets
 that are spatially scattered (e.g. the MEOP seal data), because each sample
-does not correspond to a volume.  This type of dyagram may also be helpful for
+does not correspond to a volume.  This type of diagram may also be helpful for
 comparison with publications that use scatter plots.
+
+For volumetric diagrams, two norms for the continuous color map are supported,
+``linear`` and ``log``, with ``log`` being the default.  The range of the
+colormap is is between zero and the maximum bin volume for ``linear`` and
+between the minimum non-zero bin volume and the max for ``log``.  The min/max
+bin volume is taken from the first panel containing the "main" MPAS-Ocean plot,
+and the same color map range is used for all panels.
 
 Bins and Contour Intervals
 --------------------------

--- a/docs/tasks/regionalTSDiagrams.rst
+++ b/docs/tasks/regionalTSDiagrams.rst
@@ -197,7 +197,7 @@ For more details on the remaining config options, see
  * :ref:`config_regions`
  * :ref:`config_seasons`
  * :ref:`config_colormaps`
- * :ref:`dask_treads`
+ * :ref:`dask_threads`
 
 Example Result
 --------------

--- a/docs/tasks/timeSeriesAntarcticMelt.rst
+++ b/docs/tasks/timeSeriesAntarcticMelt.rst
@@ -109,7 +109,7 @@ Other Options
 
 * :ref:`config_moving_average`
 * :ref:`config_time_axis_ticks`
-* :ref:`dask_treads`
+* :ref:`dask_threads`
 
 Observations
 ------------

--- a/docs/tasks/timeSeriesOceanRegions.rst
+++ b/docs/tasks/timeSeriesOceanRegions.rst
@@ -109,7 +109,7 @@ corresponding field in the MPAS-Ocean ``timeSeriesStatsMonthlyOutput`` files.
 Other Options
 -------------
 
-* :ref:`dask_treads`
+* :ref:`dask_threads`
 
 Example Result
 --------------

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1283,7 +1283,7 @@ variables = [{'name': 'temperature',
 ## options related to plotting T/S diagrams of ocean regions
 
 # the names of region groups to plot, each with its own section below
-regionGroups = ['Antarctic Regions', 'Ocean Basins']
+regionGroups = ['Ocean Basins']
 
 # a list of seasons to compute climatologies over
 seasons = ['ANN']

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1321,8 +1321,8 @@ diagramType = volumetric
 # if diagramType == 'volumetric', the bin boundaries for T and S
 # if diagramType == 'scatter', only the min and max are important (and the
 #   bins are only used for computing neutral density contours)
-Tbins = numpy.linspace(-2.5, 4, 66)
-Sbins = numpy.linspace(33.8, 34.8, 51)
+Tbins = numpy.linspace(-2.5, 4, 651)
+Sbins = numpy.linspace(33.8, 34.8, 1001)
 
 # density contour interval
 rhoInterval = 0.1
@@ -1331,6 +1331,8 @@ rhoInterval = 0.1
 colormap = white_cmo_deep
 # The following is more appropriate if diagramType == 'scatter'
 # colormap = cmo.deep_r
+# the type of norm used in the colormap {'linear', 'log'}
+normType = log
 
 # The minimum and maximum depth over which fields are plotted, default is
 # to take these values from the geojson feature's zmin and zmax properties.
@@ -1362,8 +1364,8 @@ diagramType = volumetric
 # if diagramType == 'volumetric', the bin boundaries for T and S
 # if diagramType == 'scatter', only the min and max are important (and the
 #   bins are only used for computing neutral density contours)
-Tbins = numpy.linspace(-2.5, 16, 75)
-Sbins = numpy.linspace(33.8, 35.8, 101)
+Tbins = numpy.linspace(-2.5, 16, 926)
+Sbins = numpy.linspace(33.8, 35.8, 1001)
 
 # density contour interval
 rhoInterval = 0.2
@@ -1372,6 +1374,8 @@ rhoInterval = 0.2
 colormap = white_cmo_deep
 # The following is more appropriate if diagramType == 'scatter'
 # colormap = cmo.deep_r
+# the type of norm used in the colormap {'linear', 'log'}
+normType = log
 
 # The minimum and maximum depth over which fields are plotted.
 zmin = -1000


### PR DESCRIPTION
Log norm is now the default.  The number of bins for T-S diagrams has also been increased substantially to give more visually pleasing and more detailed diagrams.

Fix a bug in the docs related to dask threads (and not directly related to T-S diagrams, but still...)

Some clean-up of T-S diagram task suggested by pycharm.