### PR TITLE
Change from 'acme' to 'e3sm' for NERSC template files

### DIFF
--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -39,7 +39,7 @@ ncclimoParallelMode = serial
 # its location).  For other machines, this would be the directory pointed to
 # when running "download_analysis_data.py" to get the public observations,
 # mapping files and region files.
-baseDirectory = /global/project/projectdirs/acme/diagnostics
+baseDirectory = /global/project/projectdirs/e3sm/diagnostics
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -66,7 +66,7 @@ baseDirectory = /dir/to/analysis/output
 
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
-# htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
+# htmlSubdirectory = /global/project/projectdirs/e3sm/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:

--- a/configs/cori/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/cori/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -39,7 +39,7 @@ ncclimoParallelMode = bck
 # its location).  For other machines, this would be the directory pointed to
 # when running "download_analysis_data.py" to get the public observations,
 # mapping files and region files.
-baseDirectory = /global/project/projectdirs/acme/diagnostics
+baseDirectory = /global/project/projectdirs/e3sm/diagnostics
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -73,7 +73,7 @@ baseDirectory = /dir/to/analysis/output
 
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
-# htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
+# htmlSubdirectory = /global/project/projectdirs/e3sm/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:

--- a/configs/cori/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
+++ b/configs/cori/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
@@ -39,7 +39,7 @@ ncclimoParallelMode = bck
 # its location).  For other machines, this would be the directory pointed to
 # when running "download_analysis_data.py" to get the public observations,
 # mapping files and region files.
-baseDirectory = /global/project/projectdirs/acme/diagnostics
+baseDirectory = /global/project/projectdirs/e3sm/diagnostics
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -73,7 +73,7 @@ baseDirectory = /dir/to/analysis/output
 
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
-# htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
+# htmlSubdirectory = /global/project/projectdirs/e3sm/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:

--- a/configs/cori/config.20180511.GMPAS-IAF.T62_oEC60to30v3wLI.edison
+++ b/configs/cori/config.20180511.GMPAS-IAF.T62_oEC60to30v3wLI.edison
@@ -39,7 +39,7 @@ ncclimoParallelMode = bck
 # its location).  For other machines, this would be the directory pointed to
 # when running "download_analysis_data.py" to get the public observations,
 # mapping files and region files.
-baseDirectory = /global/project/projectdirs/acme/diagnostics
+baseDirectory = /global/project/projectdirs/e3sm/diagnostics
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -73,7 +73,7 @@ baseDirectory = /path/to/output/dir
 
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
-# htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
+# htmlSubdirectory = /global/project/projectdirs/e3sm/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:

--- a/configs/cori/config.20180514.G.oQU240wLI.edison
+++ b/configs/cori/config.20180514.G.oQU240wLI.edison
@@ -39,7 +39,7 @@ ncclimoParallelMode = bck
 # its location).  For other machines, this would be the directory pointed to
 # when running "download_analysis_data.py" to get the public observations,
 # mapping files and region files.
-baseDirectory = /global/project/projectdirs/acme/diagnostics
+baseDirectory = /global/project/projectdirs/e3sm/diagnostics
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -73,7 +73,7 @@ baseDirectory = /dir/to/analysis/output
 
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
-# htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
+# htmlSubdirectory = /global/project/projectdirs/e3sm/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:

--- a/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
+++ b/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
@@ -39,7 +39,7 @@ ncclimoParallelMode = bck
 # its location).  For other machines, this would be the directory pointed to
 # when running "download_analysis_data.py" to get the public observations,
 # mapping files and region files.
-baseDirectory = /global/project/projectdirs/acme/diagnostics
+baseDirectory = /global/project/projectdirs/e3sm/diagnostics
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -73,7 +73,7 @@ baseDirectory = /path/to/output/dir
 
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
-# htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
+# htmlSubdirectory = /global/project/projectdirs/e3sm/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
 

--- a/configs/cori/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/cori/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -39,7 +39,7 @@ ncclimoParallelMode = serial
 # its location).  For other machines, this would be the directory pointed to
 # when running "download_analysis_data.py" to get the public observations,
 # mapping files and region files.
-baseDirectory = /global/project/projectdirs/acme/diagnostics
+baseDirectory = /global/project/projectdirs/e3sm/diagnostics
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -66,7 +66,7 @@ baseDirectory = /dir/to/analysis/output
 
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
-# htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
+# htmlSubdirectory = /global/project/projectdirs/e3sm/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:

--- a/configs/cori/job_script.cori-haswell.bash
+++ b/configs/cori/job_script.cori-haswell.bash
@@ -20,7 +20,7 @@
 #SBATCH -C haswell
 #SBATCH --nodes=1
 #SBATCH --time=1:00:00
-#SBATCH --account=acme
+#SBATCH --account=e3sm
 #SBATCH --job-name=mpas_analysis
 #SBATCH --output=mpas_analysis.o%j
 #SBATCH --error=mpas_analysis.e%j
@@ -30,7 +30,7 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 
 export OMP_NUM_THREADS=1
 
-source /global/project/projectdirs/acme/software/anaconda_envs/load_latest_e3sm_unified.sh
+source /global/project/projectdirs/e3sm/software/anaconda_envs/load_latest_e3sm_unified.sh
 export HDF5_USE_FILE_LOCKING=FALSE
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and

--- a/configs/cori/job_script.cori-knl.bash
+++ b/configs/cori/job_script.cori-knl.bash
@@ -20,7 +20,7 @@
 #SBATCH -C knl
 #SBATCH --nodes=1
 #SBATCH --time=1:00:00
-#SBATCH --account=acme
+#SBATCH --account=e3sm
 #SBATCH --job-name=mpas_analysis
 #SBATCH --output=mpas_analysis.o%j
 #SBATCH --error=mpas_analysis.e%j
@@ -30,7 +30,7 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 
 export OMP_NUM_THREADS=1
 
-source /global/project/projectdirs/acme/software/anaconda_envs/load_latest_e3sm_unified.sh
+source /global/project/projectdirs/e3sm/software/anaconda_envs/load_latest_e3sm_unified.sh
 export HDF5_USE_FILE_LOCKING=FALSE
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and

--- a/configs/plots/config.drake_contours
+++ b/configs/plots/config.drake_contours
@@ -39,7 +39,7 @@ ncclimoParallelMode = bck
 # its location).  For other machines, this would be the directory pointed to
 # when running "download_analysis_data.py" to get the public observations,
 # mapping files and region files.
-baseDirectory = /global/project/projectdirs/acme/diagnostics
+baseDirectory = /global/project/projectdirs/e3sm/diagnostics
 
 [input]
 ## options related to reading in the results to be analyzed
@@ -73,7 +73,7 @@ baseDirectory = /dir/to/analysis/output
 
 # provide an absolute path to put HTML in an alternative location (e.g. a web
 # portal)
-# htmlSubdirectory = /global/project/projectdirs/acme/www/USERNAME/RUNNAME
+# htmlSubdirectory = /global/project/projectdirs/e3sm/www/USERNAME/RUNNAME
 htmlSubdirectory = html
 
 # a list of analyses to generate.  Valid names can be seen by running:


### PR DESCRIPTION
Updated all config and job_script templates for cori, changing `acme` to `e3sm`.