### PR TITLE
Optionally, raise an error if requested input files are missing

### DIFF
--- a/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -117,19 +117,24 @@ endYear = 10
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 10
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 10
 

--- a/configs/alcf/20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta.yrs41-50.conf
+++ b/configs/alcf/20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta.yrs41-50.conf
@@ -115,19 +115,24 @@ subprocessCount = 2
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 50
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 50
 

--- a/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -106,7 +106,7 @@ endYear = 10
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
 startYear = 1
-endYear = 9999
+endYear = end
 
 [index]
 ## options related to producing nino index.
@@ -116,7 +116,7 @@ endYear = 9999
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -102,19 +102,24 @@ endYear = 10
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
+++ b/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
@@ -116,19 +116,24 @@ endYear = 27
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 25
 endYear = 27
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 25
 endYear = 27
 

--- a/configs/anvil/config.SO60to10ISC.20200108
+++ b/configs/anvil/config.SO60to10ISC.20200108
@@ -109,19 +109,24 @@ endYear = 10
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/configs/anvil/config.SO60to10ISC.20200108
+++ b/configs/anvil/config.SO60to10ISC.20200108
@@ -3,7 +3,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = SO60to10ISC.20200108 
+mainRunName = SO60to10ISC.20200108
 
 # config file for a control run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -113,7 +113,7 @@ endYear = 10
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
 startYear = 1
-endYear = 9999
+endYear = end
 
 [index]
 ## options related to producing nino index.
@@ -123,7 +123,7 @@ endYear = 9999
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/compy/config.20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy
+++ b/configs/compy/config.20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy
@@ -109,19 +109,24 @@ endYear = 40
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 40
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/configs/compy/config.20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy
+++ b/configs/compy/config.20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy
@@ -3,7 +3,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = 20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy 
+mainRunName = 20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy
 
 # config file for a control run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -17,7 +17,7 @@ mainRunName = 20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy
 # remapped to the comparison grid and time series have been extracted.
 # Leave this option commented out if the analysis for the main run should be
 # performed.
-mainRunConfigFile = config.GM_20190605_GMtest_Kappa3d_vary_c2_intel.compy 
+mainRunConfigFile = config.GM_20190605_GMtest_Kappa3d_vary_c2_intel.compy
 
 [execute]
 ## options related to executing parallel tasks
@@ -45,7 +45,7 @@ baseDirectory = /compyfs/diagnostics
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /compyfs/wolf966/e3sm_scratch/20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy/run 
+baseDirectory = /compyfs/wolf966/e3sm_scratch/20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy/run
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oEC60to30v3
@@ -123,7 +123,7 @@ endYear = 40
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -103,18 +103,23 @@ endYear = 10
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 10
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 10

--- a/configs/cori/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/cori/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -117,19 +117,24 @@ endYear = 10
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 10
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 10
 

--- a/configs/cori/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
+++ b/configs/cori/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
@@ -116,18 +116,23 @@ endYear = 10
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 10
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 10

--- a/configs/cori/config.20180511.GMPAS-IAF.T62_oEC60to30v3wLI.edison
+++ b/configs/cori/config.20180511.GMPAS-IAF.T62_oEC60to30v3wLI.edison
@@ -117,19 +117,24 @@ endYear = 30
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 30
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 30
 

--- a/configs/cori/config.20180514.G.oQU240wLI.edison
+++ b/configs/cori/config.20180514.G.oQU240wLI.edison
@@ -116,19 +116,24 @@ endYear = 8
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/configs/cori/config.20180514.G.oQU240wLI.edison
+++ b/configs/cori/config.20180514.G.oQU240wLI.edison
@@ -120,7 +120,7 @@ endYear = 8
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
 startYear = 1
-endYear = 9999
+endYear = end
 
 [index]
 ## options related to producing nino index.
@@ -130,7 +130,7 @@ endYear = 9999
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
+++ b/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
@@ -119,18 +119,23 @@ endYear = 30
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 30
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end

--- a/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
+++ b/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
@@ -133,4 +133,4 @@ endYear = 30
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end

--- a/configs/cori/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/cori/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -107,19 +107,24 @@ endYear = 100
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 10
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/configs/cori/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/cori/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -121,7 +121,7 @@ endYear = 10
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -114,4 +114,4 @@ endYear = 1961
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -100,18 +100,23 @@ endYear = 1961
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1960
 endYear = 1961
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end

--- a/configs/lanl/config.BGCphaeo4.testrun
+++ b/configs/lanl/config.BGCphaeo4.testrun
@@ -109,7 +109,7 @@ endYear = 100
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
 startYear = 1
-endYear = 9999
+endYear = end
 
 [index]
 ## options related to producing nino index.
@@ -119,7 +119,7 @@ endYear = 9999
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 [oceanPreprocessedReference]
 ## options related to preprocessed ocean control run with which the results

--- a/configs/lanl/config.BGCphaeo4.testrun
+++ b/configs/lanl/config.BGCphaeo4.testrun
@@ -105,19 +105,24 @@ endYear = 100
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/configs/lanl/config.CONUS.100km.NAEC60to30cr8.20181218
+++ b/configs/lanl/config.CONUS.100km.NAEC60to30cr8.20181218
@@ -104,7 +104,7 @@ endYear = 10
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
 startYear = 1
-endYear = 9999
+endYear = end
 
 [index]
 ## options related to producing nino index.
@@ -114,7 +114,7 @@ endYear = 9999
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 [climatologyMapBGC]
 preindustrial = True

--- a/configs/lanl/config.CONUS.100km.NAEC60to30cr8.20181218
+++ b/configs/lanl/config.CONUS.100km.NAEC60to30cr8.20181218
@@ -100,19 +100,24 @@ endYear = 10
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
+++ b/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
@@ -108,7 +108,7 @@ endYear = 100
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
 startYear = 1
-endYear = 9999
+endYear = end
 
 [index]
 ## options related to producing nino index.
@@ -118,7 +118,7 @@ endYear = 9999
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 [oceanPreprocessedReference]
 ## options related to preprocessed ocean control run with which the results

--- a/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
+++ b/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
@@ -104,19 +104,24 @@ endYear = 100
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -105,18 +105,23 @@ endYear = 10
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -109,7 +109,7 @@ endYear = 10
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
 startYear = 1
-endYear = 9999
+endYear = end
 
 [index]
 ## options related to producing nino index.
@@ -119,4 +119,4 @@ endYear = 9999
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -109,19 +109,24 @@ endYear = 15
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 10
 endYear = 20
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -123,7 +123,7 @@ endYear = 20
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -120,19 +120,24 @@ endYear = 10
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = 10
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -134,7 +134,7 @@ endYear = 10
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -109,18 +109,23 @@ endYear = 11
 ## options related to producing time series plots, often to compare against
 ## observations and previous runs
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 11
 endYear = 11
 
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end

--- a/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
+++ b/configs/olcf/config.GMPAS-IAF_oRRS18to6v3.titan
@@ -123,4 +123,4 @@ endYear = 11
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end

--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -1,3 +1,11 @@
+[input]
+## options related to reading in the results to be analyzed
+
+# Whether missing input data should produce an error.  If not, the user gets
+# a warning and the time bounds are adjusted to the beginning and end of the
+# available data
+errorOnMissing = True
+
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/docs/config/index.rst
+++ b/docs/config/index.rst
@@ -13,19 +13,22 @@ determine the start and end years of climate indices (such as El Ni |n~| o
   [index]
   ## options related to producing nino index.
 
-  # start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-  #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-  #   of years, and is a good way of insuring that all values are used.
-  # For valid statistics, index times should include at least 30 years
+  # start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+  # that the full range of the data should be used.  If errorOnMissing = False,
+  # the start and end year will be clipped to the valid range.  Otherwise, out
+  # of bounds values will lead to an error.  In a "control" config file used in
+  # a "main vs. control" analysis run, the range of years must be valid and
+  # cannot include "end" because the original data may not be available.
   startYear = 1
-  endYear = 9999
+  endYear = end
 
 Start and End Year
 ------------------
 
-A custom config file should specify a start and end year for climate indices.
-If the end year is beyond the range of the simulation (typically true for the
-default ``endYear = 9999``), the range will be reduced to those dates with
-available data and a warning message will be displayed.
+A custom config file should specify a start and end year for time axis.
+If ``errorOnMissing = False`` in the ``input`` section and the start or end
+year is beyond the range of the simulation, the range will be reduced to those
+dates with available data and a warning message will be displayed.  If
+``errorOnMissing = True``, out of range year will produce an error.
 
 

--- a/docs/config/input.rst
+++ b/docs/config/input.rst
@@ -41,10 +41,11 @@ these data will be read in::
   # with a single time slice.
   maxChunkSize = 10000
 
-  # Directory for mapping files (if they have been generated already). If mapping
-  # files needed by the analysis are not found here, they will be generated and
-  # placed in the output mappingSubdirectory
-  # mappingDirectory = /dir/for/mapping/files
+
+  # Whether missing input data should produce an error.  If not, the user gets
+  # a warning and the time bounds are adjusted to the beginning and end of the
+  # available data
+  errorOnMissing = False
 
 Input Directories
 -----------------
@@ -153,6 +154,15 @@ clearly related to dask (which might be the case, for example, if the error
 occrus in the ``streamfunctionMOC`` task), you may wish to reduce the
 ``maxChunkSize``.  This will make tasks using dask slower but will reduce their
 memory usage.
+
+Errors on Missing Data
+----------------------
+
+if ``errorOnMissing = False``, the time ranges (``startYear`` and ``endYear``)
+in ``climatology``, ``timeSeries``, and ``index`` will be clipped to the range
+of the available data.  If this option is set to ``True``, an error will be
+produced.  A value of ``end`` can be used for ``endYear`` to indicate that the
+full range of the available data should be used.
 
 .. _`E3SM public data repository`: https://web.lcrc.anl.gov/public/e3sm/diagnostics/
 .. _`xarray package`: https://xarray.pydata.org/en/stable/

--- a/docs/config/timeSeries.rst
+++ b/docs/config/timeSeries.rst
@@ -16,19 +16,23 @@ for anomalies::
   # only the anomaly over a later span of years is of interest.
   # anomalyRefYear = 249
 
-  # start and end years for timeseries analysis. Using out-of-bounds values
-  #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-  #   of years, and is a good way of insuring that all values are used.
+  # start and end years for timeseries analysis. Use endYear = end to indicate
+  # that the full range of the data should be used.  If errorOnMissing = False,
+  # the start and end year will be clipped to the valid range.  Otherwise, out
+  # of bounds values will lead to an error.  In a "control" config file used in
+  # a "main vs. control" analysis run, the range of years must be valid and
+  # cannot include "end" because the original data may not be available.
   startYear = 1
-  endYear = 9999
+  endYear = end
 
 Start and End Year
 ------------------
 
 A custom config file should specify a start and end year for time series.
-If the end year is beyond the range of the simulation (typically true for the
-default ``endYear = 9999``), the range will be reduced to those dates with
-available data and a warning message will be displayed.
+If ``errorOnMissing = False`` in the ``input`` section and the start or end
+year is beyond the range of the simulation, the range will be reduced to those
+dates with available data and a warning message will be displayed.  If
+``errorOnMissing = True``, out of range year will produce an error.
 
 
 Anomaly Reference Year

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -135,6 +135,11 @@ file_cache_maxsize = 1200
 # with a single time slice.
 maxChunkSize = 10000
 
+# Whether missing input data should produce an error.  If not, the user gets
+# a warning and the time bounds are adjusted to the beginning and end of the
+# available data
+errorOnMissing = False
+
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
@@ -254,7 +259,7 @@ subprocessCount = 1
 #   like start_year = 1 and end_year = 9999 will be clipped to the valid range
 #   of years, and is a good way of insuring that all values are used.
 startYear = 1
-endYear = 9999
+endYear = end
 
 
 [index]
@@ -265,7 +270,7 @@ endYear = 9999
 #   of years, and is a good way of insuring that all values are used.
 # For valid statistics, index times should include at least 30 years
 startYear = 1
-endYear = 9999
+endYear = end
 
 
 [regions]

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -255,9 +255,12 @@ subprocessCount = 1
 # only the anomaly over a later span of years is of interest.
 # anomalyRefYear = 249
 
-# start and end years for timeseries analysis. Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 
@@ -265,10 +268,12 @@ endYear = end
 [index]
 ## options related to producing nino index.
 
-# start and end years for the nino 3.4 analysis.  Using out-of-bounds values
-#   like start_year = 1 and end_year = 9999 will be clipped to the valid range
-#   of years, and is a good way of insuring that all values are used.
-# For valid statistics, index times should include at least 30 years
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
 startYear = 1
 endYear = end
 

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -666,7 +666,6 @@ def update_time_bounds_from_file_names(config, section, componentName):  # {{{
         config.set(section, 'endYear', str(endYear))
         requestedEndYear = endYear
 
-
     if startYear != requestedStartYear or endYear != requestedEndYear:
         if errorOnMissing:
             raise ValueError(

--- a/mpas_analysis/test/test_mpas_climatology_task/config.QU240
+++ b/mpas_analysis/test/test_mpas_climatology_task/config.QU240
@@ -17,6 +17,7 @@ oceanHistorySubdirectory = .
 oceanNamelistFileName = mpas-o_in
 oceanStreamsFileName = streams.ocean
 mpasMeshName = oQU240
+errorOnMissing = False
 
 [output]
 baseDirectory = /dir/for/analysis/output

--- a/mpas_analysis/test/test_remap_obs_clim_subtask/config.remap_obs
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask/config.remap_obs
@@ -9,6 +9,7 @@ runSubdirectory = .
 oceanHistorySubdirectory = .
 oceanNamelistFileName = mpas-o_in
 oceanStreamsFileName = streams.ocean
+errorOnMissing = False
 
 [output]
 baseDirectory = /dir/for/analysis/output


### PR DESCRIPTION
For polar regions runs, this is now the default.

`endYear` may now be set to `end` instead of 9999 to indicate the end of the data, and is valid even when `errorOnMissing = True`.

The example config files have been updated with `end` instead of `9999` and with a new comment.

The documentation has also been updated with the changes.