### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ conda config --set channel_priority strict
 conda create -n mpas-analysis python=3.8 numpy scipy "matplotlib-base>=3.0.2" \
     netCDF4 "xarray>=0.14.1" dask bottleneck lxml "nco>=4.8.1" pyproj \
     pillow cmocean progressbar2 requests setuptools shapely "cartopy>=0.18.0" \
-    cartopy_offlinedata geometric_features gsw "pyremap<0.1.0"
+    cartopy_offlinedata geometric_features gsw "pyremap<0.1.0" \
     "mpas_tools>=0.0.8"
 conda activate mpas-analysis
 ```


### PR DESCRIPTION
Missing a backslash for the example `conda create` to work.