### PR TITLE
Fix masking of ocean regions

### DIFF
--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -672,6 +672,8 @@ class ComputeRegionTSSubtask(AnalysisTask):
             ds['volume'] = (dsRestart.areaCell *
                             ds['timeMonthly_avg_layerThickness'])
 
+            ds.load()
+
             ds = ds.where(cellMask, drop=True)
 
             self.logger.info("Don't worry about the following dask "

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -514,6 +514,7 @@ class ComputeRegionTimeSeriesSubtask(AnalysisTask):  # {{{
                 variableList=variableList,
                 startDate=startDate,
                 endDate=endDate).isel(Time=0)
+            dsIn.load()
 
             layerThickness = dsIn.timeMonthly_avg_layerThickness
 
@@ -522,6 +523,7 @@ class ComputeRegionTimeSeriesSubtask(AnalysisTask):  # {{{
                 self.logger.info('    region: {}'.format(
                     self.regionNames[regionIndex]))
                 dsRegion = dsRegionMask.isel(nRegions=regionIndex)
+                dsRegion.load()
                 cellMask = dsRegion.cellMask
                 totalArea = dsRegion.totalArea
                 depthMask = dsRegion.depthMask.where(cellMask, drop=True)


### PR DESCRIPTION
The mask and time series need to be loaded before masking in both ocean regional time series and T-S diagrams. Otherwise, regions with no cells cause NetCDF problems in xarray 0.16.1