### PR TITLE
Move the legend to the lower left for regional profiles

### DIFF
--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -851,7 +851,7 @@ class PlotRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
                                   facecolor=color, alpha=0.2)
 
         if plotLegend and len(zArrays) > 1:
-            plt.legend()
+            plt.legend(loc='lower left')
 
         axis_font = {'size': config.get('plot', 'axisFontSize')}
         title_font = {'size': config.get('plot', 'titleFontSize'),


### PR DESCRIPTION
It is defaulting to the upper right in some cases, and therefore getting covered by the inset:
![image](https://user-images.githubusercontent.com/4179064/99909644-161e8380-2cea-11eb-82fc-16e7f948e299.png)
