### PR TITLE
Updates to Hovmoller plots

### DIFF
--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -169,12 +169,81 @@ colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227,
 colorbarLevelsDifference = [-0.5, -0.2, -0.1, -0.05, -0.02, 0,  0.02, 0.05,
                             0.1, 0.2, 0.5]
 
-
 [oceanRegionalProfiles]
 ## options related to plotting vertical profiles of regional means (and
 ## variability) of 3D MPAS fields
 
+# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['ANN']
+
+# minimum and maximum depth of profile plots, or empty for the full depth range
+depthRange = [-600., 0.]
+
+# The suffix on the regional mask file to be used to determine the regions to
+# plot.  A region mask file should be in the regionMaskDirectory and should
+# be named <mpasMeshName>_<regionMaskSuffix>.nc
+regionMaskSuffix = antarcticRegions
+
 # a list of region names from the region masks file to plot
-regionNames = ["Atlantic_Basin", "Pacific_Basin", "Indian_Basin",
-               "Arctic_Basin", "Southern_Ocean_Basin",
-               "Global Ocean", "Global Ocean 65N to 65S"]
+regionNames = ["Southern Ocean 60S", "Weddell Sea Shelf",
+               "Weddell Sea Deep", "Bellingshausen Sea Shelf",
+               "Bellingshausen Sea Deep", "Amundsen Sea Shelf",
+               "Amundsen Sea Deep", "Eastern Ross Sea Shelf",
+               "Eastern Ross Sea Deep", "Western Ross Sea Shelf",
+               "Western Ross Sea Deep",  "East Antarctic Seas Shelf",
+               "East Antarctic Seas Deep"]
+
+# Make Hovmoller plots of fields vs time and depth?
+plotHovmoller = True
+
+# web gallery options
+hovmollerGalleryGroup = Antarctic Regional Time Series vs Depths
+
+# web gallery options
+profileGalleryGroup = Antarctic Regional Profiles
+
+
+[temperatureOceanRegionalHovmoller]
+## options related to plotting time series of temperature vs. depth in ocean
+## regions
+
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': -2., 'vmax': 3.}
+normArgsDifference = {'vmin': -2., 'vmax': 2.}
+
+# Number of months over which to compute moving average
+movingAverageMonths = 12
+
+# limits on depth, the full range by default
+yLim = [-600., -5.]
+
+
+[salinityOceanRegionalHovmoller]
+## options related to plotting time series of salinity vs. depth in ocean
+## regions
+
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': 33., 'vmax': 35.}
+normArgsDifference = {'vmin': -0.5, 'vmax': 0.5}
+
+# Number of months over which to compute moving average
+movingAverageMonths = 12
+
+# limits on depth, the full range by default
+yLim = [-600., -5.]
+
+
+[potentialDensityOceanRegionalHovmoller]
+## options related to plotting time series of potential density vs. depth in
+## ocean regions
+
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': 1026.5, 'vmax': 1028.}
+normArgsDifference = {'vmin': -0.3, 'vmax': 0.3}
+
+# Number of months over which to compute moving average
+movingAverageMonths = 12
+
+# limits on depth, the full range by default
+yLim = [-600., -5.]

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -2997,13 +2997,22 @@ profileGalleryGroup = Ocean Basin Profiles
 movingAveragePoints = 1
 
 # colormap
-colormapName = RdYlBu_r
+colormapNameResult = RdYlBu_r
 # whether the colormap is indexed or continuous
-colormapType = continuous
+colormapTypeResult = continuous
 # the type of norm used in the colormap
-normType = linear
+normTypeResult = linear
 # A dictionary with keywords for the norm
-normArgs = {'vmin': -2., 'vmax': 30.}
+normArgsResult = {'vmin': -2., 'vmax': 30.}
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = continuous
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the norm
+normArgsDifference = {'vmin': -5., 'vmax': 5.}
 
 # contour line levels (use [] for automatic contour selection, 'none' for no
 # contour lines)
@@ -3033,13 +3042,22 @@ contourLevels = 'none'
 movingAveragePoints = 1
 
 # colormap
-colormapName = haline
+colormapNameResult = haline
 # whether the colormap is indexed or continuous
-colormapType = continuous
+colormapTypeResult = continuous
 # the type of norm used in the colormap
-normType = linear
+normTypeResult = linear
 # A dictionary with keywords for the norm
-normArgs = {'vmin': 30, 'vmax': 39.0}
+normArgsResult = {'vmin': 30, 'vmax': 39.0}
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = continuous
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the norm
+normArgsDifference = {'vmin': -0.5, 'vmax': 0.5}
 
 # contour line levels (use [] for automatic contour selection, 'none' for no
 # contour lines)
@@ -3069,13 +3087,23 @@ contourLevels = 'none'
 movingAveragePoints = 1
 
 # colormap
-colormapName = Spectral_r
+colormapNameResult = Spectral_r
 # whether the colormap is indexed or continuous
-colormapType = continuous
+colormapTypeResult = continuous
 # the type of norm used in the colormap
-normType = linear
+normTypeResult = linear
 # A dictionary with keywords for the norm
-normArgs = {'vmin': 1026.5, 'vmax': 1028.}
+normArgsResult = {'vmin': 1026.5, 'vmax': 1028.}
+
+
+# colormap for differences
+colormapNameDifference = balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = continuous
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the norm
+normArgsDifference = {'vmin': -0.3, 'vmax': 0.3}
 
 # contour line levels (use [] for automatic contour selection, 'none' for no
 # contour lines)

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -440,16 +440,16 @@ movingAveragePoints = 12
 # plot
 
 # colormap
-colormapName = balance
+colormapNameResult = balance
 # whether the colormap is indexed or continuous
-colormapType = indexed
+colormapTypeResult = indexed
 # colormap indices for contour color
-colormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+colormapIndicesResult = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
 # colorbar levels/values for contour boundaries
-colorbarLevels = [-2.4, -0.8, -0.4, -0.2, 0, 0.2, 0.4, 0.8, 2.4]
+colorbarLevelsResult = [-2.4, -0.8, -0.4, -0.2, 0, 0.2, 0.4, 0.8, 2.4]
 # contour line levels (use [] for automatic contour selection, 'none' for no
 # contour lines)
-contourLevels = np.arange(-2.5, 2.6, 0.5)
+contourLevelsResult = np.arange(-2.5, 2.6, 0.5)
 
 # An optional first year for the tick marks on the x axis. Leave commented out
 # to start at the beginning of the time series.
@@ -473,16 +473,16 @@ regions = ['global']
 movingAveragePoints = 12
 
 # colormap
-colormapName = balance
+colormapNameResult = balance
 # whether the colormap is indexed or continuous
-colormapType = indexed
+colormapTypeResult = indexed
 # color indices into colormapName for filled contours
-colormapIndices = [0, 28, 57, 85, 113, 125, 130, 142, 170, 198, 227, 255]
+colormapIndicesResult = [0, 28, 57, 85, 113, 125, 130, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-colorbarLevels = [-2.0, -1.0, -0.5, -0.25, -0.1, 0, 0.1, 0.25, 0.5, 1.0, 2.0]
+colorbarLevelsResult = [-2.0, -1.0, -0.5, -0.25, -0.1, 0, 0.1, 0.25, 0.5, 1.0, 2.0]
 # contour line levels (use [] for automatic contour selection, 'none' for no
 # contour lines)
-contourLevels = np.arange(-5.0, 5.51, 0.5)
+contourLevelsResult = np.arange(-5.0, 5.51, 0.5)
 
 # An optional first year for the tick marks on the x axis. Leave commented out
 # to start at the beginning of the time series.
@@ -507,18 +507,18 @@ regions = ['global']
 movingAveragePoints = 12
 
 # colormap
-colormapName = balance
+colormapNameResult = balance
 # whether the colormap is indexed or continuous
-colormapType = indexed
+colormapTypeResult = indexed
 # color indices into colormapName for filled contours
-#colormapIndices = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
-colormapIndices = [0, 28, 57, 85, 113, 125, 130, 142, 170, 198, 227, 255]
+#colormapIndicesResult = [0, 28, 57, 85, 113, 142, 170, 198, 227, 255]
+colormapIndicesResult = [0, 28, 57, 85, 113, 125, 130, 142, 170, 198, 227, 255]
 # colormap levels/values for contour boundaries
-#colorbarLevels = [-0.1, -0.02, -0.003, -0.001, 0, 0.001, 0.003, 0.02, 0.1]
-colorbarLevels = [-1.0, -0.5, -0.2, -0.1, -0.02, 0, 0.02, 0.1, 0.2, 0.5, 1.0]
+#colorbarLevelsResult = [-0.1, -0.02, -0.003, -0.001, 0, 0.001, 0.003, 0.02, 0.1]
+colorbarLevelsResult = [-1.0, -0.5, -0.2, -0.1, -0.02, 0, 0.02, 0.1, 0.2, 0.5, 1.0]
 # contour line levels (use [] for automatic contour selection, 'none' for no
 # contour lines)
-contourLevels = np.arange(-2., 2.01, 0.2)
+contourLevelsResult = np.arange(-2., 2.01, 0.2)
 
 # An optional first year for the tick marks on the x axis. Leave commented out
 # to start at the beginning of the time series.

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -148,7 +148,8 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
                         groupSubtitle=None,
                         groupLink='ocnreghovs',
                         galleryName=titleName,
-                        subtaskName=subtaskName)
+                        subtaskName=subtaskName,
+                        controlConfig=controlConfig)
                     hovmollerSubtask.run_after(combineSubtask)
                     self.add_subtask(hovmollerSubtask)
 
@@ -370,7 +371,7 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
                     (cellMasks * areaCell * var**2).sum('nCells') / totalArea
 
             # drop the original variables
-            dsLocal = dsLocal.drop(variableList)
+            dsLocal = dsLocal.drop_vars(variableList)
 
             datasets.append(dsLocal)
 

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -126,9 +126,10 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
                 for regionName in self.regionNames:
                     subtaskName = 'plotHovmoller_{}_{}'.format(
                         prefix, regionName.replace(' ', '_'))
-                    inFileName = '{}/{}_{:04d}-{:04d}.nc'.format(
-                        self.regionMaskSuffix, self.regionMaskSuffix,
-                        self.startYear, self.endYear)
+                    inFileName = \
+                        '{}/regionalProfiles_{}_{:04d}-{:04d}.nc'.format(
+                            self.regionMaskSuffix, self.regionMaskSuffix,
+                            self.startYear, self.endYear)
                     titleName = field['titleName']
                     caption = 'Time series of {} {} vs ' \
                               'depth'.format(regionName.replace('_', ' '),
@@ -265,7 +266,7 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
         except OSError:
             pass
 
-        outputFileName = '{}/{}_{:04d}-{:04d}.nc'.format(
+        outputFileName = '{}/regionalProfiles_{}_{:04d}-{:04d}.nc'.format(
             outputDirectory, timeSeriesName, self.startYear, self.endYear)
 
         inputFiles = sorted(self.historyStreams.readpath(
@@ -461,7 +462,7 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
                                    'timeseriesSubdirectory'),
             timeSeriesName)
 
-        outputFileName = '{}/{}_{:04d}-{:04d}.nc'.format(
+        outputFileName = '{}/regionalProfiles_{}_{:04d}-{:04d}.nc'.format(
             outputDirectory, timeSeriesName, self.startYears[0],
             self.endYears[-1])
 
@@ -477,7 +478,7 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
 
             inFileNames = []
             for startYear, endYear in zip(self.startYears, self.endYears):
-                inFileName = '{}/{}_{:04d}-{:04d}.nc'.format(
+                inFileName = '{}/regionalProfiles_{}_{:04d}-{:04d}.nc'.format(
                     outputDirectory, timeSeriesName, startYear, endYear)
                 inFileNames.append(inFileName)
 
@@ -491,7 +492,7 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
             write_netcdf(ds, outputFileName)
 
         regionNames = ds['regionNames']
-        ds = ds.drop('regionNames')
+        ds = ds.drop_vars('regionNames')
 
         profileMask = ds['totalArea'] > 0
 
@@ -501,9 +502,10 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
         make_directories(outputDirectory)
 
         for season in self.parentTask.seasons:
-            outputFileName = '{}/{}_{}_{:04d}-{:04d}.nc'.format(
-                outputDirectory, timeSeriesName, season,
-                self.startYears[0], self.endYears[-1])
+            outputFileName = \
+                '{}/{}_{}_{:04d}-{:04d}.nc'.format(
+                    outputDirectory, timeSeriesName, season,
+                    self.startYears[0], self.endYears[-1])
             if not os.path.exists(outputFileName):
                 monthValues = constants.monthDictionary[season]
                 dsSeason = compute_climatology(ds, monthValues,
@@ -621,7 +623,7 @@ class PlotRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
         self.xmlFileNames = []
         self.filePrefixes = {}
 
-        self.filePrefix = '{}_{}_{}_years{:04d}-{:04d}'.format(
+        self.filePrefix = 'regionalProfile_{}_{}_{}_years{:04d}-{:04d}'.format(
             self.field['prefix'], self.regionName.replace(' ', '_'),
             self.season, self.parentTask.startYear,
             self.parentTask.endYear)
@@ -717,9 +719,10 @@ class PlotRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
                 self.controlConfig, 'output',
                 'profilesSubdirectory')
 
-            controlFileName = '{}/{}_{}_{:04d}-{:04d}.nc'.format(
-                controlDirectory, timeSeriesName, self.season,
-                controlStartYear, controlEndYear)
+            controlFileName = \
+                '{}/{}_{}_{:04d}-{:04d}.nc'.format(
+                    controlDirectory, timeSeriesName, self.season,
+                    controlStartYear, controlEndYear)
 
             dsControl = xr.open_dataset(controlFileName)
             allRegionNames = decode_strings(dsControl.regionNames)

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -149,7 +149,8 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
                         groupLink='ocnreghovs',
                         galleryName=titleName,
                         subtaskName=subtaskName,
-                        controlConfig=controlConfig)
+                        controlConfig=controlConfig,
+                        regionMaskFile=masksFile)
                     hovmollerSubtask.run_after(combineSubtask)
                     self.add_subtask(hovmollerSubtask)
 

--- a/mpas_analysis/ocean/plot_hovmoller_subtask.py
+++ b/mpas_analysis/ocean/plot_hovmoller_subtask.py
@@ -282,6 +282,9 @@ class PlotHovmollerSubtask(AnalysisTask):
         else:
             yearStrideXTicks = None
 
+        movingAverageMonths = config.getWithDefault(
+            self.sectionName, 'movingAverageMonths', 1)
+
         if config.has_option(self.sectionName, 'yLim'):
             yLim = config.getExpression(self.sectionName, 'yLim')
         else:
@@ -290,8 +293,8 @@ class PlotHovmollerSubtask(AnalysisTask):
         plot_vertical_section(config, Time, z, field, self.sectionName,
                               suffix='', colorbarLabel=self.unitsLabel,
                               title=title, xlabel=xLabel, ylabel=yLabel,
-                              lineWidth=1,
-                              xArrayIsTime=True, calendar=self.calendar,
+                              lineWidth=1, xArrayIsTime=True, 
+                              N=movingAverageMonths, calendar=self.calendar,
                               firstYearXTicks=firstYearXTicks,
                               yearStrideXTicks=yearStrideXTicks,
                               yLim=yLim, invertYAxis=False)

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -532,7 +532,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             refOutput,
             bias,
             configSectionName,
-            cbarLabel=self.unitsLabel,
+            colorbarLabel=self.unitsLabel,
             xlabel=xLabel,
             ylabel=yLabel,
             title=title,

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -733,7 +733,7 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
             plot_vertical_section_comparison(
                 config, x, z, regionMOC, refRegionMOC, diff,
                 colorMapSectionName='streamfunctionMOC{}'.format(region),
-                cbarLabel=colorbarLabel,
+                colorbarLabel=colorbarLabel,
                 title=title,
                 modelTitle=mainRunName,
                 refTitle=refTitle,

--- a/mpas_analysis/shared/plot/time_series.py
+++ b/mpas_analysis/shared/plot/time_series.py
@@ -50,9 +50,6 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
     dsvalues : list of xarray DataSets
         the data set(s) to be plotted
 
-    movingAveragePoints : int
-        the number of time points over which to perform a moving average
-
     title : str
         the title of the plot
 
@@ -61,6 +58,9 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
 
     calendar : str
         the calendar to use for formatting the time axis
+
+    movingAveragePoints : int, optional
+        the number of time points over which to perform a moving average
 
     lineColors, lineStyles, markers, legendText : list of str, optional
         control line color, style, marker, and corresponding legend

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -38,7 +38,7 @@ def plot_vertical_section_comparison(
         refArray,
         diffArray,
         colorMapSectionName,
-        cbarLabel=None,
+        colorbarLabel=None,
         xlabel=None,
         ylabel=None,
         title=None,
@@ -70,11 +70,12 @@ def plot_vertical_section_comparison(
         maxXTicks=20,
         calendar='gregorian',
         compareAsContours=False,
-        contourLineStyle=None,
         comparisonContourLineStyle=None,
         comparisonContourLineColor=None,
         labelContours=False,
-        contourLabelPrecision=1):
+        contourLabelPrecision=1,
+        resultSuffix='Result',
+        diffSuffix='Difference'):
     """
     Plots vertical section plots in a three-panel format, comparing model data
     (in modelArray) to some reference dataset (in refArray), which can be
@@ -107,7 +108,7 @@ def plot_vertical_section_comparison(
     colorMapSectionName : str
         section name in ``config`` where color map info can be found.
 
-    cbarLabel : str, optional
+    colorbarLabel : str, optional
         the label for the colorbar.  If compareAsContours and labelContours are
         both True, colorbarLabel is used as follows (typically in order to
         indicate the units that are associated with the contour labels):
@@ -260,6 +261,13 @@ def plot_vertical_section_comparison(
         the precision (in terms of number of figures to the right of the
         decimal point) of contour labels
 
+    resultSuffix : str, optional
+        a suffix added to the config options related to colormap information
+        for the main and control fields
+
+    diffSuffix : str, optional
+        a suffix added to the config options related to colormap information
+        for the difference field
 
     Returns
     -------
@@ -302,7 +310,7 @@ def plot_vertical_section_comparison(
 
     fig = plt.figure(figsize=figsize, dpi=dpi)
 
-    if (title is not None):
+    if title is not None:
         if titleFontSize is None:
             titleFontSize = config.get('plot', 'threePanelTitleFontSize')
         title_font = {'size': titleFontSize,
@@ -351,8 +359,8 @@ def plot_vertical_section_comparison(
         depthArray,
         modelArray,
         colorMapSectionName,
-        suffix='Result',
-        colorbarLabel=cbarLabel,
+        suffix=resultSuffix,
+        colorbarLabel=colorbarLabel,
         title=title,
         xlabel=xlabel,
         ylabel=ylabel,
@@ -373,7 +381,7 @@ def plot_vertical_section_comparison(
         upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
         invertYAxis=invertYAxis,
         xArrayIsTime=xArrayIsTime,
-        movingAveragePoints=None,
+        movingAveragePoints=movingAveragePoints,
         firstYearXTicks=firstYearXTicks,
         yearStrideXTicks=yearStrideXTicks,
         maxXTicks=maxXTicks, calendar=calendar,
@@ -397,8 +405,8 @@ def plot_vertical_section_comparison(
             depthArray,
             refArray,
             colorMapSectionName,
-            suffix='Result',
-            colorbarLabel=cbarLabel,
+            suffix=resultSuffix,
+            colorbarLabel=colorbarLabel,
             title=refTitle,
             xlabel=xlabel,
             ylabel=ylabel,
@@ -419,7 +427,7 @@ def plot_vertical_section_comparison(
             numUpperTicks=numUpperTicks,
             invertYAxis=invertYAxis,
             xArrayIsTime=xArrayIsTime,
-            movingAveragePoints=None,
+            movingAveragePoints=movingAveragePoints,
             firstYearXTicks=firstYearXTicks,
             yearStrideXTicks=yearStrideXTicks,
             maxXTicks=maxXTicks,
@@ -437,8 +445,8 @@ def plot_vertical_section_comparison(
             depthArray,
             diffArray,
             colorMapSectionName,
-            suffix='Difference',
-            colorbarLabel=cbarLabel,
+            suffix=diffSuffix,
+            colorbarLabel=colorbarLabel,
             title=diffTitle,
             xlabel=xlabel,
             ylabel=ylabel,
@@ -459,7 +467,7 @@ def plot_vertical_section_comparison(
             numUpperTicks=numUpperTicks,
             invertYAxis=invertYAxis,
             xArrayIsTime=xArrayIsTime,
-            movingAveragePoints=None,
+            movingAveragePoints=movingAveragePoints,
             firstYearXTicks=firstYearXTicks,
             yearStrideXTicks=yearStrideXTicks,
             maxXTicks=maxXTicks,
@@ -822,10 +830,10 @@ def plot_vertical_section(
 
     # Verify that the upper x-axis parameters are consistent with each other
     # and with xArray
-    if (secondXAxisData is None and thirdXAxisData is not None):
+    if secondXAxisData is None and thirdXAxisData is not None:
         raise ValueError('secondXAxisData cannot be None if thirdXAxisData '
                          'is not None')
-    if (secondXAxisData is not None):
+    if secondXAxisData is not None:
         arrayShape = secondXAxisData.shape
         if len(arrayShape) == 1 and arrayShape[0] != num_x:
             raise ValueError('secondXAxisData has %d x values, '
@@ -839,7 +847,7 @@ def plot_vertical_section(
             raise ValueError('secondXAxisData must be a 1D or 2D array, '
                              'but is of dimension %d' %
                              (len(arrayShape)))
-    if (thirdXAxisData is not None):
+    if thirdXAxisData is not None:
         arrayShape = thirdXAxisData.shape
         if len(arrayShape) == 1 and arrayShape[0] != num_x:
             raise ValueError('thirdXAxisData has %d x values, '
@@ -908,7 +916,7 @@ def plot_vertical_section(
 
     else:     # display a white heatmap to get a white background for non-land
         zeroArray = np.ma.where(fieldArray != np.nan, 0.0, fieldArray)
-        plotHandle = plt.contourf(x, y, zeroArray, colors='white')
+        plt.contourf(x, y, zeroArray, colors='white')
 
     # set the color for NaN or masked regions, and draw a black
     # outline around them; technically, the contour level used should

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -482,7 +482,7 @@ def plot_vertical_section_comparison(
         if thirdXAxisData is not None and refArray is None:
             plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.0, 0.0, 1.0, 0.98])
         else:
-            plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.0, 0.0, 1.0, 0.80])
+            plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.0, 0.0, 1.0, 0.9])
     else:
         plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.01, 0.0, 1.0, 0.93])
 

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -730,6 +730,22 @@ def plot_vertical_section(
     # -------
     # Milena Veneziani, Mark Petersen, Xylar Asay-Davis, Greg Streletz
 
+    # compute moving averages with respect to the x dimension
+    if movingAveragePoints is not None and movingAveragePoints != 1:
+        N = movingAveragePoints
+        movingAverageDepthSlices = []
+        for nVertLevel in range(len(depthArray)):
+            depthSlice = fieldArray[[nVertLevel]][0]
+            # in case it's not an xarray already
+            depthSlice = xr.DataArray(depthSlice)
+            mean = pd.Series.rolling(depthSlice.to_series(), N,
+                                     center=True).mean()
+            mean = xr.DataArray.from_series(mean)
+            mean = mean[int(N / 2.0):-int(round(N / 2.0) - 1)]
+            movingAverageDepthSlices.append(mean)
+        xArray = xArray[int(N / 2.0):-int(round(N / 2.0) - 1)]
+        fieldArray = xr.DataArray(movingAverageDepthSlices)
+
     dimX = xArray.shape
     dimZ = depthArray.shape
     dimF = fieldArray.shape
@@ -858,22 +874,6 @@ def plot_vertical_section(
         fig = plt.figure(figsize=figsize, dpi=dpi)
     else:
         fig = plt.gcf()
-
-    # compute moving averages with respect to the x dimension
-    if movingAveragePoints is not None and movingAveragePoints != 1:
-        N = movingAveragePoints
-        movingAverageDepthSlices = []
-        for nVertLevel in range(len(depthArray)):
-            depthSlice = fieldArray[[nVertLevel]][0]
-            # in case it's not an xarray already
-            depthSlice = xr.DataArray(depthSlice)
-            mean = pd.Series.rolling(depthSlice.to_series(), N,
-                                     center=True).mean()
-            mean = xr.DataArray.from_series(mean)
-            mean = mean[int(N / 2.0):-int(round(N / 2.0) - 1)]
-            movingAverageDepthSlices.append(mean)
-        xArray = xArray[int(N / 2.0):-int(round(N / 2.0) - 1)]
-        fieldArray = xr.DataArray(movingAverageDepthSlices)
 
     colormapDict = setup_colormap(config, colorMapSectionName, suffix=suffix)
 


### PR DESCRIPTION
This merge fixes moving averaging in Hovmoller plots.

It also adds support for main vs. control Hovmoller plots.

In the process of adding main vs. control support, some clean-up was performed:
* adding support for suffixes other than `Result` and `Difference` in color maps for vertical section plots (a feature I didn't end up using)
* some PEP8 and other formatting clean-up suggested by pycharm

This merge also updates the ocean regional profiles for "polar regions" configurations.  It switches to the Antarctic regions by default, focuses on the top 600 m, not the full depth of the ocean, and turns on Hovmoller plots as well as profile plots.