### PR TITLE
Fix MLD climatology map

### DIFF
--- a/mpas_analysis/ocean/climatology_map_mld.py
+++ b/mpas_analysis/ocean/climatology_map_mld.py
@@ -231,7 +231,7 @@ class RemapObservedMLDClimatology(RemapObservedClimatologySubtask):  # {{{
         dsObs = xr.open_dataset(fileName)
 
         # Increment month value to be consistent with the model output
-        dsObs.iMONTH.values += 1
+        dsObs.assign_coords(iMONTH=dsObs.iMONTH+1)
         # Rename the dimensions to be consistent with other obs. data sets
         dsObs = dsObs.rename({'month': 'calmonth', 'lat': 'latCoord',
                               'lon': 'lonCoord', 'mld_dt_mean': 'mld'})


### PR DESCRIPTION
`xarray` requires a different syntax for modifying coordinates than was previously allowed.

closes #687 