### PR TITLE
Make docs not fail if no change

### DIFF
--- a/ci/test_and_publish_docs.bash
+++ b/ci/test_and_publish_docs.bash
@@ -39,8 +39,12 @@ mkdir "$DOCS_VERSION"
 cp -r "$REPO_PATH"/docs/_build/html/* "$DOCS_VERSION"
 # Commit and push latest version
 git add .
-git config user.name  "Travis"
-git config user.email "travis@travis-ci.org"
-git commit -m "Updated $DOCS_VERSION"
-git push -fq origin $PUBLICATION_BRANCH
+if git diff-index --quiet HEAD; then
+  echo "No changes in the docs."
+else
+  git config user.name  "Travis"
+  git config user.email "travis@travis-ci.org"
+  git commit -m "Updated $DOCS_VERSION"
+  git push -fq origin $PUBLICATION_BRANCH
+fi
 popd || exit 1


### PR DESCRIPTION
Previously, merges that try to updated the docs fail if there were no changes (trying to push an empty commit).  With this change, the docs will simply not get updated if there are no changes.