### PR TITLE
A large number fixes revealed by new deprecation warnings

### DIFF
--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -486,6 +486,7 @@ or under csh:
 Then, running MPAS-Analysis is as simple as:
 
 .. code-block:: bash
+
     $ mpas_analysis myrun.cfg
 
 Typical output is the analysis is running correctly looks something like:

--- a/mpas_analysis/__init__.py
+++ b/mpas_analysis/__init__.py
@@ -1,7 +1,5 @@
 # make sure to set the Agg backend that works even without x-forwarding
 # before any other matplotlib imports
-import sys
-import warnings
 import matplotlib as mpl
 mpl.use('Agg')
 

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -592,6 +592,7 @@ def run_analysis(config, analyses):  # {{{
     # blank line to make sure remaining output is on a new line
     print('')
 
+    handler.close()
     logger.handlers = []
 
     # raise the last exception so the process exits with an error

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -493,7 +493,7 @@ def run_analysis(config, analyses):  # {{{
     widgets = ['Running tasks: ', progressbar.Percentage(), ' ',
                progressbar.Bar(), ' ', progressbar.ETA()]
     progress = progressbar.ProgressBar(widgets=widgets,
-                                       maxval=totalTaskCount).start()
+                                       max_value=totalTaskCount).start()
 
     runningProcessCount = 0
 

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1266,7 +1266,7 @@ regionNames = ['all']
 # a list of variables to plot
 variables = [{'name': 'temperature',
               'title': 'Temperature',
-              'units': '$^\circ$C',
+              'units': r'$^\circ$C',
               'mpas': 'timeMonthly_avg_activeTracers_temperature'},
              {'name': 'salinity',
               'title': 'Salinity',

--- a/mpas_analysis/ocean/climatology_map_argo.py
+++ b/mpas_analysis/ocean/climatology_map_argo.py
@@ -443,11 +443,11 @@ class RemapArgoClimatology(RemapObservedClimatologySubtask):
         field = dsObs[self.fieldName]
         for depth in self.depths:
             if depth == 'top':
-                slices.append(field.sel(method='nearest', depth=0.).drop(
+                slices.append(field.sel(method='nearest', depth=0.).drop_vars(
                     'depth'))
             else:
-                slices.append(field.sel(method='nearest', depth=depth).drop(
-                    'depth'))
+                slices.append(
+                    field.sel(method='nearest', depth=depth).drop_vars('depth'))
 
         depthNames = [str(depth) for depth in self.depths]
         field = xr.concat(slices, dim='depthSlice')

--- a/mpas_analysis/ocean/climatology_map_bgc.py
+++ b/mpas_analysis/ocean/climatology_map_bgc.py
@@ -276,10 +276,10 @@ class RemapBGCClimatology(RemapMpasClimatologySubtask):  # {{{
             climatology['Chl'] = spChl + diatChl + diazChl + phaeoChl
             climatology.Chl.attrs['units'] = 'mg m$^{-3}$'
             climatology.Chl.attrs['description'] = 'Sum of all PFT chlorophyll'
-            climatology.drop(['timeMonthly_avg_ecosysTracers_spChl',
-                              'timeMonthly_avg_ecosysTracers_diatChl',
-                              'timeMonthly_avg_ecosysTracers_diazChl',
-                              'timeMonthly_avg_ecosysTracers_phaeoChl'])
+            climatology.drop_vars(['timeMonthly_avg_ecosysTracers_spChl',
+                                   'timeMonthly_avg_ecosysTracers_diatChl',
+                                   'timeMonthly_avg_ecosysTracers_diazChl',
+                                   'timeMonthly_avg_ecosysTracers_phaeoChl'])
 
         return climatology  # }}}
 

--- a/mpas_analysis/ocean/climatology_map_eke.py
+++ b/mpas_analysis/ocean/climatology_map_eke.py
@@ -204,10 +204,10 @@ class RemapMpasEKEClimatology(RemapMpasClimatologySubtask):  # {{{
              climatology.timeMonthly_avg_velocityMeridional ** 2)
 
         # drop unnecessary fields before re-mapping
-        climatology.drop(['timeMonthly_avg_velocityZonal',
-                          'timeMonthly_avg_velocityMeridional',
-                          'timeMonthly_avg_velocityZonalSquared',
-                          'timeMonthly_avg_velocityMeridionalSquared'])
+        climatology.drop_vars(['timeMonthly_avg_velocityZonal',
+                               'timeMonthly_avg_velocityMeridional',
+                               'timeMonthly_avg_velocityZonalSquared',
+                               'timeMonthly_avg_velocityMeridionalSquared'])
 
         # this creates a new variable eke in climatology (like netcdf)
         climatology['eke'] = eke

--- a/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
+++ b/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
@@ -328,7 +328,7 @@ class RemapMpasOHCClimatology(RemapMpasClimatologySubtask):  # {{{
             'Anomaly from year {} in ocean heat content'.format(
             self.refYearClimatolgyTask.startYear)
 
-        climatology = climatology.drop(self.variableList)
+        climatology = climatology.drop_vars(self.variableList)
 
         return climatology  # }}}
 

--- a/mpas_analysis/ocean/climatology_map_ssh.py
+++ b/mpas_analysis/ocean/climatology_map_ssh.py
@@ -249,7 +249,7 @@ class RemapObservedSSHClimatology(RemapObservedClimatologySubtask):  # {{{
         dsObs = dsObs.rename({'time': 'Time'})
         dsObs.coords['month'] = dsObs['Time.month']
         dsObs.coords['year'] = dsObs['Time.year']
-        dsObs = dsObs.drop(['Time', 'time_bnds'])
+        dsObs = dsObs.drop_vars(['Time', 'time_bnds'])
 
         # scale the field to cm from m
         dsObs['zos'] = constants.cm_per_m * dsObs['zos']

--- a/mpas_analysis/ocean/climatology_map_woa.py
+++ b/mpas_analysis/ocean/climatology_map_woa.py
@@ -386,10 +386,10 @@ class RemapWoaClimatology(RemapObservedClimatologySubtask):
             for depth in self.depths:
                 if depth == 'top':
                     slices.append(field.sel(method='nearest',
-                                            depth=0.).drop('depth'))
+                                            depth=0.).drop_vars('depth'))
                 else:
                     slices.append(field.sel(method='nearest',
-                                            depth=-depth).drop('depth'))
+                                            depth=-depth).drop_vars('depth'))
 
             depthNames = [str(depth) for depth in self.depths]
             field = xr.concat(slices, dim='depthSlice')

--- a/mpas_analysis/ocean/compute_transects_subtask.py
+++ b/mpas_analysis/ocean/compute_transects_subtask.py
@@ -400,7 +400,7 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):  # {{{
             dsObs = dsObs.rename({'nzOut': 'nz'})
             write_netcdf(dsObs, outObsFileName)
 
-        ds = ds.drop(['validMask', 'transectNumber'])
+        ds = ds.drop_vars(['validMask', 'transectNumber'])
         write_netcdf(ds, outFileName)  # }}}
 
     # }}}
@@ -638,7 +638,7 @@ class TransectsObservations(object):  # {{{
         dsObs = interp_1d(dsObs, inInterpDim='nPoints',
                           inInterpCoord='xIn', outInterpDim='nPointsOut',
                           outInterpCoord='xOut')
-        dsObs = dsObs.drop(['xIn'])
+        dsObs = dsObs.drop_vars(['xIn'])
         dsObs = dsObs.rename({'nPointsOut': 'nPoints', 'xOut': 'x'})
         return dsObs  # }}}
 

--- a/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
+++ b/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
@@ -382,7 +382,7 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
             # rolling mean seems to have trouble with dask data sets so we
             # write out the data set and read it back as a single-file data set
             # (without dask)
-            dsPreprocessed = dsPreprocessed.drop('xtime')
+            dsPreprocessed = dsPreprocessed.drop_vars('xtime')
             write_netcdf(dsPreprocessed, self.preprocessedFileName)
             dsPreprocessed = xarray.open_dataset(self.preprocessedFileName)
 

--- a/mpas_analysis/ocean/remap_depth_slices_subtask.py
+++ b/mpas_analysis/ocean/remap_depth_slices_subtask.py
@@ -219,7 +219,7 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):  # {{{
             climatology[variableName] = \
                 da.sum(dim='nVertLevels').where(self.verticalIndexMask)
 
-        climatology = climatology.drop('verticalIndex')
+        climatology = climatology.drop_vars('verticalIndex')
 
         climatology = climatology.transpose('depthSlice', 'nCells')
 

--- a/mpas_analysis/ocean/remap_sose_climatology.py
+++ b/mpas_analysis/ocean/remap_sose_climatology.py
@@ -151,12 +151,12 @@ class RemapSoseClimatology(RemapObservedClimatologySubtask):
             slices = []
             for depth in self.depths:
                 if depth == 'top':
-                    slices.append(field.sel(method='nearest', z=0.).drop(
+                    slices.append(field.sel(method='nearest', z=0.).drop_vars(
                         'z'))
                 elif depth == 'bot':
                     slices.append(dsObs[self.botFieldName])
                 else:
-                    level = field.sel(method='nearest', z=depth).drop(
+                    level = field.sel(method='nearest', z=depth).drop_vars(
                         'z')
                     slices.append(level)
 

--- a/mpas_analysis/ocean/sose_transects.py
+++ b/mpas_analysis/ocean/sose_transects.py
@@ -419,7 +419,7 @@ class SoseTransectsObservations(TransectsObservations):  # {{{
         dsObs['lat'] = dsObs.nPoints
         dsObs['z'] = dsObs.nz
         dsObs['lon'] = ('nPoints', lon * numpy.ones(dsObs.sizes['nPoints']))
-        dsObs = dsObs.drop(['nPoints', 'nz'])
+        dsObs = dsObs.drop_vars(['nPoints', 'nz'])
 
         return dsObs  # }}}
 

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -342,6 +342,7 @@ class AnalysisTask(Process):  # {{{
         self.logger.info('Execution time: {}:{:02d}:{:05.2f}'.format(h, m, s))
 
         if writeLogFile:
+            handler.close()
             # restore stdout and stderr
             sys.stdout = oldStdout
             sys.stderr = oldStderr

--- a/mpas_analysis/shared/climatology/ref_year_mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/ref_year_mpas_climatology_task.py
@@ -68,7 +68,7 @@ class RefYearMpasClimatologyTask(MpasClimatologyTask):  # {{{
         # We must reset the buffer to make it ready for reading.
         config_string.seek(0)
         new_config = MpasAnalysisConfigParser()
-        new_config.readfp(config_string)
+        new_config.read_file(config_string)
 
         # call the constructor from the base class (AnalysisTask)
         super(RefYearMpasClimatologyTask, self).__init__(

--- a/mpas_analysis/shared/interpolation/interp_1d.py
+++ b/mpas_analysis/shared/interpolation/interp_1d.py
@@ -44,7 +44,7 @@ def interp_1d(ds, inInterpDim, inInterpCoord, outInterpDim,
     coords = list(ds.coords)
     ds = ds.reset_coords(coords)
 
-    ds = ds.apply(_interp_1d_array, args=(indices, weight0, inInterpDim))
+    ds = ds.map(_interp_1d_array, args=(indices, weight0, inInterpDim))
 
     # conert back to coords
     ds = ds.set_coords(coords)

--- a/mpas_analysis/shared/io/download.py
+++ b/mpas_analysis/shared/io/download.py
@@ -102,7 +102,7 @@ def download_files(fileList, urlBase, outDir, verify=True):
             widgets = [progressbar.Percentage(), ' ', progressbar.Bar(),
                        ' ', progressbar.ETA()]
             bar = progressbar.ProgressBar(widgets=widgets,
-                                          maxval=totalSize).start()
+                                          max_value=totalSize).start()
             size = 0
             with open(outFileName, 'wb') as f:
                 try:

--- a/mpas_analysis/shared/plot/climatology_map.py
+++ b/mpas_analysis/shared/plot/climatology_map.py
@@ -160,7 +160,7 @@ def plot_polar_comparison(
         divider = make_axes_locatable(ax)
         cax = divider.append_axes("right", size="5%", pad=0.1,
                                   axes_class=plt.Axes)
-        cbar = plt.colorbar(plotHandle, cax=cax, boundaries=levels)
+        cbar = plt.colorbar(plotHandle, cax=cax)
         cbar.set_label(cbarlabel)
         if ticks is not None:
             cbar.set_ticks(ticks)

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -249,7 +249,7 @@ def compute_region_masks(geojsonFileName, cellPoints, maskFileName,
                 widgets = ['  ', progressbar.Percentage(), ' ',
                            progressbar.Bar(), ' ', progressbar.ETA()]
                 bar = progressbar.ProgressBar(widgets=widgets,
-                                              maxval=nChunks).start()
+                                              max_value=nChunks).start()
 
             mask = numpy.zeros((nCells,), bool)
             for iChunk, maskChunk in \

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -63,9 +63,9 @@ def get_simulation_start_time(streams):
     ds = xarray.open_dataset(restartFile)
     da = ds.simulationStartTime
     if da.dtype.type is numpy.string_:
-        simulationStartTime = bytes.decode(da.values.tostring())
+        simulationStartTime = bytes.decode(da.values.tobytes())
     else:
-        simulationStartTime = da.values.tostring()
+        simulationStartTime = da.values.tobytes()
     # replace underscores so it works as a CF-compliant reference date
     simulationStartTime = simulationStartTime.rstrip('\x00').replace('_', ' ')
 


### PR DESCRIPTION
Python seems to have switched to a new level of deprecation and unclosed file warnings (possibly https://www.python.org/dev/peps/pep-0565/) and this revealed a number of small issues that are fixed here:
* log files were not being closed
* various deprecated methods and function arguments
* some unused imports

I also noticed an error in the formatting of the tutorial that has been fixed.