### PR TITLE
Use only one subprocess for MPAS-Tools mask creator

### DIFF
--- a/mpas_analysis/shared/regions/compute_region_masks.py
+++ b/mpas_analysis/shared/regions/compute_region_masks.py
@@ -106,6 +106,9 @@ class ComputeRegionMasks(AnalysisTask):
             if obsFileName is not None:
                 useMpasMaskCreator = False
 
+            if useMpasMaskCreator:
+                subprocessCount = 1
+
             maskSubtask = ComputeRegionMasksSubtask(
                 self, geojsonFileName, outFileSuffix,
                 featureList=None, subtaskName=subtaskName,


### PR DESCRIPTION
It does not need to block all tasks because it isn't running in parallel.