### PR TITLE
Make regionalTSDiagram plots run after climatology

### DIFF
--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -523,6 +523,7 @@ class PlotRegionTSDiagramSubtask(AnalysisTask):
             tags=parentTask.tags,
             subtaskName='plot{}_{}'.format(fullSuffix, season))
 
+        self.run_after(mpasClimatologyTask)
         self.regionGroup = regionGroup
         self.regionName = regionName
         self.sectionName = sectionName


### PR DESCRIPTION
In some configurations of MPAS-Analysis (those on ALCF using xarray/dask to compute climatologies), regional T-S diagrams are attempting to run before the annual climatology they depend on has been computed.