### PR TITLE
Mask sea-ice bias points where no observation data is present

### DIFF
--- a/mpas_analysis/sea_ice/plot_climatology_map_subtask.py
+++ b/mpas_analysis/sea_ice/plot_climatology_map_subtask.py
@@ -365,6 +365,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):  # {{{
                 mask = np.logical_or(refOutput.mask,
                                      refOutput == self.maskValue)
                 refOutput = np.ma.masked_array(refOutput, mask)
+                difference = np.ma.masked_array(difference, mask)
 
         # mask with maskValue only after taking the diff
         if self.maskValue is not None:


### PR DESCRIPTION
This is a simple one-liner to avoid plotting bias values in sea-ice concentration and thickness maps where no observation is actually there for a bias to make sense.
This is especially relevant for ice thickness, where obs are only available above a certain latitude, and it is therefore misleading to show a bias below that latitude.