### PR TITLE
Add a test suite for MPAS-Analysis on Anvil

### DIFF
--- a/configs/anvil/20201024.GMPAS-IAF.T62_oQU240wLIC.anvil.cfg
+++ b/configs/anvil/20201024.GMPAS-IAF.T62_oQU240wLIC.anvil.cfg
@@ -3,7 +3,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = SO60to10ISC.20200108
+mainRunName = GMPAS-IAF.T62_oQU240wLIC
 
 # config file for a control run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -45,17 +45,24 @@ baseDirectory = /lcrc/group/acme/diagnostics
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /lcrc/group/acme/kehoch/acme_scratch/anvil/SO60to10ISC.20200108/run
+baseDirectory = /lcrc/group/acme/ac.xylar/acme_scratch/anvil/20201024.GMPAS-IAF.T62_oQU240wLIC.anvil
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
-mpasMeshName = oSO60to10wISC
+mpasMeshName = oQU240wLI
+
+# subdirectory containing restart files
+runSubdirectory = run
+# subdirectory for ocean history files
+oceanHistorySubdirectory = archive/ocn/hist
+# subdirectory for sea ice history files
+seaIceHistorySubdirectory = archive/ice/hist
 
 # names of namelist and streams files, either a path relative to baseDirectory
 # or an absolute path.
-oceanNamelistFileName = mpaso_in
-oceanStreamsFileName = streams.ocean
-seaIceNamelistFileName = mpassi_in
-seaIceStreamsFileName = streams.seaice
+oceanNamelistFileName = run/mpaso_in
+oceanStreamsFileName = run/streams.ocean
+seaIceNamelistFileName = run/mpassi_in
+seaIceStreamsFileName = run/streams.seaice
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
@@ -101,9 +108,9 @@ generate = ['all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke', 'no_min',
 ## observations and previous runs
 
 # the first year over which to average climatalogies
-startYear = 6
+startYear = 4
 # the last year over which to average climatalogies
-endYear = 10
+endYear = 8
 
 [timeSeries]
 ## options related to producing time series plots, often to compare against

--- a/configs/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil.cfg
+++ b/configs/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil.cfg
@@ -3,7 +3,7 @@
 ## compared against
 
 # mainRunName is a name that identifies the simulation being analyzed.
-mainRunName = GMPAS-IAF.T62_oQU240wLIC
+mainRunName = GMPAS-IAF.T62_oQU240wLI
 
 # config file for a control run to which this run will be compared.  The
 # analysis should have already been run to completion once with this config
@@ -45,7 +45,7 @@ baseDirectory = /lcrc/group/acme/diagnostics
 ## options related to reading in the results to be analyzed
 
 # directory containing model results
-baseDirectory = /lcrc/group/acme/ac.xylar/acme_scratch/anvil/20201024.GMPAS-IAF.T62_oQU240wLIC.anvil
+baseDirectory = /lcrc/group/acme/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
 
 # names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
 mpasMeshName = oQU240wLI

--- a/configs/anvil/job_script.anvil.bash
+++ b/configs/anvil/job_script.anvil.bash
@@ -10,9 +10,8 @@
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 
-source /home/xylar/miniconda3/etc/profile.d/conda.sh
-conda activate mpas-analysis
+source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified.sh
 export HDF5_USE_FILE_LOCKING=FALSE
 
-srun -N 1 -n 1 python -m mpas_analysis configs/polarRegions.conf config.SO60to10ISC.20200108
+srun -N 1 -n 1 python -m mpas_analysis configs/polarRegions.conf 20201024.GMPAS-IAF.T62_oQU240wLIC.anvil.cg
 

--- a/configs/anvil/job_script.anvil.bash
+++ b/configs/anvil/job_script.anvil.bash
@@ -13,5 +13,5 @@ export OMP_NUM_THREADS=1
 source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified.sh
 export HDF5_USE_FILE_LOCKING=FALSE
 
-srun -N 1 -n 1 python -m mpas_analysis configs/polarRegions.conf 20201024.GMPAS-IAF.T62_oQU240wLIC.anvil.cg
+srun -N 1 -n 1 python -m mpas_analysis configs/polarRegions.conf 20201025.GMPAS-IAF.T62_oQU240wLI.anvil.cg
 

--- a/configs/anvil/test_suite/QU480.cfg
+++ b/configs/anvil/test_suite/QU480.cfg
@@ -1,0 +1,149 @@
+[runs]
+## options related to the run to be analyzed and control runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = QU480
+
+# config file for a control run to which this run will be compared.  The
+# analysis should have already been run to completion once with this config
+# file, so that the relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid.  Leave this option commented out if no
+# control run is desired.
+# controlRunConfigFile = /path/to/config/file
+
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 12
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lcrc/group/acme/diagnostics
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /lcrc/group/acme/ac.xylar/acme_scratch/anvil/20200305.A_WCYCL1850.ne4_oQU480.anvil
+
+# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+mpasMeshName = oQU480
+
+# subdirectory containing restart files
+runSubdirectory = run
+# subdirectory for ocean history files
+oceanHistorySubdirectory = archive/ocn/hist
+# subdirectory for sea ice history files
+seaIceHistorySubdirectory = archive/ice/hist
+
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = run/mpaso_in
+oceanStreamsFileName = run/streams.ocean
+seaIceNamelistFileName = run/mpassi_in
+seaIceStreamsFileName = run/streams.seaice
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+baseDirectory = /lcrc/group/acme/ac.xylar/analysis_testing/baseline
+
+# Anvil doesn't have direct access to a web portal, so output will need
+# to be copied elsewhere (e.g. NERSC web portal)
+htmlSubdirectory = /lcrc/group/acme/public_html/diagnostic_output/ac.xylar/analysis_testing/baseline
+
+# a list of analyses to generate.  Valid names can be seen by running:
+#   mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
+#   'all' -- all analyses will be run
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      mpas_analysis --list
+#                                   to list all task names and their tags
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    mpas_analysis config.analysis --generate \
+#         all,no_ocean,all_timeSeries
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 3
+# the last year over which to average climatalogies
+endYear = 5
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
+startYear = 1
+endYear = end
+
+[index]
+## options related to producing nino index.
+
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
+startYear = 1
+endYear = end
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning
+## circulation (MOC)
+
+# Use postprocessing script to compute the MOC? You want this to be True
+# for low-resolution simulations that use GM to parameterize eddies, because
+# the online MOC analysis member currently does not include the bolus velocity
+# in its calculation, whereas the postprocessing script does.
+# NOTE: this is a temporary option that will be removed once the online
+# MOC takes into account the bolus velocity when GM is on.
+usePostprocessingScript = True

--- a/configs/anvil/test_suite/ctrl.cfg
+++ b/configs/anvil/test_suite/ctrl.cfg
@@ -1,0 +1,149 @@
+[runs]
+## options related to the run to be analyzed and control runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = ctrl
+
+# config file for a control run to which this run will be compared.  The
+# analysis should have already been run to completion once with this config
+# file, so that the relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid.  Leave this option commented out if no
+# control run is desired.
+# controlRunConfigFile = /path/to/config/file
+
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 12
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lcrc/group/acme/diagnostics
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /lcrc/group/acme/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
+
+# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+mpasMeshName = oQU240wLI
+
+# subdirectory containing restart files
+runSubdirectory = run
+# subdirectory for ocean history files
+oceanHistorySubdirectory = archive/ocn/hist
+# subdirectory for sea ice history files
+seaIceHistorySubdirectory = archive/ice/hist
+
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = run/mpaso_in
+oceanStreamsFileName = run/streams.ocean
+seaIceNamelistFileName = run/mpassi_in
+seaIceStreamsFileName = run/streams.seaice
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+baseDirectory = /lcrc/group/acme/ac.xylar/analysis_testing/baseline
+
+# Anvil doesn't have direct access to a web portal, so output will need
+# to be copied elsewhere (e.g. NERSC web portal)
+htmlSubdirectory = /lcrc/group/acme/public_html/diagnostic_output/ac.xylar/analysis_testing/baseline
+
+# a list of analyses to generate.  Valid names can be seen by running:
+#   mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
+#   'all' -- all analyses will be run
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      mpas_analysis --list
+#                                   to list all task names and their tags
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    mpas_analysis config.analysis --generate \
+#         all,no_ocean,all_timeSeries
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 4
+# the last year over which to average climatalogies
+endYear = 8
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
+startYear = 1
+endYear = end
+
+[index]
+## options related to producing nino index.
+
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
+startYear = 1
+endYear = end
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning
+## circulation (MOC)
+
+# Use postprocessing script to compute the MOC? You want this to be True
+# for low-resolution simulations that use GM to parameterize eddies, because
+# the online MOC analysis member currently does not include the bolus velocity
+# in its calculation, whereas the postprocessing script does.
+# NOTE: this is a temporary option that will be removed once the online
+# MOC takes into account the bolus velocity when GM is on.
+usePostprocessingScript = True

--- a/configs/anvil/test_suite/job_script.bash
+++ b/configs/anvil/test_suite/job_script.bash
@@ -1,0 +1,25 @@
+#!/bin/bash -l
+#SBATCH --nodes=1
+#SBATCH --time=2:00:00
+#SBATCH -A condo
+#SBATCH -p acme-small
+#SBATCH --job-name=mpas_analysis
+#SBATCH --output=mpas_analysis.o%j
+#SBATCH --error=mpas_analysis.e%j
+
+cd $SLURM_SUBMIT_DIR
+export OMP_NUM_THREADS=1
+
+source /home/ac.xylar/miniconda3/etc/profile.d/conda.sh
+conda activate test_env
+export HDF5_USE_FILE_LOCKING=FALSE
+
+echo env: test_env
+echo configs: ../configs/polarRegions.conf main.cfg
+
+mpas_analysis --list
+mpas_analysis --plot_colormaps
+mpas_analysis --setup_only ../configs/polarRegions.conf main.cfg
+mpas_analysis --purge ../configs/polarRegions.conf main.cfg
+mpas_analysis --html_only ../configs/polarRegions.conf main.cfg
+

--- a/configs/anvil/test_suite/job_script_no_polar_regions.bash
+++ b/configs/anvil/test_suite/job_script_no_polar_regions.bash
@@ -1,0 +1,21 @@
+#!/bin/bash -l
+#SBATCH --nodes=1
+#SBATCH --time=2:00:00
+#SBATCH -A condo
+#SBATCH -p acme-small
+#SBATCH --job-name=mpas_analysis
+#SBATCH --output=mpas_analysis.o%j
+#SBATCH --error=mpas_analysis.e%j
+
+cd $SLURM_SUBMIT_DIR
+export OMP_NUM_THREADS=1
+
+source /home/ac.xylar/miniconda3/etc/profile.d/conda.sh
+conda activate test_env
+export HDF5_USE_FILE_LOCKING=FALSE
+
+echo env: test_env
+echo configs: no_polar_regions.cfg
+
+srun -N 1 -n 1 python -m mpas_analysis no_polar_regions.cfg
+

--- a/configs/anvil/test_suite/main.cfg
+++ b/configs/anvil/test_suite/main.cfg
@@ -1,0 +1,149 @@
+[runs]
+## options related to the run to be analyzed and control runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = main
+
+# config file for a control run to which this run will be compared.  The
+# analysis should have already been run to completion once with this config
+# file, so that the relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid.  Leave this option commented out if no
+# control run is desired.
+# controlRunConfigFile = /path/to/config/file
+
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 12
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lcrc/group/acme/diagnostics
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /lcrc/group/acme/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
+
+# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+mpasMeshName = oQU240wLI
+
+# subdirectory containing restart files
+runSubdirectory = run
+# subdirectory for ocean history files
+oceanHistorySubdirectory = archive/ocn/hist
+# subdirectory for sea ice history files
+seaIceHistorySubdirectory = archive/ice/hist
+
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = run/mpaso_in
+oceanStreamsFileName = run/streams.ocean
+seaIceNamelistFileName = run/mpassi_in
+seaIceStreamsFileName = run/streams.seaice
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+baseDirectory = /lcrc/group/acme/ac.xylar/analysis_testing/baseline
+
+# Anvil doesn't have direct access to a web portal, so output will need
+# to be copied elsewhere (e.g. NERSC web portal)
+htmlSubdirectory = /lcrc/group/acme/public_html/diagnostic_output/ac.xylar/analysis_testing/baseline
+
+# a list of analyses to generate.  Valid names can be seen by running:
+#   mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
+#   'all' -- all analyses will be run
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      mpas_analysis --list
+#                                   to list all task names and their tags
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    mpas_analysis config.analysis --generate \
+#         all,no_ocean,all_timeSeries
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 4
+# the last year over which to average climatalogies
+endYear = 8
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
+startYear = 1
+endYear = end
+
+[index]
+## options related to producing nino index.
+
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
+startYear = 1
+endYear = end
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning
+## circulation (MOC)
+
+# Use postprocessing script to compute the MOC? You want this to be True
+# for low-resolution simulations that use GM to parameterize eddies, because
+# the online MOC analysis member currently does not include the bolus velocity
+# in its calculation, whereas the postprocessing script does.
+# NOTE: this is a temporary option that will be removed once the online
+# MOC takes into account the bolus velocity when GM is on.
+usePostprocessingScript = True

--- a/configs/anvil/test_suite/main_vs_ctrl.cfg
+++ b/configs/anvil/test_suite/main_vs_ctrl.cfg
@@ -1,0 +1,149 @@
+[runs]
+## options related to the run to be analyzed and control runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = main
+
+# config file for a control run to which this run will be compared.  The
+# analysis should have already been run to completion once with this config
+# file, so that the relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid.  Leave this option commented out if no
+# control run is desired.
+controlRunConfigFile = ctrl.cfg
+
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+mainRunConfigFile = main_py3.8.cfg
+
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 12
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lcrc/group/acme/diagnostics
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /lcrc/group/acme/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
+
+# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+mpasMeshName = oQU240wLI
+
+# subdirectory containing restart files
+runSubdirectory = run
+# subdirectory for ocean history files
+oceanHistorySubdirectory = archive/ocn/hist
+# subdirectory for sea ice history files
+seaIceHistorySubdirectory = archive/ice/hist
+
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = run/mpaso_in
+oceanStreamsFileName = run/streams.ocean
+seaIceNamelistFileName = run/mpassi_in
+seaIceStreamsFileName = run/streams.seaice
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+baseDirectory = /lcrc/group/acme/ac.xylar/analysis_testing/baseline
+
+# Anvil doesn't have direct access to a web portal, so output will need
+# to be copied elsewhere (e.g. NERSC web portal)
+htmlSubdirectory = /lcrc/group/acme/public_html/diagnostic_output/ac.xylar/analysis_testing/baseline
+
+# a list of analyses to generate.  Valid names can be seen by running:
+#   mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
+#   'all' -- all analyses will be run
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      mpas_analysis --list
+#                                   to list all task names and their tags
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    mpas_analysis config.analysis --generate \
+#         all,no_ocean,all_timeSeries
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 4
+# the last year over which to average climatalogies
+endYear = 8
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
+startYear = 1
+endYear = end
+
+[index]
+## options related to producing nino index.
+
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
+startYear = 1
+endYear = end
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning
+## circulation (MOC)
+
+# Use postprocessing script to compute the MOC? You want this to be True
+# for low-resolution simulations that use GM to parameterize eddies, because
+# the online MOC analysis member currently does not include the bolus velocity
+# in its calculation, whereas the postprocessing script does.
+# NOTE: this is a temporary option that will be removed once the online
+# MOC takes into account the bolus velocity when GM is on.
+usePostprocessingScript = True

--- a/configs/anvil/test_suite/no_ncclimo.cfg
+++ b/configs/anvil/test_suite/no_ncclimo.cfg
@@ -1,0 +1,153 @@
+[runs]
+## options related to the run to be analyzed and control runs to be
+## compared against
+
+# mainRunName is a name that identifies the simulation being analyzed.
+mainRunName = main
+
+# config file for a control run to which this run will be compared.  The
+# analysis should have already been run to completion once with this config
+# file, so that the relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid.  Leave this option commented out if no
+# control run is desired.
+# controlRunConfigFile = /path/to/config/file
+
+# config file for a main run on which the analysis was already run to
+# completion.  The relevant MPAS climatologies already exist and have been
+# remapped to the comparison grid and time series have been extracted.
+# Leave this option commented out if the analysis for the main run should be
+# performed.
+# mainRunConfigFile = /path/to/config/file
+
+[execute]
+## options related to executing parallel tasks
+
+# the number of parallel tasks (1 means tasks run in serial, the default)
+parallelTaskCount = 12
+
+# the parallelism mode in ncclimo ("serial" or "bck")
+# Set this to "bck" (background parallelism) if running on a machine that can
+# handle 12 simultaneous processes, one for each monthly climatology.
+ncclimoParallelMode = bck
+
+[diagnostics]
+## config options related to observations, mapping files and region files used
+## by MPAS-Analysis in diagnostics computations.
+
+# The base path to the diagnostics directory.  Typically, this will be a shared
+# directory on each E3SM supported machine (see the example config files for
+# its location).  For other machines, this would be the directory pointed to
+# when running "download_analysis_data.py" to get the public observations,
+# mapping files and region files.
+baseDirectory = /lcrc/group/acme/diagnostics
+
+[input]
+## options related to reading in the results to be analyzed
+
+# directory containing model results
+baseDirectory = /lcrc/group/acme/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
+
+# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+mpasMeshName = oQU240wLI
+
+# subdirectory containing restart files
+runSubdirectory = run
+# subdirectory for ocean history files
+oceanHistorySubdirectory = archive/ocn/hist
+# subdirectory for sea ice history files
+seaIceHistorySubdirectory = archive/ice/hist
+
+# names of namelist and streams files, either a path relative to baseDirectory
+# or an absolute path.
+oceanNamelistFileName = run/mpaso_in
+oceanStreamsFileName = run/streams.ocean
+seaIceNamelistFileName = run/mpassi_in
+seaIceStreamsFileName = run/streams.seaice
+
+[output]
+## options related to writing out plots, intermediate cached data sets, logs,
+## etc.
+
+# directory where analysis should be written
+baseDirectory = /lcrc/group/acme/ac.xylar/analysis_testing/baseline
+
+# Anvil doesn't have direct access to a web portal, so output will need
+# to be copied elsewhere (e.g. NERSC web portal)
+htmlSubdirectory = /lcrc/group/acme/public_html/diagnostic_output/ac.xylar/analysis_testing/baseline
+
+# a list of analyses to generate.  Valid names can be seen by running:
+#   mpas_analysis --list
+# This command also lists tags for each analysis.
+# Shortcuts exist to generate (or not generate) several types of analysis.
+# These include:
+#   'all' -- all analyses will be run
+#   'all_<tag>' -- all analysis with a particular tag will be run
+#   'all_<component>' -- all analyses from a given component (either 'ocean'
+#                        or 'seaIce') will be run
+#   'only_<component>', 'only_<tag>' -- all analysis from this component or
+#                                       with this tag will be run, and all
+#                                       analysis for other components or
+#                                       without the tag will be skipped
+#   'no_<task_name>' -- skip the given task
+#   'no_<component>', 'no_<tag>' -- in analogy to 'all_*', skip all analysis
+#                                   tasks from the given compoonent or with
+#                                   the given tag.  Do
+#                                      mpas_analysis --list
+#                                   to list all task names and their tags
+# an equivalent syntax can be used on the command line to override this
+# option:
+#    mpas_analysis config.analysis --generate \
+#         all,no_ocean,all_timeSeries
+# All tasks with tag "landIceCavities" are disabled because this run did not
+# include land-ice cavities.
+generate = ['all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke']
+
+[climatology]
+## options related to producing climatologies, typically to compare against
+## observations and previous runs
+
+# the first year over which to average climatalogies
+startYear = 4
+# the last year over which to average climatalogies
+endYear = 8
+
+useNcclimo = False
+daskThreads = 12
+subprocessCount = 12
+
+[timeSeries]
+## options related to producing time series plots, often to compare against
+## observations and previous runs
+
+# start and end years for timeseries analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
+startYear = 1
+endYear = end
+
+[index]
+## options related to producing nino index.
+
+# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
+# that the full range of the data should be used.  If errorOnMissing = False,
+# the start and end year will be clipped to the valid range.  Otherwise, out
+# of bounds values will lead to an error.  In a "control" config file used in
+# a "main vs. control" analysis run, the range of years must be valid and
+# cannot include "end" because the original data may not be available.
+startYear = 1
+endYear = end
+
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning
+## circulation (MOC)
+
+# Use postprocessing script to compute the MOC? You want this to be True
+# for low-resolution simulations that use GM to parameterize eddies, because
+# the online MOC analysis member currently does not include the bolus velocity
+# in its calculation, whereas the postprocessing script does.
+# NOTE: this is a temporary option that will be removed once the online
+# MOC takes into account the bolus velocity when GM is on.
+usePostprocessingScript = True

--- a/configs/anvil/test_suite/test_suite.bash
+++ b/configs/anvil/test_suite/test_suite.bash
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -e
+
+branch=$(git symbolic-ref --short HEAD)
+
+export HDF5_USE_FILE_LOCKING=FALSE
+
+source ${HOME}/miniconda3/etc/profile.d/conda.sh
+
+conda activate base
+conda update -y conda conda-build
+rm -rf ${HOME}/miniconda3/conda-bld
+
+# create the test conda envs
+for py in 3.7 3.8
+do
+    env=test_mpas_analysis_py${py}
+    conda build -m ci/python${py}.yaml ci/recipe
+    conda remove -y --all -n ${env}
+    conda create -y -n ${env} --use-local python=${py} mpas-analysis sphinx \
+        mock sphinx_rtd_theme "tabulate>=0.8.2" m2r pytest
+    conda activate ${env}
+    pytest
+    conda deactivate
+done
+
+# create another env for testing xarray master branch
+env=test_mpas_analysis_xarray_master
+conda create --yes --quiet --name ${env} --use-local python=${py} \
+    mpas-analysis pytest
+conda activate ${env}
+pip install git+https://github.com/pydata/xarray.git
+pytest
+conda deactivate
+
+# test building the docs
+py=3.8
+conda activate test_mpas_analysis_py${py}
+cd docs
+make clean
+make html
+cd ..
+conda deactivate
+
+# move to a subdirectory so we use the conda package, not the local package
+rm -rf anvil_test_suite
+mkdir anvil_test_suite
+
+cd anvil_test_suite
+
+template_path=../configs/anvil/test_suite
+
+for py in 3.7 3.8
+do
+    env=test_mpas_analysis_py${py}
+    run=main_py${py}
+    config=${run}.cfg
+    job=job_script_${run}.bash
+    sed "s/baseline/${branch}\/py${py}/g" ${template_path}/main.cfg > ${config}
+    sed -e "s/main.cfg/${config}/g" -e "s/test_env/${env}/g" \
+         ${template_path}/job_script.bash > ${job}
+done
+
+
+py=3.8
+env=test_mpas_analysis_py${py}
+
+run=no_ncclimo
+config=${run}.cfg
+job=job_script_${run}.bash
+sed "s/baseline/${branch}\/${run}/g" ${template_path}/${config} > ${config}
+sed -e "s/main.cfg/${config}/g" -e "s/test_env/${env}/g" \
+     ${template_path}/job_script.bash > ${job}
+
+run=ctrl
+config=${run}.cfg
+job=job_script_${run}.bash
+sed "s/baseline/${branch}\/py${py}/g" ${template_path}/${config} > ${config}
+
+run=main_vs_ctrl
+config=${run}.cfg
+job=job_script_${run}.bash
+sed "s/baseline/${branch}\/${run}/g" ${template_path}/${config} > ${config}
+sed -e "s/main.cfg/${config}/g" -e "s/test_env/${env}/g" \
+     ${template_path}/job_script.bash > ${job}
+
+run=no_polar_regions
+config=${run}.cfg
+job=job_script_${run}.bash
+sed "s/baseline/${branch}\/${run}/g" ${template_path}/main.cfg > ${config}
+sed -e "s/test_env/${env}/g" ${template_path}/${job} > ${job}
+
+run=QU480
+config=${run}.cfg
+job=job_script_${run}.bash
+sed "s/baseline/${branch}\/${run}/g" ${template_path}/${config} > ${config}
+sed -e "s/main.cfg/${config}/g" -e "s/test_env/${env}/g" \
+     ${template_path}/job_script.bash > ${job}
+
+env=test_mpas_analysis_xarray_master
+run=xarray_master
+config=${run}.cfg
+job=job_script_${run}.bash
+sed "s/baseline/${branch}\/${run}/g" ${template_path}/main.cfg > ${config}
+sed -e "s/main.cfg/${config}/g" -e "s/test_env/${env}/g" \
+     ${template_path}/job_script.bash > ${job}
+
+
+# submit the jobs
+sbatch job_script_main_py3.7.bash
+
+RES=$(sbatch job_script_main_py3.8.bash)
+
+sbatch --dependency=afterok:${RES##* } job_script_main_vs_ctrl.bash
+
+sbatch job_script_no_ncclimo.bash
+
+sbatch job_script_no_polar_regions.bash
+
+sbatch job_script_QU480.bash
+
+sbatch job_script_xarray_master.bash
+
+cd ..
+


### PR DESCRIPTION
The test suite tests the following, mostly with a QU240wLI simulation that I just ran off of E3SM master today:
* main with python 3.7
* main with python 3.8
* main vs. ctrl
* no ncclimo
* no polar regions
* setup only
* html only
* list
* colormaps
* main with the xarray master branch (to get advanced warning about potential incompatibilities)
* a QU480 run

I also updated the Anvil example run and job script to point to the "main" QU240wLI run.