### PR TITLE
Use output directories for temp files/dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ environment with the following packages:
  * geometric\_features >= 0.1.9
  * gsw
  * pyremap < 0.1.0
- * mpas\_tools >= 0.0.8
+ * mpas\_tools >= 0.0.13
 
 These can be installed via the conda command:
 ```
@@ -75,7 +75,7 @@ conda create -n mpas-analysis python=3.8 numpy scipy "matplotlib-base>=3.0.2" \
     netCDF4 "xarray>=0.14.1" dask bottleneck lxml "nco>=4.8.1" pyproj \
     pillow cmocean progressbar2 requests setuptools shapely "cartopy>=0.18.0" \
     cartopy_offlinedata "geometric_features>=0.1.9" gsw "pyremap<0.1.0" \
-    "mpas_tools>=0.0.8"
+    "mpas_tools>=0.0.13"
 conda activate mpas-analysis
 ```
 

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - geometric_features >=0.1.9
     - gsw
     - pyremap <0.1.0
-    - mpas_tools >=0.0.8
+    - mpas_tools >=0.0.13
 
 test:
   requires:

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -95,11 +95,6 @@ mappingSubdirectory = mpas_analysis/maps
 # point to a path that is not within the baseDirectory above.
 regionMaskSubdirectory = mpas_analysis/region_masks
 
-# A path to a directory for geometric data cached from the geometric_features
-# package.  If none is supplied, a geometric_data subdirectory of the analysis
-# output baseDirectory is used.
-geometricDataDirectory = none
-
 
 [input]
 ## options related to reading in the results to be analyzed

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -182,11 +182,16 @@ class ComputeMOCMasksSubtask(AnalysisTask):  # {{{
 
         mesh_filename = self.runStreams.readpath('restart')[0]
 
+        maskSubdirectory = build_config_full_path(config, 'output',
+                                                  'maskSubdirectory')
+        make_directories(maskSubdirectory)
+
         make_moc_basins_and_transects(gf, mesh_filename,
                                       self.maskAndTransectFileName,
                                       geojson_filename=self.geojsonFileName,
                                       mask_filename=self.maskFileName,
-                                      logger=self.logger)
+                                      logger=self.logger,
+                                      dir=maskSubdirectory)
         # }}}
 # }}}
 

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -26,7 +26,7 @@ from mpas_analysis.shared.plot import plot_vertical_section_comparison, \
     timeseries_analysis_plot, savefig
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    make_directories, get_files_year_month, get_region_mask, get_geometric_data
+    make_directories, get_files_year_month, get_region_mask
 
 from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
 
@@ -177,8 +177,7 @@ class ComputeMOCMasksSubtask(AnalysisTask):  # {{{
         config = self.config
 
         # make the geojson file
-        geometricDataDirectory = get_geometric_data(config)
-        gf = GeometricFeatures(cacheLocation=geometricDataDirectory)
+        gf = GeometricFeatures()
 
         mesh_filename = self.runStreams.readpath('restart')[0]
 

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -21,6 +21,8 @@ from __future__ import absolute_import, division, print_function, \
 import xarray as xr
 import os
 import numpy
+from tempfile import TemporaryDirectory
+
 from pyremap import Remapper, LatLonGridDescriptor, ProjectionGridDescriptor
 
 from mpas_analysis.shared.constants import constants
@@ -120,7 +122,13 @@ def get_remapper(config, sourceDescriptor, comparisonDescriptor,
 
     mpiTasks = config.getWithDefault('execute', 'mapMpiTasks', 1)
 
-    remapper.build_mapping_file(method=method, logger=logger, mpiTasks=mpiTasks)
+    mappingSubdirectory = \
+        build_config_full_path(config, 'output',
+                               'mappingSubdirectory')
+    make_directories(mappingSubdirectory)
+    with TemporaryDirectory(dir=mappingSubdirectory) as tempdir:
+        remapper.build_mapping_file(method=method, logger=logger,
+                                    mpiTasks=mpiTasks, tempdir=tempdir)
 
     return remapper  # }}}
 

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -218,36 +218,6 @@ def get_region_mask(config, regionMaskFile):  # {{{
     return fullFileName  # }}}
 
 
-def get_geometric_data(config):  # {{{
-    """
-    Get the full path for a region mask with a given file name
-
-    Parameters
-    ----------
-    config : MpasAnalysisConfigParser object
-        configuration from which to read the path
-
-    Returns
-    -------
-    geometricDataDirectory : str
-        A directory where geometric data cached from ``geometric_features`` can
-        be stored
-    """
-    # Authors
-    # -------
-    # Xylar Asay-Davis
-
-    geometricDataDirectory = config.get('diagnostics',
-                                        'geometricDataDirectory')
-
-    if geometricDataDirectory == 'none':
-        geometricDataDirectory = '{}/geometric_data'.format(
-            config.get('output', 'baseDirectory'))
-
-    make_directories(geometricDataDirectory)
-
-    return geometricDataDirectory  # }}}
-
 def build_obs_path(config, component, relativePathOption=None,
                    relativePathSection=None, relativePath=None):  # {{{
     """

--- a/mpas_analysis/shared/transects/compute_transect_masks_subtask.py
+++ b/mpas_analysis/shared/transects/compute_transect_masks_subtask.py
@@ -25,7 +25,7 @@ from mpas_analysis.shared.io import write_netcdf
 
 
 def compute_mpas_transect_masks(geojsonFileName, meshFileName, maskFileName,
-                                logger=None):
+                                logger=None, dir=None):
     """
     Build a transect mask file from the given MPAS mesh and geojson file \
     defining a set of transects.
@@ -36,7 +36,7 @@ def compute_mpas_transect_masks(geojsonFileName, meshFileName, maskFileName,
     dsMesh = xr.open_dataset(meshFileName)
     fcMask = read_feature_collection(geojsonFileName)
     dsMask = mpas_tools.conversion.mask(dsMesh=dsMesh, fcMask=fcMask,
-                                        logger=logger)
+                                        logger=logger, dir=dir)
 
     write_netcdf(dsMask, maskFileName)
 
@@ -137,9 +137,9 @@ class ComputeTransectMasksSubtask(AnalysisTask):  # {{{
             raise IOError('No MPAS restart file found: need at least one '
                           'restart file to perform region masking.')
 
-        maskSubdirectory = build_config_full_path(self.config, 'output',
-                                                  'maskSubdirectory')
-        make_directories(maskSubdirectory)
+        self.maskSubdirectory = build_config_full_path(self.config, 'output',
+                                                       'maskSubdirectory')
+        make_directories(self.maskSubdirectory)
 
         # first, see if we have cached a mask file name in the region masks
         # directory
@@ -153,9 +153,7 @@ class ComputeTransectMasksSubtask(AnalysisTask):  # {{{
             # no cached mask file, so let's see if there's already one in the
             # masks subfolder of the output directory
 
-            maskSubdirectory = build_config_full_path(self.config, 'output',
-                                                      'maskSubdirectory')
-            self.maskFileName = '{}/{}_{}.nc'.format(maskSubdirectory,
+            self.maskFileName = '{}/{}_{}.nc'.format(self.maskSubdirectory,
                                                      meshName,
                                                      self.outFileSuffix)
 
@@ -177,7 +175,7 @@ class ComputeTransectMasksSubtask(AnalysisTask):  # {{{
 
         compute_mpas_transect_masks(
             self.geojsonFileName, self.obsFileName, self.maskFileName,
-            logger=self.logger)
+            logger=self.logger, dir=self.maskSubdirectory)
 
     # }}}
 


### PR DESCRIPTION
This was causing problems for systems where /tmp fills up.

This requires changes in `mpas_tools>=0.0.13`.

closes #729 