### PR TITLE
Update docstrings to get rid of recent warnings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -142,7 +142,6 @@ Configuration
 .. autosummary::
    :toctree: generated/
 
-   MpasAnalysisConfigParser
    MpasAnalysisConfigParser.getWithDefault
    MpasAnalysisConfigParser.getExpression
 

--- a/mpas_analysis/configuration/mpas_analysis_config_parser.py
+++ b/mpas_analysis/configuration/mpas_analysis_config_parser.py
@@ -50,7 +50,7 @@ class MpasAnalysisConfigParser(ConfigParser):
         option : str
             The option in the config file
 
-        default : one of bool, int, float, list, tuple, dict, str
+        default : {bool, int, float, list, tuple, dict, str}
             The default value if the option and/or section is not found, used
             to determine the type of the option if it *is* found. If
             ``default`` is a list, tuple, or dict, ``getExpression(...)`` is
@@ -83,7 +83,7 @@ class MpasAnalysisConfigParser(ConfigParser):
                       usenumpyfunc=False):
         """
         Get an option as an expression (typically a list, though tuples and
-        dicts are also availabe).  The expression is required to have valid
+        dicts are also available).  The expression is required to have valid
         python syntax, so that string entries are required to be in single or
         double quotes.
 
@@ -95,7 +95,7 @@ class MpasAnalysisConfigParser(ConfigParser):
         option : str
             The option in the config file
 
-        elementType : (bool, int, float, etc.), optional
+        elementType : {bool, int, float, list, tuple, str}, optional
             If supplied, each element in a list or tuple, or
             each value in a dictionary are cast to this type.  This is likely
             most useful for ensuring that all elements in a list of numbers are

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -134,11 +134,11 @@ def compute_monthly_climatology(ds, calendar=None, maskVaries=True):  # {{{
 
     Parameters
     ----------
-    ds : ``xarray.Dataset`` or ``xarray.DataArray`` object
+    ds : xarray.Dataset or xarray.DataArray
         A data set with a ``Time`` coordinate expressed as days since
         0001-01-01 or ``month`` coordinate
 
-    calendar : ``{'gregorian', 'gregorian_noleap'}``, optional
+    calendar : {'gregorian', 'gregorian_noleap'}, optional
         The name of one of the calendars supported by MPAS cores, used to
         determine ``month`` from ``Time`` coordinate, so must be supplied if
         ``ds`` does not already have a ``month`` coordinate or data array
@@ -184,14 +184,14 @@ def compute_climatology(ds, monthValues, calendar=None,
 
     Parameters
     ----------
-    ds : ``xarray.Dataset`` or ``xarray.DataArray`` object
+    ds : xarray.Dataset or xarray.DataArray
         A data set with a ``Time`` coordinate expressed as days since
         0001-01-01 or ``month`` coordinate
 
     monthValues : int or array-like of ints
         A single month or an array of months to be averaged together
 
-    calendar : ``{'gregorian', 'gregorian_noleap'}``, optional
+    calendar : {'gregorian', 'gregorian_noleap'}, optional
         The name of one of the calendars supported by MPAS cores, used to
         determine ``month`` from ``Time`` coordinate, so must be supplied if
         ``ds`` does not already have a ``month`` coordinate or data array

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -142,7 +142,7 @@ def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
         The absolute path to the cache file where the times series will be
         stored
 
-    calendar : ``{'gregorian', 'gregorian_noleap'}``
+    calendar : {'gregorian', 'gregorian_noleap'}
         The name of one of the calendars supported by MPAS cores, used to
         determine ``year`` and ``month`` from ``Time`` coordinate
 


### PR DESCRIPTION
In a few cases, lists of items were being referenced inside of a string literal, which seems to cause trouble since sphinx/napoleon are also trying to turn them into a string literal.

There is no reason to generate documentation for the `MpasAnalysisConfigParser` class, since the constructor and most methods are inherited from `ConfigParser`.