### PR TITLE
Add Rignot obs for Antarctic, FRIS, Ross

### DIFF
--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -564,9 +564,9 @@ class PlotMeltSubtask(AnalysisTask):
         observationsDirectory = build_obs_path(config, 'ocean',
                                                'meltSubdirectory')
         obsFileNameDict = {'Rignot et al. (2013)':
-                           'Rignot_2013_melt_rates_20200623.csv',
+                           'Rignot_2013_melt_rates_20201117.csv',
                            'Rignot et al. (2013) SS':
-                           'Rignot_2013_melt_rates_SS_20200623.csv'}
+                           'Rignot_2013_melt_rates_SS_20201117.csv'}
 
         obsDict = {}  # dict for storing dict of obs data
         for obsName in obsFileNameDict:


### PR DESCRIPTION
These measurements were originally missing because they are not in the Rignot et al. (2013) table.

The uncertainties for Filchner-Ronne and Ross have been computed simply by adding the uncertainties of the two constituent pieces of each shelf.  This is likely an overestimate but seems the safest option for our visualization purpose, since we do not have enough information to combine them in another way (e.g. RMS weighted by the number of measurements used to obtain each).