### PR TITLE
Disable ncclimo files from stdin

### DIFF
--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -497,6 +497,7 @@ class MpasClimatologyTask(AnalysisTask):  # {{{
             seasons = ['none']
 
         args = ['ncclimo',
+                '--no_stdin',
                 '-4',
                 '--clm_md=mth',
                 '-a', 'sdd',


### PR DESCRIPTION
We never use `stdin` to specify files to process, but `ncclimo` gets confused when running via `pytest` (which uses `stdin` for other purposes) so we need to explicitly disable `stdin`.