### PR TITLE
Add support for transects plotted on the native MPAS-Ocean mesh

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -268,6 +268,7 @@ Plotting
    plot_polar_comparison
    plot_global_comparison
    plot_1D
+   plot_vertical_section_comparison
    plot_vertical_section
    colormap.setup_colormap
    ticks.plot_xtick_format

--- a/docs/config/transects.rst
+++ b/docs/config/transects.rst
@@ -8,45 +8,59 @@ the comparison grid for each transect::
 
     # The approximate horizontal resolution (in km) of each transect.  Latitude/
     # longitude between observation points will be subsampled at this interval.
-    # Use 'obs' to indicate no subsampling.
-    horizontalResolution = obs
+    # Use 'obs' to indicate no subsampling. Use 'mpas' to indicate plotting of
+    # model data on the native grid, in which case comparison with observations
+    # will take place on the observation grid.
+    #horizontalResolution = mpas
+    #horizontalResolution = obs
+    horizontalResolution = 5
 
     # The name of the vertical comparison grid.  Valid values are 'mpas' for the
     # MPAS vertical grid, 'obs' to use the locations of observations or
-    # any other name if the vertical grid is defined by 'verticalComparisonGrid'
-    # verticalComparisonGridName = obs
-    verticalComparisonGridName = uniform_0_to_4000m_at_10m
+    # any other name if the vertical grid is defined by 'verticalComparisonGrid'.
+    # If horizontalResolution is 'mpas', model data (both main and control) will be
+    # plotted on the MPAS vertical grid, regardless of the comparison grid.
     #verticalComparisonGridName = mpas
+    #verticalComparisonGridName = obs
+    verticalComparisonGridName = uniform_0_to_4000m_at_10m
 
     # The vertical comparison grid if 'verticalComparisonGridName' is not 'mpas' or
     # 'obs'.  This should be numpy array of (typically negative) elevations (in m).
     verticalComparisonGrid = numpy.linspace(0, -4000, 401)
 
-The ``horizontalResolution`` of all transects can be either ``obs`` or a number
-of kilometers.  If ``obs``, model data are sampled at latitute and longitude
-points corresponding to WOCE stations.  It a number of kilometers is given,
-linear interpolation between observation points is performed with approximately
-the requested resolution.  The distance between stations is always divided into
-an integer number of segments of equal length so the resolution may be slightly
-above or below ``horizontalResolution``.
+    # A range for the y axis (if any)
+    verticalBounds = []
 
+The ``horizontalResolution`` of all transects can be ``obs``, ``mpas`` or a
+number of kilometers.  If ``obs``, model data are sampled at latitude and
+longitude points corresponding to the observations.  If the horizontal grid
+is ``mpas``, then the native MPAS-Ocean mesh is used for both the horizontal and
+vertical grids.  If a number of kilometers is given, linear interpolation
+between observation points is performed with approximately the requested
+resolution.  The distance between observation points is always divided into an
+integer number of segments of equal length so the resolution may be slightly
+above or below ``horizontalResolution``.
 
 The vertical grid is determined by two parameters,
 ``verticalComparisonGridName`` and ``verticalComparisonGrid``.  If
-``verticalComparisonGridName = mpas``, the MPAS-Ocean vertical coordinate will
-be interpolated horitontally from grid cell centers to the latitude and
-longitude of each point along the transect, and the observations will be
-interpolated vertically to the resulting grid.  If
-``verticalComparisonGridName = obs``, the vertical grid of the observations
-is used instead.  If ``verticalComparisonGridName`` is anything else, it is
-taken to be the name of a user-defined vertical grid (best to make it
-descriptive and unique, e.g. ``uniform_0_to_4000m_at_10m``) and
+``verticalComparisonGridName = mpas``, but ``horizontalResoltuion`` is not
+``mpas``, the MPAS-Ocean vertical coordinate will be interpolated horizontally
+from grid cell centers to the latitude and longitude of each point along the
+transect, and the observations will be interpolated vertically to the resulting
+grid.  If ``verticalComparisonGridName = obs``, the vertical grid of the
+observations is used instead.  If ``verticalComparisonGridName`` is anything
+else, it is taken to be the name of a user-defined vertical grid (best to make
+it descriptive and unique, e.g. ``uniform_0_to_4000m_at_10m``) and
 ``verticalComparisonGrid`` should be assigned a valid array of positive-up
 depth values (in the form of a python list or numpy array), e.g.::
 
     verticalComparisonGrid = numpy.linspace(0, -4000, 401)
 
 produces points between 0 and -4000 m sampled every 10 m.
+
+``verticalBounds`` is a list of minimum and maximum limits for the vertical axis
+of the transect.  The default is an empty list, which means ``matplotlib``
+selects the axis limits to encompass the full range of the vertical grid.
 
 .. note::
 

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -2332,7 +2332,10 @@ seasons =  ['ANN']
 
 # The approximate horizontal resolution (in km) of each transect.  Latitude/
 # longitude between observation points will be subsampled at this interval.
-# Use 'obs' to indicate no subsampling.
+# Use 'obs' to indicate no subsampling. Use 'mpas' to indicate plotting of
+# model data on the native grid, in which case comparison with observations
+# will take place on the observation grid.
+#horizontalResolution = mpas
 #horizontalResolution = obs
 horizontalResolution = 5
 
@@ -2345,13 +2348,17 @@ horizontalBounds = {'WOCE_A21': [],
 
 # The name of the vertical comparison grid.  Valid values are 'mpas' for the
 # MPAS vertical grid, 'obs' to use the locations of observations or
-# any other name if the vertical grid is defined by 'verticalComparisonGrid'
+# any other name if the vertical grid is defined by 'verticalComparisonGrid'.
+# If horizontalResolution is 'mpas', model data (both main and control) will be
+# plotted on the MPAS vertical grid, regardless of the comparison grid.
 #verticalComparisonGridName = mpas
 #verticalComparisonGridName = obs
 verticalComparisonGridName = uniform_0_to_4000m_at_10m
 
 # The vertical comparison grid if 'verticalComparisonGridName' is not 'mpas' or
 # 'obs'.  This should be numpy array of (typically negative) elevations (in m).
+# The first and last entries are used as axis bounds for 'mpas' and 'obs'
+# vertical comparison grids
 verticalComparisonGrid = numpy.linspace(0, -4000, 401)
 
 # The minimum weight of a destination cell after remapping. Any cell with
@@ -2471,7 +2478,6 @@ normArgsDifference = {'vmin': -0.3, 'vmax': 0.3}
 contourLevelsDifference = []
 
 
-
 [geojsonTransects]
 ## options related to plotting model transects at points determined by a
 ## geojson file.  To generate your own geojson file, go to:
@@ -2524,7 +2530,9 @@ seasons =  ['ANN']
 
 # The approximate horizontal resolution (in km) of each transect.  Latitude/
 # longitude between observation points will be subsampled at this interval.
-# Use 'obs' to indicate no subsampling.
+# Use 'obs' to indicate no subsampling. Use 'mpas' to indicate plotting of
+# model data on the native grid.
+#horizontalResolution = mpas
 #horizontalResolution = obs
 horizontalResolution = 5
 
@@ -2536,6 +2544,8 @@ verticalComparisonGridName = uniform_0_to_4000m_at_10m
 
 # The vertical comparison grid if 'verticalComparisonGridName' is not 'mpas'.
 # This should be numpy array of (typically negative) elevations (in m).
+# The first and last entries are used as axis bounds for 'mpas' vertical
+# comparison grids
 verticalComparisonGrid = numpy.linspace(0, -4000, 401)
 
 # The minimum weight of a destination cell after remapping. Any cell with
@@ -2713,7 +2723,10 @@ seasons =  ['ANN', 'JFM', 'JAS']
 
 # The approximate horizontal resolution (in km) of each transect.  Latitude/
 # longitude between observation points will be subsampled at this interval.
-# Use 'obs' to indicate no subsampling.
+# Use 'obs' to indicate no subsampling. Use 'mpas' to indicate plotting of
+# model data on the native grid, in which case comparison with observations
+# will take place on the observation grid.
+#horizontalResolution = mpas
 #horizontalResolution = obs
 horizontalResolution = 5
 
@@ -2726,6 +2739,8 @@ verticalComparisonGridName = uniform_10_to_1500m_at_10m
 
 # The vertical comparison grid if 'verticalComparisonGridName' is not 'mpas' or
 # 'obs'.  This should be numpy array of (typically negative) elevations (in m).
+# The first and last entries are used as axis bounds for 'mpas' and 'obs'
+# vertical comparison grids
 verticalComparisonGrid = numpy.linspace(-10, -1500, 150)
 
 # The minimum weight of a destination cell after remapping. Any cell with

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -2361,6 +2361,9 @@ verticalComparisonGridName = uniform_0_to_4000m_at_10m
 # vertical comparison grids
 verticalComparisonGrid = numpy.linspace(0, -4000, 401)
 
+# A range for the y axis (if any)
+verticalBounds = []
+
 # The minimum weight of a destination cell after remapping. Any cell with
 # weights lower than this threshold will therefore be masked out.
 renormalizationThreshold = 0.01
@@ -2547,6 +2550,9 @@ verticalComparisonGridName = uniform_0_to_4000m_at_10m
 # The first and last entries are used as axis bounds for 'mpas' vertical
 # comparison grids
 verticalComparisonGrid = numpy.linspace(0, -4000, 401)
+
+# A range for the y axis (if any)
+verticalBounds = []
 
 # The minimum weight of a destination cell after remapping. Any cell with
 # weights lower than this threshold will therefore be masked out.
@@ -2742,6 +2748,9 @@ verticalComparisonGridName = uniform_10_to_1500m_at_10m
 # The first and last entries are used as axis bounds for 'mpas' and 'obs'
 # vertical comparison grids
 verticalComparisonGrid = numpy.linspace(-10, -1500, 150)
+
+# A range for the y axis (if any)
+verticalBounds = []
 
 # The minimum weight of a destination cell after remapping. Any cell with
 # weights lower than this threshold will therefore be masked out.

--- a/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
+++ b/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
@@ -349,7 +349,7 @@ class RemapMpasOHCClimatology(RemapMpasClimatologySubtask):  # {{{
 
         nVertLevels = dsRestart.sizes['nVertLevels']
 
-        zMid = compute_zmid(dsRestart.bottomDepth, dsRestart.maxLevelCell,
+        zMid = compute_zmid(dsRestart.bottomDepth, dsRestart.maxLevelCell-1,
                             dsRestart.layerThickness)
 
         vertIndex = xarray.DataArray.from_dict(

--- a/mpas_analysis/ocean/geojson_transects.py
+++ b/mpas_analysis/ocean/geojson_transects.py
@@ -81,6 +81,8 @@ class GeojsonTransects(AnalysisTask):  # {{{
             verticalComparisonGrid = config.getExpression(
                 sectionName, 'verticalComparisonGrid', usenumpyfunc=True)
 
+        verticalBounds = config.getExpression(sectionName, 'verticalBounds')
+
         fields = config.getExpression(sectionName, 'fields')
 
         obsFileNames = OrderedDict()
@@ -163,7 +165,8 @@ class GeojsonTransects(AnalysisTask):  # {{{
                         groupLink='geojson',
                         galleryName=field['titleName'],
                         configSectionName='geojson{}Transects'.format(
-                            fieldPrefixUpper))
+                            fieldPrefixUpper),
+                        verticalBounds=verticalBounds)
 
                     self.add_subtask(subtask)
         # }}}

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -356,8 +356,9 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             filePrefix = self.filePrefixes['mhtZ']
             outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
             colorbarLabel = '(PW/m)'
-            plot_vertical_section(config, x, y, z, self.sectionName,
-                                  suffix='', colorbarLabel=colorbarLabel,
+            plot_vertical_section(config, z, self.sectionName, xCoords=x,
+                                  zCoord=y, suffix='',
+                                  colorbarLabel=colorbarLabel,
                                   title=title, xlabels=xLabel, ylabel=yLabel,
                                   xLim=xLimGlobal,
                                   yLim=depthLimGlobal, invertYAxis=False,

--- a/mpas_analysis/ocean/plot_hovmoller_subtask.py
+++ b/mpas_analysis/ocean/plot_hovmoller_subtask.py
@@ -288,9 +288,15 @@ class PlotHovmollerSubtask(AnalysisTask):
             z = np.zeros(depths.shape)
             z[0] = -0.5 * depths[0]
             z[1:] = -0.5 * (depths[0:-1] + depths[1:])
+            z = xr.DataArray(dims='nVertLevels', data=z)
 
-        Time = ds.Time.values
-        field = ds[self.mpasFieldName].values.transpose()
+        Time = ds.Time
+        field = ds[self.mpasFieldName]
+
+        # drop any NaN values, because this causes issues with rolling averages
+        mask = field.notnull().all(dim='Time')
+        field = field.where(mask, drop=True)
+        z = z.where(mask, drop=True)
 
         xLabel = 'Time (years)'
         yLabel = 'Depth (m)'
@@ -342,7 +348,12 @@ class PlotHovmollerSubtask(AnalysisTask):
                 regionDim = 'nOceanRegionsTmp'
 
             dsRef = dsRef.isel(**{regionDim: regionIndex})
-            refField = dsRef[self.mpasFieldName].values.transpose()
+            refField = dsRef[self.mpasFieldName]
+            # drop any NaN values, because this causes issues with rolling
+            # averages
+            refMask = refField.notnull().all(dim='Time')
+            assert(np.all(refMask.values == mask.values))
+            refField = refField.where(mask, drop=True)
             assert(field.shape == refField.shape)
             diff = field - refField
             refTitle = self.controlConfig.get('runs', 'mainRunName')
@@ -366,8 +377,8 @@ class PlotHovmollerSubtask(AnalysisTask):
         fig, _, suptitle = plot_vertical_section_comparison(
             config, Time, z, field, refField, diff, self.sectionName,
             colorbarLabel=self.unitsLabel, title=title, modelTitle=mainRunName,
-            refTitle=refTitle, diffTitle=diffTitle, xlabel=xLabel,
-            ylabel=yLabel, lineWidth=1, xArrayIsTime=True,
+            refTitle=refTitle, diffTitle=diffTitle, xlabels=xLabel,
+            ylabel=yLabel, lineWidth=1, xCoordIsTime=True,
             movingAveragePoints=movingAverageMonths, calendar=self.calendar,
             firstYearXTicks=firstYearXTicks, yearStrideXTicks=yearStrideXTicks,
             yLim=yLim, invertYAxis=False, titleFontSize=titleFontSize,

--- a/mpas_analysis/ocean/plot_hovmoller_subtask.py
+++ b/mpas_analysis/ocean/plot_hovmoller_subtask.py
@@ -375,10 +375,10 @@ class PlotHovmollerSubtask(AnalysisTask):
             defaultFontSize = None
 
         fig, _, suptitle = plot_vertical_section_comparison(
-            config, Time, z, field, refField, diff, self.sectionName,
-            colorbarLabel=self.unitsLabel, title=title, modelTitle=mainRunName,
-            refTitle=refTitle, diffTitle=diffTitle, xlabels=xLabel,
-            ylabel=yLabel, lineWidth=1, xCoordIsTime=True,
+            config, field, refField, diff, self.sectionName, xCoords=Time,
+            zCoord=z, colorbarLabel=self.unitsLabel, title=title,
+            modelTitle=mainRunName, refTitle=refTitle, diffTitle=diffTitle,
+            xlabels=xLabel, ylabel=yLabel, lineWidth=1, xCoordIsTime=True,
             movingAveragePoints=movingAverageMonths, calendar=self.calendar,
             firstYearXTicks=firstYearXTicks, yearStrideXTicks=yearStrideXTicks,
             yLim=yLim, invertYAxis=False, titleFontSize=titleFontSize,

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -657,7 +657,6 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         # }}}
 
-
     def _lat_greater_extent(self, lat, lon):
         # {{{
         """

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -382,6 +382,12 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         lat = remappedModelClimatology.lat
         lon = remappedModelClimatology.lon
 
+        if len(lat.dims) > 1:
+            lat = lat[:, 0]
+
+        if len(lon.dims) > 1:
+            lon = lon[:, 0]
+
         # This will do strange things at the antemeridian but there's little
         # we can do about that.
         lon_pm180 = numpy.mod(lon + 180., 360.) - 180.
@@ -544,7 +550,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             numUpperTicks=numUpperTicks,
             upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
             invertYAxis=False,
-            backgroundColor='#918167',
+            backgroundColor='#d9bf96',
             xLim=self.horizontalBounds,
             compareAsContours=compareAsContours,
             lineStyle=contourLineStyle,

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -528,12 +528,12 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         fig, axes, suptitle = plot_vertical_section_comparison(
             config,
-            xs,
-            z,
             modelOutput,
             refOutput,
             bias,
             configSectionName,
+            xCoords=xs,
+            zCoord=z,
             colorbarLabel=self.unitsLabel,
             xlabels=xLabels,
             ylabel=yLabel,

--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -660,7 +660,7 @@ class ComputeRegionTSSubtask(AnalysisTask):
             ds = ds[variableList]
 
             ds['zMid'] = compute_zmid(dsRestart.bottomDepth,
-                                      dsRestart.maxLevelCell,
+                                      dsRestart.maxLevelCell-1,
                                       dsRestart.layerThickness)
 
             ds['volume'] = (dsRestart.areaCell *

--- a/mpas_analysis/ocean/remap_depth_slices_subtask.py
+++ b/mpas_analysis/ocean/remap_depth_slices_subtask.py
@@ -117,7 +117,7 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):  # {{{
 
         depthNames = [str(depth) for depth in self.depths]
 
-        zMid = compute_zmid(ds.bottomDepth, ds.maxLevelCell,
+        zMid = compute_zmid(ds.bottomDepth, ds.maxLevelCell-1,
                             ds.layerThickness)
 
         nVertLevels = zMid.shape[1]

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -769,7 +769,7 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
                 diff = regionMOC - refRegionMOC
 
             plot_vertical_section_comparison(
-                config, x, z, regionMOC, refRegionMOC, diff,
+                config, regionMOC, refRegionMOC, diff, xCoords=x, zCoord=z,
                 colorMapSectionName='streamfunctionMOC{}'.format(region),
                 colorbarLabel=colorbarLabel,
                 title=title,

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -755,26 +755,16 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
             maxLat = config.getExpression('streamfunctionMOC{}'.format(region),
                                           'latBinMax')
             indLat = np.logical_and(x >= minLat, x <= maxLat)
-            x = x[indLat]
-            regionMOC = regionMOC[:, indLat]
+            x = x.where(indLat, drop=True)
+            regionMOC = regionMOC.where(indLat, drop=True)
             if self.controlConfig is None:
                 refRegionMOC = None
                 diff = None
             else:
                 # the coords of the ref MOC won't necessarily match this MOC
                 # so we need to interpolate
-                nz, nx = regionMOC.shape
-                refNz, refNx = refMOC[region].shape
-                temp = np.zeros((refNz, nx))
-                for zIndex in range(refNz):
-                    temp[zIndex, :] = np.interp(
-                        x, refLat[region], refMOC[region][zIndex, :],
-                        left=np.nan, right=np.nan)
-                refRegionMOC = np.zeros((nz, nx))
-                for xIndex in range(nx):
-                    refRegionMOC[:, xIndex] = np.interp(
-                        depth, refDepth, temp[:, xIndex],
-                        left=np.nan, right=np.nan)
+                refRegionMOC = _interp_moc(x, z, regionMOC, refLat[region],
+                                           refDepth, refMOC[region])
 
                 diff = regionMOC - refRegionMOC
 
@@ -786,7 +776,7 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
                 modelTitle=mainRunName,
                 refTitle=refTitle,
                 diffTitle=diffTitle,
-                xlabel=xLabel,
+                xlabels=xLabel,
                 ylabel=yLabel,
                 movingAveragePoints=movingAveragePointsClimatological,
                 maxTitleLength=70)
@@ -820,15 +810,13 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
             endYear)
 
         # Read from file
-        ncFile = netCDF4.Dataset(inputFileName, mode='r')
-        depth = ncFile.variables['depth'][:]
+        ds = xr.open_dataset(inputFileName)
+        depth = ds['depth']
         lat = {}
         moc = {}
         for region in self.regionNames:
-            lat[region] = ncFile.variables['lat{}'.format(region)][:]
-            moc[region] = \
-                ncFile.variables['moc{}'.format(region)][:, :]
-        ncFile.close()
+            lat[region] = ds['lat{}'.format(region)]
+            moc[region] = ds['moc{}'.format(region)]
         return depth, lat, moc  # }}}
 
     # }}}
@@ -1605,5 +1593,30 @@ def _compute_moc(latBins, nz, latCell, regionCellMask, transportZ,
     mocTop = mocTop * m3ps_to_Sv
     mocTop = mocTop.T
     return mocTop  # }}}
+
+
+def _interp_moc(x, z, regionMOC, refX, refZ, refMOC):
+    x = x.values
+    z = z.values
+    dims = regionMOC.dims
+    regionMOC = regionMOC.values
+    refX = refX.values
+    refZ = refZ.values
+    refMOC = refMOC.values
+
+    nz, nx = regionMOC.shape
+    refNz, refNx = refMOC.shape
+    temp = np.zeros((refNz, nx))
+    for zIndex in range(refNz):
+        temp[zIndex, :] = np.interp(
+            x, refX, refMOC[zIndex, :],
+            left=np.nan, right=np.nan)
+    refRegionMOC = np.zeros((nz, nx))
+    for xIndex in range(nx):
+        refRegionMOC[:, xIndex] = np.interp(
+            z, refZ, temp[:, xIndex],
+            left=np.nan, right=np.nan)
+
+    return xr.DataArray(dims=dims, data=refRegionMOC)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -313,7 +313,7 @@ class ComputeRegionDepthMasksSubtask(AnalysisTask):  # {{{
             config_zmax = None
 
         dsRestart = xarray.open_dataset(restartFileName).isel(Time=0)
-        zMid = compute_zmid(dsRestart.bottomDepth, dsRestart.maxLevelCell,
+        zMid = compute_zmid(dsRestart.bottomDepth, dsRestart.maxLevelCell-1,
                             dsRestart.layerThickness)
         areaCell = dsRestart.areaCell
         if 'landIceMask' in dsRestart:

--- a/mpas_analysis/ocean/utility.py
+++ b/mpas_analysis/ocean/utility.py
@@ -33,7 +33,7 @@ def compute_zmid(bottomDepth, maxLevelCell, layerThickness):  # {{{
         the depth of the ocean bottom (positive)
 
     maxLevelCell : ``xarray.DataArray``
-        the 1-based vertical index of the bottom of the ocean
+        the 0-based vertical index of the bottom of the ocean
 
     layerThickness : ``xarray.DataArray``
         the thickness of MPAS-Ocean layers (possibly as a function of time)
@@ -54,7 +54,7 @@ def compute_zmid(bottomDepth, maxLevelCell, layerThickness):  # {{{
         xarray.DataArray.from_dict({'dims': ('nVertLevels',),
                                     'data': numpy.arange(nVertLevels)})
 
-    layerThickness = layerThickness.where(vertIndex < maxLevelCell)
+    layerThickness = layerThickness.where(vertIndex <= maxLevelCell)
 
     thicknessSum = layerThickness.sum(dim='nVertLevels')
     thicknessCumSum = layerThickness.cumsum(dim='nVertLevels')

--- a/mpas_analysis/ocean/woce_transects.py
+++ b/mpas_analysis/ocean/woce_transects.py
@@ -77,6 +77,8 @@ class WoceTransects(AnalysisTask):  # {{{
             verticalComparisonGrid = config.getExpression(
                 sectionName, 'verticalComparisonGrid', usenumpyfunc=True)
 
+        verticalBounds = config.getExpression(sectionName, 'verticalBounds')
+
         horizontalBounds = config.getExpression(
             sectionName, 'horizontalBounds')
 
@@ -115,7 +117,7 @@ class WoceTransects(AnalysisTask):  # {{{
                  'units': r'kg m$^{-3}$'}}
 
         transectCollectionName = 'WOCE_transects'
-        if horizontalResolution != 'obs':
+        if horizontalResolution not in ['obs', 'mpas']:
             transectCollectionName = '{}_{}km'.format(transectCollectionName,
                                                       horizontalResolution)
 
@@ -187,7 +189,8 @@ class WoceTransects(AnalysisTask):  # {{{
                         groupLink='woce',
                         galleryName=titleName,
                         configSectionName='woce{}Transects'.format(
-                            fieldNameUpper))
+                            fieldNameUpper),
+                        verticalBounds=verticalBounds)
 
                     self.add_subtask(subtask)
         # }}}

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -133,6 +133,22 @@ regionNames = ["Atlantic_Basin", "Pacific_Basin", "Indian_Basin",
 longitudes = [318., 325., 0., 75., 117., 145., 160., 184., 187., 198., 253.,
               280., 288.]
 
+# The approximate horizontal resolution (in km) of each transect.  Latitude/
+# longitude between observation points will be subsampled at this interval.
+# Use 'obs' to indicate no subsampling. Use 'mpas' to indicate plotting of
+# model data on the native grid, in which case comparison with observations
+# will take place on the observation grid.
+horizontalResolution = mpas
+
+# The name of the vertical comparison grid.  Valid values are 'mpas' for the
+# MPAS vertical grid, 'obs' to use the locations of observations or
+# any other name if the vertical grid is defined by 'verticalComparisonGrid'
+verticalComparisonGridName = mpas
+
+# A range for the y axis (if any)
+verticalBounds = [-1500., 0.]
+
+
 [soseTemperatureTransects]
 # options related to plotting SOSE transects of potential temperature
 
@@ -178,12 +194,27 @@ colorbarLevelsDifference = [-0.5, -0.2, -0.1, -0.05, -0.02, 0,  0.02, 0.05,
 ## options related to plotting model vs. World Ocean Circulation Experiment
 ## (WOCE) transects.
 
+# The approximate horizontal resolution (in km) of each transect.  Latitude/
+# longitude between observation points will be subsampled at this interval.
+# Use 'obs' to indicate no subsampling. Use 'mpas' to indicate plotting of
+# model data on the native grid, in which case comparison with observations
+# will take place on the observation grid.
+horizontalResolution = mpas
+
+# The name of the vertical comparison grid.  Valid values are 'mpas' for the
+# MPAS vertical grid, 'obs' to use the locations of observations or
+# any other name if the vertical grid is defined by 'verticalComparisonGrid'
+verticalComparisonGridName = mpas
+
 # Horizontal bounds of the plot (in km), or an empty list for automatic bounds
 # The bounds are a 2-element list of the minimum and maximum distance along the
 # transect
 horizontalBounds = {'WOCE_A21': [630., 830.],
                     'WOCE_A23': [0., 200.],
                     'WOCE_A12': [4620., 4820.]}
+
+# A range for the y axis (if any)
+verticalBounds = [-4000., 0.]
 
 [woceTemperatureTransects]
 ## options related to plotting WOCE transects of potential temperature

--- a/mpas_analysis/shared/climatology/__init__.py
+++ b/mpas_analysis/shared/climatology/__init__.py
@@ -4,7 +4,8 @@ from mpas_analysis.shared.climatology.climatology import get_remapper, \
     get_unmasked_mpas_climatology_directory, \
     get_unmasked_mpas_climatology_file_name, \
     get_masked_mpas_climatology_file_name, \
-    get_remapped_mpas_climatology_file_name
+    get_remapped_mpas_climatology_file_name, \
+    get_climatology_op_directory
 
 from mpas_analysis.shared.climatology.mpas_climatology_task import \
     MpasClimatologyTask

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -585,7 +585,7 @@ def get_remapped_mpas_climatology_file_name(config, season, componentName,
                                                          comparisonGridName)
         comparisonFullMeshName = comparisonDescriptor.meshName
     else:
-        comparisonFullMeshName = comparisonGridName
+        comparisonFullMeshName = comparisonGridName.replace(' ', '_')
 
     stageDirectory = '{}/remapped'.format(climatologyOpDirectory)
 

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -537,7 +537,7 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
 
             # add valid mask as a variable, useful for remapping later
             climatology['validMask'] = \
-                xr.DataArray(numpy.ones(climatology.dims['nCells']),
+                xr.DataArray(numpy.ones(climatology.sizes['nCells']),
                              dims=['nCells'])
             # mask the data set
             for variableName in self.variableList:

--- a/mpas_analysis/shared/plot/inset.py
+++ b/mpas_analysis/shared/plot/inset.py
@@ -8,9 +8,9 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-'''
+"""
 Functions for plotting inset maps in plots (e.g. for transects)
-'''
+"""
 # Authors
 # -------
 # Xylar Asay-Davis
@@ -31,7 +31,7 @@ from geometric_features.plot import subdivide_geom
 def add_inset(fig, fc, latlonbuffer=45., polarbuffer=5., width=1.0,
               height=1.0, lowerleft=None, xbuffer=None, ybuffer=None,
               maxlength=1.):
-    '''
+    """
     Plots an inset map showing the location of a transect or polygon.  Shapes
     are plotted on a polar grid if they are entirely poleward of +/-50 deg.
     latitude and with a lat/lon grid if not.
@@ -71,7 +71,7 @@ def add_inset(fig, fc, latlonbuffer=45., polarbuffer=5., width=1.0,
     -------
     inset : ``matplotlib.axes.Axes``
         The new inset axis
-    '''
+    """
     # Authors
     # -------
     # Xylar Asay-Davis
@@ -170,13 +170,14 @@ def add_inset(fig, fc, latlonbuffer=45., polarbuffer=5., width=1.0,
 
 
 def _set_circular_boundary(ax):
-    '''Set the boundary of the given axis to be circular (for a polar plot)'''
+    """Set the boundary of the given axis to be circular (for a polar plot)"""
 
     # Compute a circle in axes coordinates, which we can use as a boundary
     # for the map. We can pan/zoom as much as we like - the boundary will be
     # permanently circular.
     theta = numpy.linspace(0, 2*numpy.pi, 100)
-    center, radius = [0.5, 0.5], 0.5
+    center = numpy.array([0.5, 0.5])
+    radius = 0.5
     verts = numpy.vstack([numpy.sin(theta), numpy.cos(theta)]).T
     circle = matplotlib.path.Path(verts * radius + center)
 
@@ -184,12 +185,12 @@ def _set_circular_boundary(ax):
 
 
 def _get_bounds(fc):
-    '''Compute the lon/lat bounding box for all transects and regions'''
+    """Compute the lon/lat bounding box for all transects and regions"""
 
     bounds = shapely.geometry.GeometryCollection()
     for feature in fc.features:
         shape = shapely.geometry.shape(feature['geometry'])
         shape_bounds = shapely.geometry.box(*shape.bounds)
-        bounds = shapely.geometry.box(*(bounds.union(shape_bounds).bounds))
+        bounds = shapely.geometry.box(*bounds.union(shape_bounds).bounds)
 
     return bounds.bounds

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -762,7 +762,6 @@ def plot_vertical_section(
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')
     matplotlib.rc('font', size=defaultFontSize)
-    mask = field.notnull()
     if xCoords is not None:
         if not isinstance(xCoords, list):
             xCoords = [xCoords]
@@ -806,9 +805,11 @@ def plot_vertical_section(
             y = y.rolling(dim={dim: movingAveragePoints},
                           center=True).mean().dropna(dim)
 
+        mask = field.notnull()
         maskedTriangulation, unmaskedTriangulation = _get_triangulation(
             x, y, mask)
     else:
+        mask = field.notnull()
         maskedTriangulation, unmaskedTriangulation = _get_ds_triangulation(
             dsTransectTriangles, mask)
 

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -708,8 +708,8 @@ def plot_vertical_section(
 
     movingAveragePoints : int, optional
         the number of points over which to perform a moving average
-        NOTE: this option is mostly intended for use when ``xCoordIsTime`` is True,
-        although it will work with other data as well.  Also, the moving
+        NOTE: this option is mostly intended for use when ``xCoordIsTime`` is
+        True, although it will work with other data as well.  Also, the moving
         average calculation is based on number of points, not actual x axis
         values, so for best results, the values in the first entry in
         ``xCoords`` should be equally spaced.
@@ -893,7 +893,8 @@ def plot_vertical_section(
     else:
         # display a white heatmap to get a white background for non-land
         zeroArray = xr.zeros_like(field)
-        plt.tricontourf(maskedTriangulation, zeroArray.values.ravel(), colors='white')
+        plt.tricontourf(maskedTriangulation, zeroArray.values.ravel(),
+                        colors='white')
 
     ax = plt.gca()
     ax.set_facecolor(backgroundColor)
@@ -1025,6 +1026,7 @@ def plot_vertical_section(
                 ax3.spines['top'].set_position(('outward', 36))
 
     return fig, ax  # }}}
+
 
 def _get_triangulation(x, y, mask):
     """divide each quad in the x/y mesh into 2 triangles"""

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import, division, print_function, \
 import matplotlib
 import matplotlib.pyplot as plt
 import xarray as xr
-import pandas as pd
 import numpy as np
 
 from mpas_analysis.shared.timekeeping.utility import date_to_days
@@ -34,14 +33,14 @@ from mpas_analysis.shared.plot.title import limit_title
 
 def plot_vertical_section_comparison(
         config,
-        xArray,
-        depthArray,
+        xCoords,
+        zCoord,
         modelArray,
         refArray,
         diffArray,
         colorMapSectionName,
         colorbarLabel=None,
-        xlabel=None,
+        xlabels=None,
         ylabel=None,
         title=None,
         modelTitle='Model',
@@ -59,14 +58,10 @@ def plot_vertical_section_comparison(
         backgroundColor='grey',
         xLim=None,
         yLim=None,
-        secondXAxisData=None,
-        secondXAxisLabel=None,
-        thirdXAxisData=None,
-        thirdXAxisLabel=None,
         numUpperTicks=None,
         upperXAxisTickLabelPrecision=None,
         invertYAxis=True,
-        xArrayIsTime=False,
+        xCoordIsTime=False,
         movingAveragePoints=None,
         firstYearXTicks=None,
         yearStrideXTicks=None,
@@ -96,14 +91,18 @@ def plot_vertical_section_comparison(
         the configuration, containing a [plot] section with options that
         control plotting
 
-    xArray : float array
-        x array (latitude, longitude, spherical distance, or distance along
-        a transect;  or, time for Hovmoller plots)
+    xCoords : xarray.DataArray or list of xarray.DataArray
+       The x coordinate(s) in ``field``.  Optional second
+       and third entries will be used for a second and third x axis above the
+       plot.  The typical use for the second and third axis is for transects,
+       for which the primary x axis represents distance along a transect, and
+       the second and third x axes are used to display the corresponding
+       latitudes and longitudes.
 
-    depthArray : float array
-        depth array [m]
+    zCoord : xarray.DataArray
+        The z coordinates in ``field``
 
-    modelArray, refArray : float arrays
+    modelArray, refArray : xarray.DataArray
         model and observational or control run data sets
 
     diffArray : float array
@@ -121,8 +120,11 @@ def plot_vertical_section_comparison(
         parenthetically appended to the legend entries of the contour
         comparison plot.
 
-    xlabel, ylabel : str, optional
-        label of x- and y-axis
+    xlabels : str or list of str, optional
+        labels of x-axes.  Labels correspond to entries in ``xCoords``.
+
+    ylabel : str, optional
+        label of y-axis
 
     title : str, optional
         the subtitle of the plot
@@ -182,28 +184,6 @@ def plot_vertical_section_comparison(
     yLim : float array, optional
         y range of plot
 
-    secondXAxisData : the data to use to display a second x axis (which will be
-        placed above the plot).  This array must have the same number of values
-        as xArray, and it is assumed that the values in this array define
-        locations along the x axis that are the same as those defined by the
-        corresponding values in xArray, but in some different unit system.
-
-    secondXAxisLabel : the label for the second x axis, if requested
-
-    thirdXAxisData : the data to use to display a third x axis (which will be
-        placed above the plot and above the second x axis, which must be
-        specified if a third x axis is to be specified).  This array must have
-        the same number of values as xArray, and it is assumed that the values
-        in this array define locations along the x axis that are the same as
-        those defined by the corresponding values in xArray, but in some
-        different unit system (which is presumably also different from the unit
-        system used for the values in the secondXAxisData array).  The typical
-        use for this third axis is for transects, for which the primary x axis
-        represents distance along a transect, and the second and third x axes
-        are used to display the corresponding latitudes and longitudes.
-
-    thirdXAxisLabel : the label for the third x axis, if requested
-
     numUpperTicks : the approximate number of ticks to use on the upper x axis
         or axes (these are the second and third x axes, which are placed above
         the plot if they have been requested by specifying the secondXAxisData
@@ -217,13 +197,13 @@ def plot_vertical_section_comparison(
     invertYAxis : logical, optional
         if True, invert Y axis
 
-    xArrayIsTime : logical, optional
+    xCoordIsTime : logical, optional
         if True, format the x axis for time (this applies only to the primary
         x axis, not to the optional second or third x axes)
 
     movingAveragePoints : int, optional
         the number of points over which to perform a moving average
-        NOTE: this option is mostly intended for use when xArrayIsTime is True,
+        NOTE: this option is mostly intended for use when xCoordIsTime is True,
         although it will work with other data as well.  Also, the moving
         average calculation is based on number of points, not actual x axis
         values, so for best results, the values in the xArray should be equally
@@ -240,11 +220,11 @@ def plot_vertical_section_comparison(
     maxXTicks : int, optional
         the maximum number of tick marks that will be allowed along the primary
         x axis.  This may need to be adjusted depending on the figure size and
-        aspect ratio.  NOTE:  maxXTicks is only used if xArrayIsTime is True
+        aspect ratio.  NOTE:  maxXTicks is only used if xCoordIsTime is True
 
     calendar : str, optional
         the calendar to use for formatting the time axis
-        NOTE:  calendar is only used if xArrayIsTime is True
+        NOTE:  calendar is only used if xCoordIsTime is True
 
     compareAsContours : bool, optional
        if compareAsContours is True, instead of creating a three panel plot
@@ -298,6 +278,11 @@ def plot_vertical_section_comparison(
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')
     matplotlib.rc('font', size=defaultFontSize)
+    if not isinstance(xCoords, list):
+        xCoords = [xCoords]
+
+    if not isinstance(xlabels, list):
+        xlabels = [xlabels]
 
     if refArray is None or compareAsContours:
         singlePanel = True
@@ -312,13 +297,13 @@ def plot_vertical_section_comparison(
         # depending on how many x axes are to be displayed on the plots
         if singlePanel:
             if compareAsContours and refArray is not None:
-                if thirdXAxisData is not None:
+                if len(xCoords) == 3:
                     figsize = (8, 8)
                 else:
                     figsize = (8, 7)
             else:
                 figsize = (8, 5)
-        elif thirdXAxisData is not None:
+        elif len(xCoords) == 3:
             figsize = (8, 17)
         else:
             figsize = (8, 13)
@@ -339,12 +324,12 @@ def plot_vertical_section_comparison(
     if plotTitleFontSize is None:
         plotTitleFontSize = config.get('plot', 'threePanelPlotTitleFontSize')
 
-    if thirdXAxisData is not None:
+    if len(xCoords) == 3:
         if singlePanel:
             titleY = 1.64
         else:
             titleY = 1.34
-    elif secondXAxisData is not None:
+    elif len(xCoords) >= 2:
         titleY = 1.20
     else:
         titleY = 1.06
@@ -357,12 +342,12 @@ def plot_vertical_section_comparison(
 
     if not compareAsContours or refArray is None:
         title = modelTitle
-        contourComparisonFieldArray = None
+        contourComparisonField = None
         comparisonFieldName = None
         originalFieldName = None
     else:
         title = None
-        contourComparisonFieldArray = refArray
+        contourComparisonField = refArray
         comparisonFieldName = refTitle
         originalFieldName = modelTitle
 
@@ -370,14 +355,14 @@ def plot_vertical_section_comparison(
 
     _, ax = plot_vertical_section(
         config,
-        xArray,
-        depthArray,
+        xCoords,
+        zCoord,
         modelArray,
         colorMapSectionName,
         suffix=resultSuffix,
         colorbarLabel=colorbarLabel,
         title=title,
-        xlabel=xlabel,
+        xlabels=xlabels,
         ylabel=ylabel,
         figsize=None,
         titleFontSize=plotTitleFontSize,
@@ -389,21 +374,17 @@ def plot_vertical_section_comparison(
         lineWidth=lineWidth,
         lineStyle=lineStyle,
         lineColor=lineColor,
-        secondXAxisData=secondXAxisData,
-        secondXAxisLabel=secondXAxisLabel,
-        thirdXAxisData=thirdXAxisData,
-        thirdXAxisLabel=thirdXAxisLabel,
         numUpperTicks=numUpperTicks,
         upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
         invertYAxis=invertYAxis,
-        xArrayIsTime=xArrayIsTime,
+        xCoordIsTime=xCoordIsTime,
         movingAveragePoints=movingAveragePoints,
         firstYearXTicks=firstYearXTicks,
         yearStrideXTicks=yearStrideXTicks,
         maxXTicks=maxXTicks, calendar=calendar,
         backgroundColor=backgroundColor,
         plotAsContours=compareAsContours,
-        contourComparisonFieldArray=contourComparisonFieldArray,
+        contourComparisonField=contourComparisonField,
         comparisonFieldName=comparisonFieldName,
         originalFieldName=originalFieldName,
         comparisonContourLineStyle=comparisonContourLineStyle,
@@ -418,14 +399,14 @@ def plot_vertical_section_comparison(
         plt.subplot(3, 1, 2)
         _, ax = plot_vertical_section(
             config,
-            xArray,
-            depthArray,
+            xCoords,
+            zCoord,
             refArray,
             colorMapSectionName,
             suffix=resultSuffix,
             colorbarLabel=colorbarLabel,
             title=refTitle,
-            xlabel=xlabel,
+            xlabels=xlabels,
             ylabel=ylabel,
             figsize=None,
             titleFontSize=plotTitleFontSize,
@@ -437,14 +418,10 @@ def plot_vertical_section_comparison(
             lineWidth=lineWidth,
             lineStyle=lineStyle,
             lineColor=lineColor,
-            secondXAxisData=secondXAxisData,
-            secondXAxisLabel=secondXAxisLabel,
-            thirdXAxisData=thirdXAxisData,
-            thirdXAxisLabel=thirdXAxisLabel,
             upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
             numUpperTicks=numUpperTicks,
             invertYAxis=invertYAxis,
-            xArrayIsTime=xArrayIsTime,
+            xCoordIsTime=xCoordIsTime,
             movingAveragePoints=movingAveragePoints,
             firstYearXTicks=firstYearXTicks,
             yearStrideXTicks=yearStrideXTicks,
@@ -460,14 +437,14 @@ def plot_vertical_section_comparison(
         plt.subplot(3, 1, 3)
         _, ax = plot_vertical_section(
             config,
-            xArray,
-            depthArray,
+            xCoords,
+            zCoord,
             diffArray,
             colorMapSectionName,
             suffix=diffSuffix,
             colorbarLabel=colorbarLabel,
             title=diffTitle,
-            xlabel=xlabel,
+            xlabels=xlabels,
             ylabel=ylabel,
             figsize=None,
             titleFontSize=plotTitleFontSize,
@@ -479,14 +456,10 @@ def plot_vertical_section_comparison(
             lineWidth=lineWidth,
             lineStyle=lineStyle,
             lineColor=lineColor,
-            secondXAxisData=secondXAxisData,
-            secondXAxisLabel=secondXAxisLabel,
-            thirdXAxisData=thirdXAxisData,
-            thirdXAxisLabel=thirdXAxisLabel,
             upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
             numUpperTicks=numUpperTicks,
             invertYAxis=invertYAxis,
-            xArrayIsTime=xArrayIsTime,
+            xCoordIsTime=xCoordIsTime,
             movingAveragePoints=movingAveragePoints,
             firstYearXTicks=firstYearXTicks,
             yearStrideXTicks=yearStrideXTicks,
@@ -500,7 +473,7 @@ def plot_vertical_section_comparison(
         axes.append(ax)
 
     if singlePanel:
-        if thirdXAxisData is not None and refArray is None:
+        if len(xCoords) == 3 and refArray is None:
             plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.0, 0.0, 1.0, 0.98])
         else:
             plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.0, 0.0, 1.0, 0.95])
@@ -512,14 +485,14 @@ def plot_vertical_section_comparison(
 
 def plot_vertical_section(
         config,
-        xArray,
-        depthArray,
-        fieldArray,
+        xCoords,
+        zCoord,
+        field,
         colorMapSectionName,
         suffix='',
         colorbarLabel=None,
         title=None,
-        xlabel=None,
+        xlabels=None,
         ylabel=None,
         figsize=(10, 4),
         dpi=None,
@@ -533,21 +506,17 @@ def plot_vertical_section(
         lineStyle='solid',
         lineColor='black',
         backgroundColor='grey',
-        secondXAxisData=None,
-        secondXAxisLabel=None,
-        thirdXAxisData=None,
-        thirdXAxisLabel=None,
         numUpperTicks=None,
         upperXAxisTickLabelPrecision=None,
         invertYAxis=True,
-        xArrayIsTime=False,
+        xCoordIsTime=False,
         movingAveragePoints=None,
         firstYearXTicks=None,
         yearStrideXTicks=None,
         maxXTicks=20,
         calendar='gregorian',
         plotAsContours=False,
-        contourComparisonFieldArray=None,
+        contourComparisonField=None,
         comparisonFieldName=None,
         originalFieldName=None,
         comparisonContourLineStyle=None,
@@ -559,12 +528,12 @@ def plot_vertical_section(
     Plots a data set as a x distance (latitude, longitude,
     or spherical distance) vs depth map (vertical section).
 
-    Or, if xArrayIsTime is True, plots data set on a vertical
+    Or, if xCoordIsTime is True, plots data set on a vertical
     Hovmoller plot (depth vs. time).
 
-    Typically, the fieldArray data are plotted using a heatmap, but if
-    contourComparisonFieldArray is not None, then contours of both
-    fieldArray and contourComparisonFieldArray are plotted instead.
+    Typically, the ``field`` data are plotted using a heatmap, but if
+    ``contourComparisonField`` is not None, then contours of both
+    ``field`` and ``contourComparisonField`` are plotted instead.
 
     Parameters
     ----------
@@ -572,15 +541,25 @@ def plot_vertical_section(
         the configuration, containing a [plot] section with options that
         control plotting
 
-    xArray : float array
-        x array (latitude, longitude, or spherical distance; or, time for a
-        Hovmoller plot)
+    xCoords : xarray.DataArray or list of xarray.DataArray
+        The x coordinate(s) in ``field``.  Optional second
+        and third entries will be used for a second and third x axis above the
+        plot.  The typical use for the second and third axis is for transects,
+        for which the primary x axis represents distance along a transect, and
+        the second and third x axes are used to display the corresponding
+        latitudes and longitudes.
 
-    depthArray : float array
-        depth array [m]
+    zCoord : xarray.DataArray
+        The z coordinates in ``field``
 
-    fieldArray : float array
-        field array to plot
+    field : xarray.DataArray
+        field array to plot.  For contour plots, ``xCoords`` and ``zCoords``
+        should broadcast to the same shape as ``field``.  For heatmap plots,
+        ``xCoords`` and ``zCoords`` are the corners of the plot.  If they
+        broadcast to the same shape as ``field``, ``field`` will be bilinearly
+        interpolated to center values for each plot cell.  If the coordinates
+        have one extra element in each direction than ``field``, ``field`` is
+        assumed to contain cell values and no interpolation is performed.
 
     colorMapSectionName : str
         section name in ``config`` where color map info can be found.
@@ -592,16 +571,19 @@ def plot_vertical_section(
         the label for the colorbar.  If plotAsContours and labelContours are
         both True, colorbarLabel is used as follows (typically in order to
         indicate the units that are associated with the contour labels):
-        if contourComparisonFieldArray is None, the colorbarLabel string is
+        if ``contourComparisonField`` is None, the ``colorbarLabel`` string is
         parenthetically appended to the plot title;  if
-        contourComparisonFieldArray is not None, it is parenthetically appended
+        ``contourComparisonField`` is not None, it is parenthetically appended
         to the legend entries of the contour comparison plot.
 
     title : str, optional
         title of plot
 
-    xlabel, ylabel : str, optional
-        label of x- and y-axis
+    xlabels : str or list of str, optional
+        labels of x-axes.  Labels correspond to entries in ``xCoords``.
+
+    ylabel : str, optional
+        label of y-axis
 
     figsize : tuple of float, optional
         size of the figure in inches, or None if the current figure should
@@ -635,45 +617,25 @@ def plot_vertical_section(
     lineStyle : str, optional
         the line style of contour lines (if specified); this applies to the
         style of contour lines of fieldArray (the style of the contour lines
-        of contourComparisonFieldArray is set using
+        of contourComparisonField is set using
         contourComparisonLineStyle).
 
     lineColor : str, optional
         the color of contour lines (if specified); this applies to the
         contour lines of fieldArray (the color of the contour lines of
-        contourComparisonFieldArray is set using contourComparisonLineColor
+        contourComparisonField is set using contourComparisonLineColor
 
     backgroundColor : str, optional
         the background color for the plot (NaNs will be shown in this color)
 
-    secondXAxisData : the data to use to display a second x axis (which will be
-        placed above the plot).  This array must have the same number of values
-        as xArray, and it is assumed that the values in this array define
-        locations along the x axis that are the same as those defined by the
-        corresponding values in xArray, but in some different unit system.
-
-    secondXAxisLabel : the label for the second x axis, if requested
-
-    thirdXAxisData : the data to use to display a third x axis (which will be
-        placed above the plot and above the second x axis, which must be
-        specified if a third x axis is to be specified).  This array must have
-        the same number of values as xArray, and it is assumed that the values
-        in this array define locations along the x axis that are the same as
-        those defined by the corresponding values in xArray, but in some
-        different unit system (which is presumably also different from the unit
-        system used for the values in the secondXAxisData array).  The typical
-        use for this third axis is for transects, for which the primary x axis
-        represents distance along a transect, and the second and third x axes
-        are used to display the corresponding latitudes and longitudes.
-
-    thirdXAxisLabel : the label for the third x axis, if requested
-
-    numUpperTicks : the approximate number of ticks to use on the upper x axis
+    numUpperTicks :  int, optional
+        the approximate number of ticks to use on the upper x axis
         or axes (these are the second and third x axes, which are placed above
         the plot if they have been requested by specifying the secondXAxisData
         or thirdXAxisData arrays above)
 
-    upperXAxisTickLabelPrecision : the number of decimal places (to the right
+    upperXAxisTickLabelPrecision : int, optional
+        the number of decimal places (to the right
         of the decimal point) to use for values at upper axis ticks.  This
         value can be adjusted (in concert with numUpperTicks) to avoid problems
         with overlapping numbers along the upper axis.
@@ -681,17 +643,17 @@ def plot_vertical_section(
     invertYAxis : logical, optional
         if True, invert Y axis
 
-    xArrayIsTime : logical, optional
+    xCoordIsTime : logical, optional
         if True, format the x axis for time (this applies only to the primary
         x axis, not to the optional second or third x axes)
 
     movingAveragePoints : int, optional
         the number of points over which to perform a moving average
-        NOTE: this option is mostly intended for use when xArrayIsTime is True,
+        NOTE: this option is mostly intended for use when ``xCoordIsTime`` is True,
         although it will work with other data as well.  Also, the moving
         average calculation is based on number of points, not actual x axis
-        values, so for best results, the values in the xArray should be equally
-        spaced.
+        values, so for best results, the values in the first entry in
+        ``xCoords`` should be equally spaced.
 
     firstYearXTicks : int, optional
         The year of the first tick on the x axis.  By default, the first time
@@ -704,38 +666,36 @@ def plot_vertical_section(
     maxXTicks : int, optional
         the maximum number of tick marks that will be allowed along the primary
         x axis.  This may need to be adjusted depending on the figure size and
-        aspect ratio.  NOTE:  maxXTicks is only used if xArrayIsTime is True
+        aspect ratio.  NOTE:  maxXTicks is only used if xCoordIsTime is True
 
     calendar : str, optional
         the calendar to use for formatting the time axis
-        NOTE:  calendar is only used if xArrayIsTime is True
+        NOTE:  calendar is only used if xCoordIsTime is True
 
     plotAsContours : bool, optional
-        if plotAsContours is True, instead of plotting fieldArray as a
-        heatmap, the function will plot only the contours of fieldArray.  In
-        addition, if contourComparisonFieldArray is not None, the contours
+        if plotAsContours is True, instead of plotting ``field`` as a
+        heatmap, the function will plot only the contours of ``field``.  In
+        addition, if contourComparisonField is not None, the contours
         of this field will be plotted on the same plot.  The selection of
         contour levels is still determined as for the contours on the heatmap
-        plots, via the 'contours' entry in colorMapSectionName.
+        plots, via the 'contours' entry in ``colorMapSectionName``.
 
-    contourComparisonFieldArray : float array, optional
-        a comparison field array (typically observational data or results from
-        another simulation run), assumed to be of the same shape as fieldArray,
-        and related to xArray and depthArray in the same way fieldArray is.
-        If contourComparisonFieldArray is None, then fieldArray will be plotted
-        as a heatmap.  However, if countourComparisonFieldArray is not None,
-        then contours of both fieldArray and contourComparisonFieldArray will
-        be plotted in order to enable a comparison of the two fields on the
-        same plot.  If plotAsContours is False, this parameter is ignored.
+    contourComparisonField : float array, optional
+        a comparison ``field`` array (typically observational data or results
+        from another simulation run), assumed to be of the same shape as
+        ``field``. If ``plotAsContours`` is ``True`` and
+        ``countourComparisonFieldArray`` is not ``None``, then contours of both
+        ``field`` and ``contourComparisonField`` will be plotted in order to
+        enable a comparison of the two fields on the same plot.
 
     comparisonFieldName : str, optional
-       the name for the comparison field.  If contourComparisonFieldArray is
-       None, this parameter is ignored.
+        the name for the comparison field.  If contourComparisonField is
+        None, this parameter is ignored.
 
     originalFieldName : str, optional
-       the name for the fieldArray field (for the purposes of labeling the
-       contours on a contour comparison plot).  If contourComparisonFieldArray
-       is None, this parameter is ignored.
+        the name for the ``field`` field (for the purposes of labeling the
+        contours on a contour comparison plot).  If contourComparisonField
+        is None, this parameter is ignored.
 
     comparisonContourLineStyle : str, optional
         the line style of contour lines of the comparisonFieldName field on
@@ -771,143 +731,44 @@ def plot_vertical_section(
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')
     matplotlib.rc('font', size=defaultFontSize)
+    if not isinstance(xCoords, list):
+        xCoords = [xCoords]
+
+    if not isinstance(xlabels, list):
+        xlabels = [xlabels]
+
+    if len(xCoords) != len(xlabels):
+        raise ValueError('Expected the same number of xCoords and xlabels')
+
+    x, y = xr.broadcast(xCoords[0], zCoord)
+    dims_in_field = all([dim in field.dims for dim in x.dims])
+
+    if dims_in_field:
+        x = x.transpose(*field.dims)
+        y = y.transpose(*field.dims)
+    else:
+        xsize = list(x.sizes.values())
+        fieldsize = list(field.sizes.values())
+        if xsize[0] == fieldsize[0] + 1 and xsize[1] == fieldsize[1] + 1:
+            pass
+        elif xsize[0] == fieldsize[1] + 1 and xsize[1] == fieldsize[0] + 1:
+            x = x.transpose(x.dims[1], x.dims[0])
+            y = y.transpose(y.dims[1], y.dims[0])
+        else:
+            raise ValueError('Sizes of coords {}x{} and field {}x{} not '
+                             'compatible.'.format(xsize[0], xsize[1],
+                                                  fieldsize[0], fieldsize[1]))
 
     # compute moving averages with respect to the x dimension
     if movingAveragePoints is not None and movingAveragePoints != 1:
-        N = movingAveragePoints
-        movingAverageDepthSlices = []
-        for nVertLevel in range(len(depthArray)):
-            depthSlice = fieldArray[[nVertLevel]][0]
-            # in case it's not an xarray already
-            depthSlice = xr.DataArray(depthSlice)
-            mean = pd.Series.rolling(depthSlice.to_series(), N,
-                                     center=True).mean()
-            mean = xr.DataArray.from_series(mean)
-            mean = mean[int(N / 2.0):-int(round(N / 2.0) - 1)]
-            movingAverageDepthSlices.append(mean)
-        xArray = xArray[int(N / 2.0):-int(round(N / 2.0) - 1)]
-        fieldArray = xr.DataArray(movingAverageDepthSlices)
 
-    dimX = xArray.shape
-    dimZ = depthArray.shape
-    dimF = fieldArray.shape
-    if contourComparisonFieldArray is not None:
-        dimC = contourComparisonFieldArray.shape
-
-    if len(dimX) != 1 and len(dimX) != 2:
-        raise ValueError('xArray must have either one or two dimensions '
-                         '(has %d)' % dimX)
-
-    if len(dimZ) != 1 and len(dimZ) != 2:
-        raise ValueError('depthArray must have either one or two dimensions '
-                         '(has %d)' % dimZ)
-
-    if len(dimF) != 2:
-        raise ValueError('fieldArray must have two dimensions (has %d)' % dimF)
-
-    if contourComparisonFieldArray is not None:
-        if len(dimC) != 2:
-            raise ValueError('contourComparisonFieldArray must have two '
-                             'dimensions (has %d)' % dimC)
-        elif (fieldArray.shape[0] != contourComparisonFieldArray.shape[0]) or \
-             (fieldArray.shape[1] != contourComparisonFieldArray.shape[1]):
-            raise ValueError('size mismatch between fieldArray (%d x %d) and '
-                             'contourComparisonFieldArray (%d x %d)' %
-                             (fieldArray.shape[0], fieldArray.shape[1],
-                              contourComparisonFieldArray.shape[0],
-                              contourComparisonFieldArray.shape[1]))
-
-    # verify that the dimensions of fieldArray are consistent with those of
-    # xArray and depthArray
-    if len(dimX) == 1 and len(dimZ) == 1:
-        num_x = dimX[0]
-        num_z = dimZ[0]
-        if num_x != fieldArray.shape[1] or num_z != fieldArray.shape[0]:
-            raise ValueError('size mismatch between xArray (%d), '
-                             'depthArray (%d), and fieldArray (%d x %d)' %
-                             (num_x, num_z, fieldArray.shape[0],
-                              fieldArray.shape[1]))
-    elif len(dimX) == 1:
-        num_x = dimX[0]
-        num_x_Z = dimZ[1]
-        num_z = dimZ[0]
-        if num_x != fieldArray.shape[1] or num_z != fieldArray.shape[0] or \
-                num_x != num_x_Z:
-            raise ValueError('size mismatch between xArray (%d), '
-                             'depthArray (%d x %d), and fieldArray (%d x %d)' %
-                             (num_x, num_z, num_x_Z,
-                              fieldArray.shape[0],
-                              fieldArray.shape[1]))
-    elif len(dimZ) == 1:
-        num_x = dimX[1]
-        num_z_X = dimX[0]
-        num_z = dimZ[0]
-        if num_x != fieldArray.shape[1] or num_z != fieldArray.shape[0] or \
-                num_z != num_z_X:
-            raise ValueError('size mismatch between xArray (%d x %d), '
-                             'depthArray (%d), and fieldArray (%d x %d)' %
-                             (num_z_X, num_x, num_z,
-                              fieldArray.shape[0],
-                              fieldArray.shape[1]))
-    else:
-        num_x = dimX[1]
-        num_z_X = dimX[0]
-        num_x_Z = dimZ[1]
-        num_z = dimZ[0]
-        if num_x != fieldArray.shape[1] or num_z != fieldArray.shape[0] \
-                or num_x != num_x_Z or num_z != num_z_X:
-            raise ValueError('size mismatch between xArray (%d x %d), '
-                             'depthArray (%d x %d), and fieldArray (%d x %d)' %
-                             (num_z_X, num_x, num_z, num_x_Z,
-                              fieldArray.shape[0],
-                              fieldArray.shape[1]))
-
-    # Verify that the upper x-axis parameters are consistent with each other
-    # and with xArray
-    if secondXAxisData is None and thirdXAxisData is not None:
-        raise ValueError('secondXAxisData cannot be None if thirdXAxisData '
-                         'is not None')
-    if secondXAxisData is not None:
-        arrayShape = secondXAxisData.shape
-        if len(arrayShape) == 1 and arrayShape[0] != num_x:
-            raise ValueError('secondXAxisData has %d x values, '
-                             'but should have num_x = %d x values' %
-                             (arrayShape[0], num_x))
-        elif len(arrayShape) == 2 and arrayShape[1] != num_x:
-            raise ValueError('secondXAxisData has %d x values, '
-                             'but should have num_x = %d x values' %
-                             (arrayShape[1], num_x))
-        elif len(arrayShape) > 2:
-            raise ValueError('secondXAxisData must be a 1D or 2D array, '
-                             'but is of dimension %d' %
-                             (len(arrayShape)))
-    if thirdXAxisData is not None:
-        arrayShape = thirdXAxisData.shape
-        if len(arrayShape) == 1 and arrayShape[0] != num_x:
-            raise ValueError('thirdXAxisData has %d x values, '
-                             'but should have num_x = %d x values' %
-                             (arrayShape[0], num_x))
-        elif len(arrayShape) == 2 and arrayShape[1] != num_x:
-            raise ValueError('thirdXAxisData has %d x values, '
-                             'but should have num_x = %d x values' %
-                             (arrayShape[1], num_x))
-        elif len(arrayShape) > 2:
-            raise ValueError('thirdXAxisData must be a 1D or 2D array, '
-                             'but is of dimension %d' %
-                             (len(arrayShape)))
-
-    # define x and y as the appropriate 2D arrays for plotting
-    if len(dimX) == 1 and len(dimZ) == 1:
-        x, y = np.meshgrid(xArray, depthArray)
-    elif len(dimX) == 1:
-        x, y = np.meshgrid(xArray, np.zeros(num_z))
-        y = depthArray
-    elif len(dimZ) == 1:
-        x, y = np.meshgrid(np.zeros(num_x), depthArray)
-        x = xArray
-    else:
-        x = xArray
-        y = depthArray
+        dim = field.dims[0]
+        field = field.rolling(dim={dim: movingAveragePoints},
+                              center=True).mean().dropna(dim)
+        x = x.rolling(dim={dim: movingAveragePoints},
+                      center=True).mean().dropna(dim)
+        y = y.rolling(dim={dim: movingAveragePoints},
+                      center=True).mean().dropna(dim)
 
     # set up figure
     if dpi is None:
@@ -919,21 +780,28 @@ def plot_vertical_section(
 
     colormapDict = setup_colormap(config, colorMapSectionName, suffix=suffix)
 
-    if not plotAsContours:    # display a heatmap of fieldArray
+    if not plotAsContours:
+        # display a heatmap of fieldArray
 
         if colormapDict['levels'] is None:
             # interpFieldArray contains the values at centers of grid cells,
             # for pcolormesh plots (using bilinear interpolation)
-            interpFieldArray = \
-                0.5 * (0.5 * (fieldArray[1:, 1:] + fieldArray[0:-1, 1:]) +
-                       0.5 * (fieldArray[1:, 0:-1] + fieldArray[0:-1, 0:-1]))
 
-            plotHandle = plt.pcolormesh(x, y, interpFieldArray,
+            interpField = field.values
+            if field.sizes == x.sizes:
+                # interpFieldArray contains the values at centers of grid cells,
+                # for pcolormesh plots (using bilinear interpolation)
+                interpField = 0.25 * (interpField[1:, 1:] +
+                                      interpField[0:-1, 1:] +
+                                      interpField[1:, 0:-1] +
+                                      interpField[0:-1, 0:-1])
+
+            plotHandle = plt.pcolormesh(x.values, y.values, interpField,
                                         cmap=colormapDict['colormap'],
                                         norm=colormapDict['norm'],
                                         rasterized=True)
         else:
-            plotHandle = plt.contourf(x, y, fieldArray,
+            plotHandle = plt.contourf(x.values, y.values, field.values,
                                       cmap=colormapDict['colormap'],
                                       norm=colormapDict['norm'],
                                       levels=colormapDict['levels'],
@@ -949,9 +817,10 @@ def plot_vertical_section(
         if colorbarLabel is not None:
             cbar.set_label(colorbarLabel)
 
-    else:     # display a white heatmap to get a white background for non-land
-        zeroArray = np.ma.where(fieldArray != np.nan, 0.0, fieldArray)
-        plt.contourf(x, y, zeroArray, colors='white')
+    else:
+        # display a white heatmap to get a white background for non-land
+        zeroArray = xr.zeros_like(field).where(field.nonnull())
+        plt.contourf(x.values, y.values, zeroArray.values, colors='white')
 
     # set the color for NaN or masked regions, and draw a black
     # outline around them; technically, the contour level used should
@@ -959,18 +828,20 @@ def plot_vertical_section(
     # is used instead
     ax = plt.gca()
     ax.set_facecolor(backgroundColor)
-    landArray = np.ma.where(fieldArray != np.nan, 1.0, fieldArray)
-    landArray = np.ma.masked_where(landArray == np.nan, landArray, copy=True)
-    landArray = landArray.filled(0.0)
-    plt.contour(x, y, landArray, levels=[0.999], colors='black', linewidths=1)
+    landMask = np.isnan(field.values)
+    plt.contour(x, y, landMask, levels=[0.0001], colors='black', linewidths=1)
 
     # plot contours, if they were requested
     contourLevels = colormapDict['contours']
+    fmt_string = None
+    cs1 = None
+    cs2 = None
+
     if contourLevels is not None:
         if len(contourLevels) == 0:
             # automatic calculation of contour levels
             contourLevels = None
-        cs1 = plt.contour(x, y, fieldArray,
+        cs1 = plt.contour(x, y, field,
                           levels=contourLevels,
                           colors=lineColor,
                           linestyles=lineStyle,
@@ -978,8 +849,8 @@ def plot_vertical_section(
         if labelContours:
             fmt_string = "%%1.%df" % int(contourLabelPrecision)
             plt.clabel(cs1, fmt=fmt_string)
-        if plotAsContours and contourComparisonFieldArray is not None:
-            cs2 = plt.contour(x, y, contourComparisonFieldArray,
+        if plotAsContours and contourComparisonField is not None:
+            cs2 = plt.contour(x, y, contourComparisonField,
                               levels=contourLevels,
                               colors=comparisonContourLineColor,
                               linestyles=comparisonContourLineStyle,
@@ -987,7 +858,7 @@ def plot_vertical_section(
             if labelContours:
                 plt.clabel(cs2, fmt=fmt_string)
 
-    if plotAsContours and contourComparisonFieldArray is not None:
+    if plotAsContours and contourComparisonField is not None:
         h1, _ = cs1.legend_elements()
         h2, _ = cs2.legend_elements()
         if labelContours:
@@ -999,7 +870,7 @@ def plot_vertical_section(
 
     if title is not None:
         if plotAsContours and labelContours \
-           and contourComparisonFieldArray is None:
+                and contourComparisonField is None:
             title = limit_title(title, maxTitleLength-(3+len(colorbarLabel)))
             title = title + " (" + colorbarLabel + ")"
         else:
@@ -1014,13 +885,12 @@ def plot_vertical_section(
         else:
             plt.title(title, **title_font)
 
-    if (xlabel is not None) or (ylabel is not None):
-        if axisFontSize is None:
-            axisFontSize = config.get('plot', 'axisFontSize')
-        axis_font = {'size': axisFontSize}
+    if axisFontSize is None:
+        axisFontSize = config.get('plot', 'axisFontSize')
+    axis_font = {'size': axisFontSize}
 
-    if xlabel is not None:
-        plt.xlabel(xlabel, **axis_font)
+    if xlabels is not None:
+        plt.xlabel(xlabels[0], **axis_font)
     if ylabel is not None:
         plt.ylabel(ylabel, **axis_font)
 
@@ -1032,42 +902,48 @@ def plot_vertical_section(
     if yLim:
         ax.set_ylim(yLim)
 
-    if xArrayIsTime:
+    if xCoordIsTime:
         if firstYearXTicks is None:
-            minDays = [xArray[0]]
+            minDays = xCoords[0][0].values
         else:
             minDays = date_to_days(year=firstYearXTicks, calendar=calendar)
-        maxDays = [xArray[-1]]
+        maxDays = xCoords[0][-1].values
 
         plot_xtick_format(calendar, minDays, maxDays, maxXTicks,
                           yearStride=yearStrideXTicks)
 
     # add a second x-axis scale, if it was requested
-    if secondXAxisData is not None:
+    if len(xCoords) >= 2:
         ax2 = ax.twiny()
         ax2.set_facecolor(backgroundColor)
-        ax2.set_xlabel(secondXAxisLabel, **axis_font)
+        if xlabels[1] is not None:
+            ax2.set_xlabel(xlabels[1], **axis_font)
         xlimits = ax.get_xlim()
         ax2.set_xlim(xlimits)
-        xticks = np.linspace(xlimits[0], xlimits[1], numUpperTicks)
-        tickValues = np.interp(xticks, x.flatten()[:num_x], secondXAxisData)
-        ax2.set_xticks(xticks)
-        formatString = "{{0:.{:d}f}}{}".format(
-            upperXAxisTickLabelPrecision, r'$\degree$')
-        ax2.set_xticklabels([formatString.format(member)
-                             for member in tickValues])
+        formatString = None
+        xticks = None
+        if numUpperTicks is not None:
+            xticks = np.linspace(xlimits[0], xlimits[1], numUpperTicks)
+            tickValues = np.interp(xticks, xCoords[0].values, xCoords[1].values)
+            ax2.set_xticks(xticks)
+            formatString = "{{0:.{:d}f}}{}".format(
+                upperXAxisTickLabelPrecision, r'$\degree$')
+            ax2.set_xticklabels([formatString.format(member)
+                                 for member in tickValues])
 
         # add a third x-axis scale, if it was requested
-        if thirdXAxisData is not None:
+        if len(xCoords) == 3:
             ax3 = ax.twiny()
             ax3.set_facecolor(backgroundColor)
-            ax3.set_xlabel(thirdXAxisLabel, **axis_font)
+            ax3.set_xlabel(xlabels[2], **axis_font)
             ax3.set_xlim(xlimits)
             ax3.set_xticks(xticks)
-            tickValues = np.interp(xticks, x.flatten()[:num_x], thirdXAxisData)
-            ax3.set_xticklabels([formatString.format(member)
-                                 for member in tickValues])
-            ax3.spines['top'].set_position(('outward', 36))
+            if numUpperTicks is not None:
+                tickValues = np.interp(xticks, xCoords[0].values,
+                                       xCoords[2].values)
+                ax3.set_xticklabels([formatString.format(member)
+                                     for member in tickValues])
+                ax3.spines['top'].set_position(('outward', 36))
 
     return fig, ax  # }}}
 

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -34,12 +34,13 @@ from mpas_analysis.shared.plot.title import limit_title
 
 def plot_vertical_section_comparison(
         config,
-        xCoords,
-        zCoord,
         modelArray,
         refArray,
         diffArray,
         colorMapSectionName,
+        xCoords=None,
+        zCoord=None,
+        dsTransectTriangles=None,
         colorbarLabel=None,
         xlabels=None,
         ylabel=None,
@@ -93,22 +94,28 @@ def plot_vertical_section_comparison(
         the configuration, containing a [plot] section with options that
         control plotting
 
-    xCoords : xarray.DataArray or list of xarray.DataArray
-       The x coordinate(s) in ``field``.  Optional second
+    modelArray, refArray : xarray.DataArray
+        model and observational or control run data sets
+
+    diffArray : float array
+        difference between modelArray and refArray
+
+    xCoords : xarray.DataArray or list of xarray.DataArray, optional
+       The x coordinate(s) for the model, ref and diff arrays.  Optional second
        and third entries will be used for a second and third x axis above the
        plot.  The typical use for the second and third axis is for transects,
        for which the primary x axis represents distance along a transect, and
        the second and third x axes are used to display the corresponding
        latitudes and longitudes.
 
-    zCoord : xarray.DataArray
-        The z coordinates in ``field``
+    zCoord : xarray.DataArray, optional
+        The z coordinates for the model, ref and diff arrays
 
-    modelArray, refArray : xarray.DataArray
-        model and observational or control run data sets
-
-    diffArray : float array
-        difference between modelArray and refArray
+    dsTransectTriangles : xarray.Dataset, optional
+        A dataset defining the transect on triangles rather than as a logically
+        rectangular grid.  If this option is provided, ``xCoords`` is only
+        used for tick marks if more than one x axis is requested, and
+        ``zCoord`` will be ignored.
 
     colorMapSectionName : str
         section name in ``config`` where color map info can be found.
@@ -361,10 +368,11 @@ def plot_vertical_section_comparison(
 
     _, ax = plot_vertical_section(
         config,
-        xCoords,
-        zCoord,
         modelArray,
         colorMapSectionName,
+        xCoords=xCoords,
+        zCoord=zCoord,
+        dsTransectTriangles=dsTransectTriangles,
         suffix=resultSuffix,
         colorbarLabel=colorbarLabel,
         title=title,
@@ -406,10 +414,11 @@ def plot_vertical_section_comparison(
         plt.subplot(3, 1, 2)
         _, ax = plot_vertical_section(
             config,
-            xCoords,
-            zCoord,
             refArray,
             colorMapSectionName,
+            xCoords=xCoords,
+            zCoord=zCoord,
+            dsTransectTriangles=dsTransectTriangles,
             suffix=resultSuffix,
             colorbarLabel=colorbarLabel,
             title=refTitle,
@@ -445,10 +454,11 @@ def plot_vertical_section_comparison(
         plt.subplot(3, 1, 3)
         _, ax = plot_vertical_section(
             config,
-            xCoords,
-            zCoord,
             diffArray,
             colorMapSectionName,
+            xCoords=xCoords,
+            zCoord=zCoord,
+            dsTransectTriangles=dsTransectTriangles,
             suffix=diffSuffix,
             colorbarLabel=colorbarLabel,
             title=diffTitle,
@@ -494,10 +504,11 @@ def plot_vertical_section_comparison(
 
 def plot_vertical_section(
         config,
-        xCoords,
-        zCoord,
         field,
         colorMapSectionName,
+        xCoords=None,
+        zCoord=None,
+        dsTransectTriangles=None,
         suffix='',
         colorbarLabel=None,
         title=None,
@@ -551,17 +562,6 @@ def plot_vertical_section(
         the configuration, containing a [plot] section with options that
         control plotting
 
-    xCoords : xarray.DataArray or list of xarray.DataArray
-        The x coordinate(s) in ``field``.  Optional second
-        and third entries will be used for a second and third x axis above the
-        plot.  The typical use for the second and third axis is for transects,
-        for which the primary x axis represents distance along a transect, and
-        the second and third x axes are used to display the corresponding
-        latitudes and longitudes.
-
-    zCoord : xarray.DataArray
-        The z coordinates in ``field``
-
     field : xarray.DataArray
         field array to plot.  For contour plots, ``xCoords`` and ``zCoords``
         should broadcast to the same shape as ``field``.  For heatmap plots,
@@ -573,6 +573,23 @@ def plot_vertical_section(
 
     colorMapSectionName : str
         section name in ``config`` where color map info can be found.
+
+    xCoords : xarray.DataArray or list of xarray.DataArray, optional
+       The x coordinate(s) for the ``field``.  Optional second
+       and third entries will be used for a second and third x axis above the
+       plot.  The typical use for the second and third axis is for transects,
+       for which the primary x axis represents distance along a transect, and
+       the second and third x axes are used to display the corresponding
+       latitudes and longitudes.
+
+    zCoord : xarray.DataArray, optional
+        The z coordinates for the ``field``
+
+    dsTransectTriangles : xarray.Dataset, optional
+        A dataset defining the transect on triangles rather than as a logically
+        rectangular grid.  If this option is provided, ``xCoords`` is only
+        used for tick marks if more than one x axis is requested, and
+        ``zCoord`` will be ignored.
 
     suffix : str, optional
         the suffix used for colorbar config options
@@ -745,44 +762,55 @@ def plot_vertical_section(
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')
     matplotlib.rc('font', size=defaultFontSize)
-    if not isinstance(xCoords, list):
-        xCoords = [xCoords]
+    mask = field.notnull()
+    if xCoords is not None:
+        if not isinstance(xCoords, list):
+            xCoords = [xCoords]
 
-    if not isinstance(xlabels, list):
-        xlabels = [xlabels]
+        if not isinstance(xlabels, list):
+            xlabels = [xlabels]
 
-    if len(xCoords) != len(xlabels):
-        raise ValueError('Expected the same number of xCoords and xlabels')
+        if len(xCoords) != len(xlabels):
+            raise ValueError('Expected the same number of xCoords and xlabels')
 
-    x, y = xr.broadcast(xCoords[0], zCoord)
-    dims_in_field = all([dim in field.dims for dim in x.dims])
+    if dsTransectTriangles is None:
 
-    if dims_in_field:
-        x = x.transpose(*field.dims)
-        y = y.transpose(*field.dims)
-    else:
-        xsize = list(x.sizes.values())
-        fieldsize = list(field.sizes.values())
-        if xsize[0] == fieldsize[0] + 1 and xsize[1] == fieldsize[1] + 1:
-            pass
-        elif xsize[0] == fieldsize[1] + 1 and xsize[1] == fieldsize[0] + 1:
-            x = x.transpose(x.dims[1], x.dims[0])
-            y = y.transpose(y.dims[1], y.dims[0])
+        x, y = xr.broadcast(xCoords[0], zCoord)
+        dims_in_field = all([dim in field.dims for dim in x.dims])
+
+        if dims_in_field:
+            x = x.transpose(*field.dims)
+            y = y.transpose(*field.dims)
         else:
-            raise ValueError('Sizes of coords {}x{} and field {}x{} not '
-                             'compatible.'.format(xsize[0], xsize[1],
-                                                  fieldsize[0], fieldsize[1]))
+            xsize = list(x.sizes.values())
+            fieldsize = list(field.sizes.values())
+            if xsize[0] == fieldsize[0] + 1 and xsize[1] == fieldsize[1] + 1:
+                pass
+            elif xsize[0] == fieldsize[1] + 1 and xsize[1] == fieldsize[0] + 1:
+                x = x.transpose(x.dims[1], x.dims[0])
+                y = y.transpose(y.dims[1], y.dims[0])
+            else:
+                raise ValueError('Sizes of coords {}x{} and field {}x{} not '
+                                 'compatible.'.format(xsize[0], xsize[1],
+                                                      fieldsize[0],
+                                                      fieldsize[1]))
 
-    # compute moving averages with respect to the x dimension
-    if movingAveragePoints is not None and movingAveragePoints != 1:
+        # compute moving averages with respect to the x dimension
+        if movingAveragePoints is not None and movingAveragePoints != 1:
 
-        dim = field.dims[0]
-        field = field.rolling(dim={dim: movingAveragePoints},
-                              center=True).mean().dropna(dim)
-        x = x.rolling(dim={dim: movingAveragePoints},
-                      center=True).mean().dropna(dim)
-        y = y.rolling(dim={dim: movingAveragePoints},
-                      center=True).mean().dropna(dim)
+            dim = field.dims[0]
+            field = field.rolling(dim={dim: movingAveragePoints},
+                                  center=True).mean().dropna(dim)
+            x = x.rolling(dim={dim: movingAveragePoints},
+                          center=True).mean().dropna(dim)
+            y = y.rolling(dim={dim: movingAveragePoints},
+                          center=True).mean().dropna(dim)
+
+        maskedTriangulation, unmaskedTriangulation = _get_triangulation(
+            x, y, mask)
+    else:
+        maskedTriangulation, unmaskedTriangulation = _get_ds_triangulation(
+            dsTransectTriangles, mask)
 
     # set up figure
     if dpi is None:
@@ -792,10 +820,9 @@ def plot_vertical_section(
     else:
         fig = plt.gcf()
 
-    colormapDict = setup_colormap(config, colorMapSectionName, suffix=suffix)
+    colormapDict = setup_colormap(config, colorMapSectionName,
+                                  suffix=suffix)
 
-    mask = field.notnull()
-    maskedTriangulation, unmaskedTriangulation = _get_triangulation(x, y, mask)
     if not plotAsContours:
         # display a heatmap of fieldArray
         fieldMasked = field.where(mask, 0.0).values.ravel()
@@ -827,12 +854,12 @@ def plot_vertical_section(
         zeroArray = xr.zeros_like(field)
         plt.tricontourf(maskedTriangulation, zeroArray.values, colors='white')
 
+    ax = plt.gca()
     if outlineValid:
         # set the color for NaN or masked regions, and draw a black
         # outline around them; technically, the contour level used should
         # be 1.0, but the contours don't show up when using 1.0, so 0.999
         # is used instead
-        ax = plt.gca()
         ax.set_facecolor(backgroundColor)
         landMask = np.isnan(field.values).ravel()
         plt.tricontour(unmaskedTriangulation, landMask, levels=[0.0001],
@@ -910,7 +937,7 @@ def plot_vertical_section(
     if yLim:
         ax.set_ylim(yLim)
 
-    if xCoordIsTime:
+    if xCoords is not None and xCoordIsTime:
         if firstYearXTicks is None:
             minDays = xCoords[0][0].values
         else:
@@ -921,7 +948,7 @@ def plot_vertical_section(
                           yearStride=yearStrideXTicks)
 
     # add a second x-axis scale, if it was requested
-    if len(xCoords) >= 2:
+    if xCoords is not None and len(xCoords) >= 2:
         ax2 = ax.twiny()
         ax2.set_facecolor(backgroundColor)
         if xlabels[1] is not None:
@@ -954,6 +981,29 @@ def plot_vertical_section(
                 ax3.spines['top'].set_position(('outward', 36))
 
     return fig, ax  # }}}
+
+
+def _get_ds_triangulation(dsTransectTriangles, mask):
+    """get matplotlib Triangulation from triangulation dataset"""
+
+    triMask = np.logical_not(mask)
+    # if any node of a triangle is masked, the triangle is masked
+    triMask = triMask.max(dim='nTriangleNodes')
+
+    nTransectTriangles = dsTransectTriangles.sizes['nTransectTriangles']
+    dNode = dsTransectTriangles.dNode.isel(
+        nSegments=dsTransectTriangles.segmentIndices,
+        nHorizBounds=dsTransectTriangles.nodeHorizBoundsIndices)
+    x = dNode.values.ravel()
+
+    zTransectNode = dsTransectTriangles.zTransectNode
+    y = zTransectNode.values.ravel()
+
+    tris = np.arange(3 * nTransectTriangles).reshape((nTransectTriangles, 3))
+    maskedTriangulation = Triangulation(x=x, y=y, triangles=tris, mask=triMask)
+    unmaskedTriangulation = Triangulation(x=x, y=y, triangles=tris)
+
+    return maskedTriangulation, unmaskedTriangulation
 
 
 def _get_triangulation(x, y, mask):


### PR DESCRIPTION
This merge adds support for using MPAS-Tools to compute transects on the native MPAS-Ocean mesh.  Observations are interpolated to the MPAS transect so comparison can also take place on this mesh.

Major changes are made to how vertical sections are plotted, making a `matplotlib.tri.Triangulation` from the logically rectangular grids we have used so far so that we can optionally pass the arguments needed to create a triangulation on the native MPAS mesh.  The approach of outlining the valid region of the transect using a contour also no longer works with the native triangulation, so coordinates for producing an outline can optionally be passed in instead.

The `mpas` native grid has been made the default in `configs/polarRegions.conf`.

closes #586 