### PR TITLE
Make T-S diagram tasks run after mask tasks

### DIFF
--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -609,12 +609,22 @@ class ComputeRegionTSSubtask(AnalysisTask):
             if config.has_option(sectionName, 'zmin'):
                 zmin = config.getfloat(sectionName, 'zmin')
             else:
-                zmin = dsMask.zmin.values
+                if 'zminRegions' in dsMask:
+                    zmin = dsMask.zminRegions.values
+                else:
+                    # the old naming convention, used in some pre-generated
+                    # mask files
+                    zmin = dsMask.zmin.values
 
             if config.has_option(sectionName, 'zmax'):
                 zmax = config.getfloat(sectionName, 'zmax')
             else:
-                zmax = dsMask.zmax.values
+                if 'zmaxRegions' in dsMask:
+                    zmax = dsMask.zmaxRegions.values
+                else:
+                    # the old naming convention, used in some pre-generated
+                    # mask files
+                    zmax = dsMask.zmax.values
 
             inFileName = get_unmasked_mpas_climatology_file_name(
                 config, self.season, self.componentName, op='avg')

--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -527,6 +527,7 @@ class ComputeRegionTSSubtask(AnalysisTask):
             subtaskName='compute{}_{}'.format(fullSuffix, season))
 
         self.run_after(mpasClimatologyTask)
+        self.run_after(mpasMasksSubtask)
         self.regionGroup = regionGroup
         self.regionName = regionName
         self.sectionName = sectionName

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -392,12 +392,22 @@ class ComputeRegionTimeSeriesSubtask(AnalysisTask):  # {{{
                 self.logger.info("Don't worry about the following dask "
                                  "warnings.")
                 if config_zmin is None:
-                    zmin = dsMask.zmin
+                    if 'zminRegions' in dsMask:
+                        zmin = dsMask.zminRegions
+                    else:
+                        # the old naming convention, used in some pre-generated
+                        # mask files
+                        zmin = dsMask.zmin
                 else:
                     zmin = config_zmin
 
                 if config_zmax is None:
-                    zmax = dsMask.zmax
+                    if 'zmaxRegions' in dsMask:
+                        zmax = dsMask.zmaxRegions
+                    else:
+                        # the old naming convention, used in some pre-generated
+                        # mask files
+                        zmax = dsMask.zmax
                 else:
                     zmax = config_zmax
 

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -166,7 +166,7 @@ def compute_monthly_climatology(ds, calendar=None, maskVaries=True):  # {{{
     ds = add_years_months_days_in_month(ds, calendar)
 
     monthlyClimatology = \
-        ds.groupby('month').apply(compute_one_month_climatology)
+        ds.groupby('month').map(compute_one_month_climatology)
 
     return monthlyClimatology  # }}}
 

--- a/mpas_analysis/shared/containers.py
+++ b/mpas_analysis/shared/containers.py
@@ -19,10 +19,10 @@
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-import collections
+from collections.abc import Mapping
 
 
-class ReadOnlyDict(collections.Mapping):  # {{{
+class ReadOnlyDict(Mapping):  # {{{
     """ Read only-dictionary
     http://stackoverflow.com/questions/19022868/how-to-make-dictionary-read-only-in-python
     310/22/2016

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -163,7 +163,8 @@ def compute_lon_lat_region_masks(geojsonFileName, lon, lat, maskFileName,
         dsMasks['regionNames'][index] = regionName
 
     for propertyName in properties:
-        dsMasks[propertyName] = (('nRegions'), properties[propertyName])
+        dsMasks['{}Regions'.format(propertyName)] = \
+            (('nRegions'), properties[propertyName])
 
     write_netcdf(dsMasks, maskFileName)
 


### PR DESCRIPTION
Without this fix, tasks are failing because the mask doesn't exist when it is needed.

Testing of this change also made clear that the mask creator tool (`MasMaskCreator.x`) adds
`Regions` to the end of the geojson properties it stores in mask NetCDF variables.  This merge updates the tasks that use these extra properties (`zmin` and `zmax`) to work with this suffix by default.  For backwards compatibility, the old version without the `Regions` suffix is also supported.

### Clean up
A few things are showing up in `pytest` that are deprecated and which I have fixed here:
* import from `containers.abc` instead of `containers`
* switch from `apply` to `map` in `xarray`'s `group_by` feature.