### PR TITLE
Change the way for checking if a symlink is needed

### DIFF
--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -432,8 +432,10 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
                 '{:02d}-01.nc'.format(symlinkDirectory, self.ncclimoModel,
                                       year, month)
 
-            if not os.path.exists(outFileName):
+            try:
                 os.symlink(inFileName, outFileName)
+            except OSError:
+                pass
 
         return symlinkDirectory
 


### PR DESCRIPTION
Since multiple tasks may be creating the same symlink, a try/except approach is more robust than checking if the file exists.