### PR TITLE
Fix norm for empty TS diagrams

### DIFF
--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -42,7 +42,6 @@ normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
 # the names of region groups to plot, each with its own section below
 regionGroups = ['Antarctic Regions', 'Ocean Basins']
 
-
 [TSDiagramsForAntarcticRegions]
 ## options related to plotting T/S diagrams of Antarctic regions
 
@@ -50,6 +49,16 @@ regionGroups = ['Antarctic Regions', 'Ocean Basins']
 # to take these values from the geojson feature's zmin and zmax properties.
 zmin = -1000
 zmax = 0
+
+[TSDiagramsForOceanBasins]
+## options related to plotting T/S diagrams of major ocean basins
+
+# list of regions to plot or ['all'] for all regions in the masks file.
+# See "regionNames" in the antarcticRegions masks file in
+# regionMaskSubdirectory for details.
+regionNames = ["Atlantic_Basin", "Pacific_Basin", "Indian_Basin",
+               "Arctic_Basin", "Southern_Ocean_Basin",
+               "Global Ocean", "Global Ocean 65N to 65S"]
 
 
 [soseTransects]

--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -703,10 +703,14 @@ class PlotRegionTSDiagramSubtask(AnalysisTask):
                 if normType == 'linear':
                     norm = colors.Normalize(vmin=0., vmax=volMaxMpas)
                 elif normType == 'log':
-                    norm = colors.LogNorm(vmin=volMinMpas, vmax=volMaxMpas)
+                    if volMinMpas is None or volMaxMpas is None:
+                        norm = None
+                    else:
+                        norm = colors.LogNorm(vmin=volMinMpas, vmax=volMaxMpas)
                 else:
                     raise ValueError('Unsupported normType {}'.format(normType))
-                lastPanel.set_norm(norm)
+                if norm is not None:
+                    lastPanel.set_norm(norm)
             else:
                 lastPanel = self._plot_scatter_panel(T, S, z, zmin, zmax)
 


### PR DESCRIPTION
The log norm raises an error if the limits are set to `None`, so don't set a norm if there aren't any values.

Also, remove some unneeded regions from TS diagrams in the polar regions config.