### PR TITLE
Various updates to T-S diagrams

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1377,6 +1377,11 @@ normType = log
 # zmin = -1000
 # zmax = -400
 
+# the minimum and maximum volume for the colorbar, default is the minimum and
+# maximum over the mode output
+# volMin = 3e9
+# volMax = 1e12
+
 # Obserational data sets to compare against
 obs = ['SOSE', 'WOA18']
 

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1365,7 +1365,7 @@ Sbins = numpy.linspace(33.8, 34.8, 1001)
 rhoInterval = 0.1
 
 # The color map for depth or volume
-colormap = white_cmo_deep
+colormap = cmo.deep
 # The following is more appropriate if diagramType == 'scatter'
 # colormap = cmo.deep_r
 # the type of norm used in the colormap {'linear', 'log'}

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1358,8 +1358,8 @@ diagramType = volumetric
 # if diagramType == 'volumetric', the bin boundaries for T and S
 # if diagramType == 'scatter', only the min and max are important (and the
 #   bins are only used for computing neutral density contours)
-Tbins = numpy.linspace(-2.5, 4, 651)
-Sbins = numpy.linspace(33.8, 34.8, 1001)
+Tbins = numpy.linspace(-2.5, 4, 131)
+Sbins = numpy.linspace(33.8, 34.8, 201)
 
 # density contour interval
 rhoInterval = 0.1

--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -1102,6 +1102,30 @@ class PlotRegionTSDiagramSubtask(AnalysisTask):
 
         inset = add_inset(fig, fc, width=1.5, height=1.5)
 
+        # add an empty plot covering the subplots to give common axis labels
+        pos0 = axarray[0, 0].get_position()
+        pos1 = axarray[-1, -1].get_position()
+        pos_common = [pos0.x0, pos1.y0, pos1.x1-pos0.x0, pos0.y1-pos1.y0]
+        print(pos_common)
+        common_ax = fig.add_axes(pos_common, zorder=-2)
+        common_ax.spines['top'].set_color('none')
+        common_ax.spines['bottom'].set_color('none')
+        common_ax.spines['left'].set_color('none')
+        common_ax.spines['right'].set_color('none')
+        common_ax.tick_params(labelcolor='w', top=False, bottom=False,
+                              left=False, right=False)
+
+        common_ax.set_xlabel('Salinity (PSU)', **axis_font)
+        common_ax.set_ylabel(r'Potential temperature ($^\circ$C)', **axis_font)
+
+        # turn off labels for individual plots (just used for spacing)
+        for index in range(len(axisIndices)):
+            row = nRows-1 - index//nCols
+            col = numpy.mod(index, nCols)
+            ax = axarray[row, col]
+            ax.set_xlabel('')
+            ax.set_ylabel('')
+
         # move the color bar down a little ot avoid the inset
         pos0 = inset.get_position()
         pos1 = axarray[-1, -1].get_position()

--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -1025,8 +1025,14 @@ class PlotRegionTSDiagramSubtask(AnalysisTask):
             raise ValueError('Unexpected diagramType {}'.format(diagramType))
 
         lastPanel = None
-        volMinMpas = None
-        volMaxMpas = None
+        if config.has_option(sectionName, 'volMin'):
+            volMinMpas = config.getfloat(sectionName, 'volMin')
+        else:
+            volMinMpas = None
+        if config.has_option(sectionName, 'volMax'):
+            volMaxMpas = config.getfloat(sectionName, 'volMax')
+        else:
+            volMaxMpas = None
         for index in range(len(axisIndices)):
             panelIndex = axisIndices[index]
 
@@ -1052,8 +1058,9 @@ class PlotRegionTSDiagramSubtask(AnalysisTask):
                 lastPanel, volMin, volMax = \
                     self._plot_volumetric_panel(T, S, volume)
 
-                if index == 0:
+                if volMinMpas is None:
                     volMinMpas = volMin
+                if volMaxMpas is None:
                     volMaxMpas = volMax
                 if normType == 'linear':
                     norm = colors.Normalize(vmin=0., vmax=volMaxMpas)


### PR DESCRIPTION
This merge includes:
* Changing axis labels and default colormap for T-S diagrams.  There is now a single x and y axis label for all panels.  The color map no longer fades to white at low density.
* Coarsening the bins for the T/S diagrams. Otherwise, they are not dense enough to be well sampled at lower resolution.
* Adding support for user-specified min/max vol in TS diagrams