### PR TITLE
Fix anvil testsuite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ ENV/
 .ropeproject
  
 .DS_Store
+
+# Anvil test suite
+/anvil_test_suite/

--- a/configs/anvil/test_suite/QU480.cfg
+++ b/configs/anvil/test_suite/QU480.cfg
@@ -100,7 +100,8 @@ htmlSubdirectory = /lcrc/group/acme/public_html/diagnostic_output/ac.xylar/analy
 #         all,no_ocean,all_timeSeries
 # All tasks with tag "landIceCavities" are disabled because this run did not
 # include land-ice cavities.
-generate = ['all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke']
+generate = ['all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke',
+            'no_landIceCavities']
 
 [climatology]
 ## options related to producing climatologies, typically to compare against

--- a/configs/anvil/test_suite/clean_suilte.bash
+++ b/configs/anvil/test_suite/clean_suilte.bash
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+
+branch=$(git symbolic-ref --short HEAD)
+
+rm -rf anvil_test_suite
+rm -rf /lcrc/group/acme/ac.xylar/analysis_testing/${branch}
+rm -rf /lcrc/group/acme/public_html/diagnostic_output/ac.xylar/analysis_testing/${branch}

--- a/configs/anvil/test_suite/ctrl.cfg
+++ b/configs/anvil/test_suite/ctrl.cfg
@@ -122,7 +122,7 @@ endYear = 8
 # a "main vs. control" analysis run, the range of years must be valid and
 # cannot include "end" because the original data may not be available.
 startYear = 1
-endYear = end
+endYear = 8
 
 [index]
 ## options related to producing nino index.
@@ -134,7 +134,7 @@ endYear = end
 # a "main vs. control" analysis run, the range of years must be valid and
 # cannot include "end" because the original data may not be available.
 startYear = 1
-endYear = end
+endYear = 8
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/anvil/test_suite/job_script.bash
+++ b/configs/anvil/test_suite/job_script.bash
@@ -20,6 +20,6 @@ echo configs: ../configs/polarRegions.conf main.cfg
 mpas_analysis --list
 mpas_analysis --plot_colormaps
 mpas_analysis --setup_only ../configs/polarRegions.conf main.cfg
-mpas_analysis --purge ../configs/polarRegions.conf main.cfg
+mpas_analysis --purge ../configs/polarRegions.conf main.cfg --verbose
 mpas_analysis --html_only ../configs/polarRegions.conf main.cfg
 

--- a/configs/anvil/test_suite/job_script_no_polar_regions.bash
+++ b/configs/anvil/test_suite/job_script_no_polar_regions.bash
@@ -17,5 +17,5 @@ export HDF5_USE_FILE_LOCKING=FALSE
 echo env: test_env
 echo configs: no_polar_regions.cfg
 
-srun -N 1 -n 1 python -m mpas_analysis no_polar_regions.cfg
+srun -N 1 -n 1 python -m mpas_analysis no_polar_regions.cfg --verbose
 

--- a/configs/anvil/test_suite/main.cfg
+++ b/configs/anvil/test_suite/main.cfg
@@ -122,7 +122,7 @@ endYear = 8
 # a "main vs. control" analysis run, the range of years must be valid and
 # cannot include "end" because the original data may not be available.
 startYear = 1
-endYear = end
+endYear = 8
 
 [index]
 ## options related to producing nino index.
@@ -134,7 +134,7 @@ endYear = end
 # a "main vs. control" analysis run, the range of years must be valid and
 # cannot include "end" because the original data may not be available.
 startYear = 1
-endYear = end
+endYear = 8
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/configs/anvil/test_suite/main_vs_ctrl.cfg
+++ b/configs/anvil/test_suite/main_vs_ctrl.cfg
@@ -122,7 +122,7 @@ endYear = 8
 # a "main vs. control" analysis run, the range of years must be valid and
 # cannot include "end" because the original data may not be available.
 startYear = 1
-endYear = end
+endYear = 8
 
 [index]
 ## options related to producing nino index.
@@ -134,7 +134,7 @@ endYear = end
 # a "main vs. control" analysis run, the range of years must be valid and
 # cannot include "end" because the original data may not be available.
 startYear = 1
-endYear = end
+endYear = 8
 
 [streamfunctionMOC]
 ## options related to plotting the streamfunction of the meridional overturning

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -295,8 +295,8 @@ class ComputeRegionDepthMasksSubtask(AnalysisTask):  # {{{
         except OSError:
             pass
 
-        outFileName = '{}/depthMasks{}.nc'.format(outputDirectory,
-                                                  timeSeriesName)
+        outFileName = '{}/depthMasks_{}.nc'.format(outputDirectory,
+                                                   timeSeriesName)
 
         if os.path.exists(outFileName):
             self.logger.info('  Mask file exists -- Done.')
@@ -563,8 +563,8 @@ class ComputeRegionTimeSeriesSubtask(AnalysisTask):  # {{{
             self.logger.info('  Time series exists -- Done.')
             return
 
-        regionMaskFileName = '{}/depthMasks{}.nc'.format(outputDirectory,
-                                                         timeSeriesName)
+        regionMaskFileName = '{}/depthMasks_{}.nc'.format(outputDirectory,
+                                                          timeSeriesName)
         dsRegionMask = xarray.open_dataset(regionMaskFileName)
         nRegions = dsRegionMask.sizes['nRegions']
         areaCell = dsRegionMask.areaCell
@@ -834,6 +834,11 @@ class ComputeObsRegionalTimeSeriesSubtask(AnalysisTask):
             build_config_full_path(self.config, 'output',
                                    'timeseriesSubdirectory'),
             timeSeriesName)
+
+        try:
+            os.makedirs(outputDirectory)
+        except OSError:
+            pass
 
         outFileName = '{}/TS_{}_{}.nc'.format(
             outputDirectory, obsDict['suffix'], self.prefix)

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -698,7 +698,7 @@ class MpasClimatologySeasonSubtask(AnalysisTask):  # {{{
             fileNames = sorted(parentTask.inputFiles)
             years, months = get_files_year_month(
                 fileNames,  self.historyStreams,
-                'timeSeriesStatsMonthlyOutput')
+                parentTask.streamName)
 
             with xarray.open_mfdataset(parentTask.inputFiles,
                                        combine='nested',


### PR DESCRIPTION
The test suite on Anvil has been failing without me having noticed.  This PR fixes many small issues so it's working:
* Remove melt-rates from QU480 test case, since it doesn't include ice-shelf cavities
* Add missing `makedirs` call in ocean regional time series
* Adds an explicit `endYear = 8` to time series to main vs. ctrl analysis works correctly
* Fixes the name of the stream for min/max streams (was using the "average" stream name for all streams, which isn't correct).
* Add the `--verbose` flag to Anvil test suite so we can see why setup fails if it does.

This merge also includes a few clean-up changes:
* Add a clean-up script to the test suite -- deletes the analysis, html and test-suite logs file output so everything can start fresh
* Add the `anvil_test_suite` directory to the `.gitignore` file
