### PR TITLE
Fix an issue with argmin with newest xarray

### DIFF
--- a/mpas_analysis/ocean/remap_depth_slices_subtask.py
+++ b/mpas_analysis/ocean/remap_depth_slices_subtask.py
@@ -148,7 +148,7 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):  # {{{
                 mask[depthIndex, :] = self.maxLevelCell.values >= 0
             else:
 
-                verticalIndex = np.argmin(np.abs(zMid - depth), axis=1)
+                verticalIndex = np.abs(zMid - depth).argmin(dim='nVertLevels')
 
                 verticalIndices[depthIndex, :] = verticalIndex.values
                 mask[depthIndex, :] = np.logical_and(depth <= zTop,


### PR DESCRIPTION
The modification used the `xarray`, rather than the `numpy`, version of `argmin`, which is better because it refers to the named dimension rather than the axis number.