### PR TITLE
Make masks for all features, not just the requested ones

### DIFF
--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -104,7 +104,7 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
 
         masksSubtask = ComputeRegionMasksSubtask(
             self, masksFile, outFileSuffix=self.regionMaskSuffix,
-            featureList=self.regionNames, subprocessCount=parallelTaskCount)
+            featureList=None, subprocessCount=parallelTaskCount)
 
         if 'all' in self.regionNames:
             self.regionNames = get_feature_list(config, masksFile)

--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -179,7 +179,7 @@ class RegionalTSDiagrams(AnalysisTask):  # {{{
             subtaskName = 'computeMpas{}Masks'.format(sectionSuffix)
             mpasMasksSubtask = ComputeRegionMasksSubtask(
                 self, regionMaskFile, outFileSuffix=fileSuffix,
-                featureList=regionNames, subtaskName=subtaskName,
+                featureList=None, subtaskName=subtaskName,
                 subprocessCount=parallelTaskCount)
 
             self.add_subtask(mpasMasksSubtask)
@@ -196,7 +196,7 @@ class RegionalTSDiagrams(AnalysisTask):  # {{{
                     relativePath=localObsDict['gridFileName'])
                 obsMasksSubtask = ComputeRegionMasksSubtask(
                     self, regionMaskFile, outFileSuffix=fileSuffix,
-                    featureList=regionNames, subtaskName=subtaskName,
+                    featureList=None, subtaskName=subtaskName,
                     subprocessCount=parallelTaskCount,
                     obsFileName=obsFileName, lonVar=localObsDict['lonVar'],
                     latVar=localObsDict['latVar'],

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -89,7 +89,7 @@ class TimeSeriesAntarcticMelt(AnalysisTask):  # {{{
 
         masksSubtask = ComputeRegionMasksSubtask(
             self, self.iceShelfMasksFile, outFileSuffix='iceShelfMasks',
-            featureList=iceShelvesToPlot, subprocessCount=parallelTaskCount)
+            featureList=None, subprocessCount=parallelTaskCount)
 
         self.add_subtask(masksSubtask)
 

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -99,7 +99,7 @@ class TimeSeriesOceanRegions(AnalysisTask):  # {{{
             subtaskName = 'compute{}Masks'.format(sectionSuffix)
             masksSubtask = ComputeRegionMasksSubtask(
                 self, regionMaskFile, outFileSuffix=fileSuffix,
-                featureList=regionNames, subtaskName=subtaskName,
+                featureList=None, subtaskName=subtaskName,
                 subprocessCount=parallelTaskCount,)
 
             self.add_subtask(masksSubtask)


### PR DESCRIPTION
We want mask files that can be used on any run, not just the current one so it would be best to create masks for all features, not just the ones requested in the current analysis run.