### PR TITLE
Build region and transect masks from geometric_features aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ environment with the following packages:
  * shapely
  * cartopy >= 0.18.0
  * cartopy\_offlinedata
- * geometric\_features >= 0.1.9
+ * geometric\_features >= 0.1.12
  * gsw
  * pyremap < 0.1.0
- * mpas\_tools >= 0.0.13
+ * mpas\_tools >= 0.0.15
 
 These can be installed via the conda command:
 ```
@@ -74,8 +74,8 @@ conda config --set channel_priority strict
 conda create -n mpas-analysis python=3.8 numpy scipy "matplotlib>=3.0.2" \
     netCDF4 "xarray>=0.14.1" dask bottleneck lxml "nco>=4.8.1" pyproj \
     pillow cmocean progressbar2 requests setuptools shapely "cartopy>=0.18.0" \
-    cartopy_offlinedata "geometric_features>=0.1.9" gsw "pyremap<0.1.0" \
-    "mpas_tools>=0.0.13"
+    cartopy_offlinedata "geometric_features>=0.1.12" gsw "pyremap<0.1.0" \
+    "mpas_tools>=0.0.15"
 conda activate mpas-analysis
 ```
 

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -40,10 +40,10 @@ requirements:
     - shapely
     - cartopy >=0.18.0
     - cartopy_offlinedata
-    - geometric_features >=0.1.9
+    - geometric_features >=0.1.12
     - gsw
     - pyremap <0.1.0
-    - mpas_tools >=0.0.13
+    - mpas_tools >=0.0.15
 
 test:
   requires:

--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -53,6 +53,11 @@ regionGroups = ['Antarctic Regions', 'Ocean Basins']
 [TSDiagramsForAntarcticRegions]
 ## options related to plotting T/S diagrams of Antarctic regions
 
+# list of regions to plot or ['all'] for all regions in the masks file.
+# See "regionNames" in the antarcticRegions masks file in
+# regionMaskSubdirectory for details.
+regionNames = ['all']
+
 # The minimum and maximum depth over which fields are plotted, default is
 # to take these values from the geojson feature's zmin and zmax properties.
 zmin = -1000
@@ -188,10 +193,8 @@ seasons =  ['ANN']
 # minimum and maximum depth of profile plots, or empty for the full depth range
 depthRange = [-600., 0.]
 
-# The suffix on the regional mask file to be used to determine the regions to
-# plot.  A region mask file should be in the regionMaskDirectory and should
-# be named <mpasMeshName>_<regionMaskSuffix>.nc
-regionMaskSuffix = antarcticRegions20200621
+# The name of a region group defining the region for each profile
+regionGroup = Antarctic Regions
 
 # a list of region names from the region masks file to plot
 regionNames = ["Southern Ocean 60S", "Weddell Sea Shelf",
@@ -269,3 +272,19 @@ colorbarTicksResult = [-20., -10., -5., -2., -1., 0., 1., 2., 5., 10., 20.]
 normArgsDifference = {'linthresh': 1., 'linscale': 0.5, 'vmin': -20.,
                       'vmax': 20.}
 colorbarTicksDifference = [-20., -10., -5., -2., -1., 0., 1., 2., 5., 10., 20.]
+
+# make a tables of mean melt rates and melt fluxes for individual ice shelves?
+makeTables = True
+
+# If making tables, which ice shelves?  This is a list of ice shelves or
+# ['all'] for all 106 ice shelves and regions.
+iceShelvesInTable = ['all']
+
+
+[timeSeriesAntarcticRegions]
+## options related to plotting time series of Antarctic regions
+
+# list of regions to plot or ['all'] for all regions in the masks file.
+# See "regionNames" in the antarcticRegions masks file in
+# regionMaskSubdirectory for details.
+regionNames = ['all']

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1217,11 +1217,11 @@ colorbarTicksDifference = [-100., -50., -20., -10., -5., -2., -1., 0., 1., 2.,
                            5., 10., 20., 50., 100.]
 
 # make a tables of mean melt rates and melt fluxes for individual ice shelves?
-makeTables = True
+makeTables = False
 
 # If making tables, which ice shelves?  This is a list of ice shelves or
 # ['all'] for all 106 ice shelves and regions.
-iceShelvesInTable = ['all']
+iceShelvesInTable = []
 
 
 [timeSeriesAntarcticMelt]
@@ -1260,16 +1260,10 @@ regionGroups = ['Antarctic Regions']
 [timeSeriesAntarcticRegions]
 ## options related to plotting time series of Antarctic regions
 
-# An identifying string that is the prefix for a geojson file containing
-# Antarctic ocean regions.  Each region must have 'zmin' and 'zmax' properties
-# in addition to the usual properties for a region in geometric_features.  The
-# string is also used as the suffix for mask files generated from the geojson
-regionMaskSuffix = 'antarcticRegions20200621'
-
 # list of regions to plot or ['all'] for all regions in the masks file.
 # See "regionNames" in the antarcticRegions masks file in
 # regionMaskSubdirectory for details.
-regionNames = ['all']
+regionNames = []
 
 # a list of variables to plot
 variables = [{'name': 'temperature',
@@ -1347,16 +1341,10 @@ subprocessCount = 4
 [TSDiagramsForAntarcticRegions]
 ## options related to plotting T/S diagrams of Antarctic regions
 
-# An identifying string that is the prefix for a geojson file containing
-# Antarctic ocean regions.  Each region must have 'zmin' and 'zmax' properties
-# in addition to the usual properties for a region in geometric_features.  The
-# string is also used as the suffix for mask files generated from the geojson
-regionMaskSuffix = 'antarcticRegions20200621'
-
 # list of regions to plot or ['all'] for all regions in the masks file.
 # See "regionNames" in the antarcticRegions masks file in
 # regionMaskSubdirectory for details.
-regionNames = ['all']
+regionNames = []
 
 # diagram type, either 'volumetric' or 'scatter', depending on if the points
 # should be binned the plot should show the volume fraction in each bin or
@@ -1396,16 +1384,13 @@ obs = ['SOSE', 'WOA18']
 [TSDiagramsForOceanBasins]
 ## options related to plotting T/S diagrams of major ocean basins
 
-# An identifying string that is the prefix for a geojson file containing
-# ocean basins.  Each region must have 'zmin' and 'zmax' properties in addition
-# to the usual properties for a region in geometric_features.  The string is
-# also used as the suffix for mask files generated from the geojson file
-regionMaskSuffix = 'oceanBasins20200621'
-
 # list of regions to plot or ['all'] for all regions in the masks file.
 # See "regionNames" in the oceanBasins masks file in
 # regionMaskSubdirectory for details.
-regionNames = ['all']
+regionNames = ["Atlantic_Basin", "Pacific_Basin", "Indian_Basin",
+               "Arctic_Basin", "Southern_Ocean_Basin", "Mediterranean_Basin",
+               "Global Ocean", "Global Ocean 65N to 65S",
+               "Global Ocean 15S to 15N"]
 
 # diagram type, either 'volumetric' or 'scatter', depending on if the points
 # should be binned the plot should show the volume fraction in each bin or
@@ -2969,10 +2954,8 @@ seasons =  ['JFM', 'JAS', 'ANN']
 # minimum and maximum depth of profile plots, or empty for the full depth range
 depthRange = []
 
-# The suffix on the regional mask file to be used to determine the regions to
-# plot.  A region mask file should be in the regionMaskDirectory and should
-# be named <mpasMeshName>_<regionMaskSuffix>.nc
-regionMaskSuffix = oceanBasins20200621
+# The name of a region group defining the region for each profile
+regionGroup = Ocean Basins
 
 # a list of region names from the region masks file to plot
 regionNames = ["Atlantic_Basin", "Pacific_Basin", "Indian_Basin",

--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -20,8 +20,8 @@ from pyremap import ProjectionGridDescriptor
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io.utility import build_obs_path, get_region_mask, \
-    decode_strings, build_config_full_path
+from mpas_analysis.shared.io.utility import build_obs_path, decode_strings, \
+    build_config_full_path
 from mpas_analysis.shared.io import write_netcdf
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
@@ -33,8 +33,6 @@ from mpas_analysis.ocean.plot_climatology_map_subtask import \
     PlotClimatologyMapSubtask
 
 from mpas_analysis.shared.constants import constants
-
-from mpas_analysis.shared.regions import get_feature_list
 
 
 class ClimatologyMapAntarcticMelt(AnalysisTask):  # {{{
@@ -376,11 +374,9 @@ class AntarcticMeltTableSubtask(AnalysisTask):
         self.mpasClimatologyTask = mpasClimatologyTask
         self.controlConfig = controlConfig
 
-        self.iceShelfMasksFile = get_region_mask(config,
-                                                 'iceShelves20200621.geojson')
-
         self.masksSubtask = regionMasksTask.add_mask_subtask(
-            self.iceShelfMasksFile, outFileSuffix='iceShelves20200621')
+            regionGroup='Ice Shelves')
+        self.iceShelfMasksFile = self.masksSubtask.geojsonFileName
 
         self.run_after(self.masksSubtask)
         self.run_after(mpasClimatologyTask)
@@ -400,8 +396,8 @@ class AntarcticMeltTableSubtask(AnalysisTask):
         sectionName = self.taskName
         iceShelvesInTable = config.getExpression(sectionName,
                                                  'iceShelvesInTable')
-        if 'all' in iceShelvesInTable:
-            iceShelvesInTable = get_feature_list(self.iceShelfMasksFile)
+        iceShelvesInTable = self.masksSubtask.expand_region_names(
+            iceShelvesInTable)
 
         meltRateFileName = get_masked_mpas_climatology_file_name(
             config, self.season, self.componentName,

--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -396,6 +396,9 @@ class AntarcticMeltTableSubtask(AnalysisTask):
         sectionName = self.taskName
         iceShelvesInTable = config.getExpression(sectionName,
                                                  'iceShelvesInTable')
+        if len(iceShelvesInTable) == 0:
+            return
+
         iceShelvesInTable = self.masksSubtask.expand_region_names(
             iceShelvesInTable)
 

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -82,6 +82,8 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
 
         self.regionNames = config.getExpression('oceanRegionalProfiles',
                                                 'regionNames')
+        if len(self.regionNames) == 0:
+            return
 
         plotHovmoller = config.getboolean('oceanRegionalProfiles',
                                           'plotHovmoller')

--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -165,6 +165,8 @@ class RegionalTSDiagrams(AnalysisTask):  # {{{
             sectionName = 'TSDiagramsFor{}'.format(sectionSuffix)
 
             regionNames = config.getExpression(sectionName, 'regionNames')
+            if len(regionNames) == 0:
+                continue
 
             mpasMasksSubtask = regionMasksTask.add_mask_subtask(
                 regionGroup=regionGroup)

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -29,11 +29,9 @@ from mpas_analysis.shared.plot import timeseries_analysis_plot, savefig, \
 from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    make_directories, build_obs_path, decode_strings, get_region_mask
+    make_directories, build_obs_path, decode_strings
 
 from mpas_analysis.shared.html import write_image_xml
-
-from mpas_analysis.shared.regions import get_feature_list
 
 
 class TimeSeriesAntarcticMelt(AnalysisTask):  # {{{
@@ -76,16 +74,13 @@ class TimeSeriesAntarcticMelt(AnalysisTask):  # {{{
             componentName='ocean',
             tags=['timeSeries', 'melt', 'landIceCavities', 'antarctic'])
 
-        self.iceShelfMasksFile = get_region_mask(config,
-                                                 'iceShelves20200621.geojson')
-
+        regionGroup = 'Ice Shelves'
+        masksSubtask = regionMasksTask.add_mask_subtask(regionGroup=regionGroup)
         iceShelvesToPlot = config.getExpression('timeSeriesAntarcticMelt',
                                                 'iceShelvesToPlot')
-        if 'all' in iceShelvesToPlot:
-            iceShelvesToPlot = get_feature_list(self.iceShelfMasksFile)
+        self.iceShelfMasksFile = masksSubtask.geojsonFileName
 
-        masksSubtask = regionMasksTask.add_mask_subtask(
-            self.iceShelfMasksFile, outFileSuffix='iceShelves20200621')
+        iceShelvesToPlot = masksSubtask.expand_region_names(iceShelvesToPlot)
 
         startYear = config.getint('timeSeries', 'startYear')
         endYear = config.get('timeSeries', 'endYear')
@@ -154,7 +149,7 @@ class ComputeMeltSubtask(AnalysisTask):  # {{{
 
         Parameters
         ----------
-        parentTask :  ``AnalysisTask``
+        parentTask :  TimeSeriesAntarcticMelt
             The parent task, used to get the ``taskName``, ``config`` and
             ``componentName``
 
@@ -382,7 +377,7 @@ class CombineMeltSubtask(AnalysisTask):  # {{{
 
         Parameters
         ----------
-        parentTask : ``TimeSeriesOceanRegions``
+        parentTask : TimeSeriesAntarcticMelt
             The main task of which this is a subtask
 
         startYears, endYears : list
@@ -465,7 +460,7 @@ class PlotMeltSubtask(AnalysisTask):
 
         Parameters
         ----------
-        parentTask :  ``AnalysisTask``
+        parentTask :  TimeSeriesAntarcticMelt
             The parent task, used to get the ``taskName``, ``config`` and
             ``componentName``
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -75,9 +75,13 @@ class TimeSeriesAntarcticMelt(AnalysisTask):  # {{{
             tags=['timeSeries', 'melt', 'landIceCavities', 'antarctic'])
 
         regionGroup = 'Ice Shelves'
-        masksSubtask = regionMasksTask.add_mask_subtask(regionGroup=regionGroup)
         iceShelvesToPlot = config.getExpression('timeSeriesAntarcticMelt',
                                                 'iceShelvesToPlot')
+        if len(iceShelvesToPlot) == 0:
+            # nothing else to do
+            return
+
+        masksSubtask = regionMasksTask.add_mask_subtask(regionGroup=regionGroup)
         self.iceShelfMasksFile = masksSubtask.geojsonFileName
 
         iceShelvesToPlot = masksSubtask.expand_region_names(iceShelvesToPlot)

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -124,6 +124,9 @@ class TimeSeriesOceanRegions(AnalysisTask):  # {{{
             sectionName = 'timeSeries{}'.format(sectionSuffix)
 
             regionNames = config.getExpression(sectionName, 'regionNames')
+            if len(regionNames) == 0:
+                # no regions in this group were requested
+                continue
 
             masksSubtask = regionMasksTask.add_mask_subtask(
                 regionGroup=regionGroup)

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -343,8 +343,8 @@ class ComputeRegionDepthMasksSubtask(AnalysisTask):  # {{{
         for regionIndex in range(nRegions):
             self.logger.info('    region: {}'.format(
                 self.regionNames[regionIndex]))
-            dsRregion = dsRegionMask.isel(nRegions=regionIndex)
-            cellMask = dsRregion.regionCellMasks == 1
+            dsRegion = dsRegionMask.isel(nRegions=regionIndex)
+            cellMask = dsRegion.regionCellMasks == 1
 
             if openOceanMask is not None:
                 cellMask = numpy.logical_and(cellMask, openOceanMask)
@@ -354,29 +354,28 @@ class ComputeRegionDepthMasksSubtask(AnalysisTask):  # {{{
                 1e-12 * totalArea.values))
 
             if config_zmin is None:
-                if 'zminRegions' in dsRregion:
-                    zmin = dsRregion.zminRegions
+                if 'zminRegions' in dsRegion:
+                    zmin = dsRegion.zminRegions.values
                 else:
                     # the old naming convention, used in some pre-generated
                     # mask files
-                    zmin = dsRregion.zmin
+                    zmin = dsRegion.zmin.values
             else:
-                zmin = (('nRegions',), config_zmin)
+                zmin = config_zmin
 
             if config_zmax is None:
-                if 'zmaxRegions' in dsRregion:
-                    zmax = dsRregion.zmaxRegions
+                if 'zmaxRegions' in dsRegion:
+                    zmax = dsRegion.zmaxRegions.values
                 else:
                     # the old naming convention, used in some pre-generated
                     # mask files
-                    zmax = dsRregion.zmax
+                    zmax = dsRegion.zmax.values
             else:
-                zmax = (('nRegions',), config_zmax)
-
+                zmax = config_zmax
             depthMask = numpy.logical_and(zMid >= zmin, zMid <= zmax)
             dsOut = xarray.Dataset()
-            dsOut['zmin'] = zmin
-            dsOut['zmax'] = zmax
+            dsOut['zmin'] = ('nRegions', [zmin])
+            dsOut['zmax'] = ('nRegions', [zmax])
             dsOut['totalArea'] = totalArea
             dsOut['cellMask'] = cellMask
             dsOut['depthMask'] = depthMask

--- a/mpas_analysis/ocean/time_series_transport.py
+++ b/mpas_analysis/ocean/time_series_transport.py
@@ -81,6 +81,8 @@ class TimeSeriesTransport(AnalysisTask):  # {{{
 
         transectsToPlot = config.getExpression('timeSeriesTransport',
                                                'transectsToPlot')
+        if len(transectsToPlot) == 0:
+            return
 
         masksSubtask = ComputeTransectMasksSubtask(
             parentTask=self, transectGroup='Transport Transects')

--- a/mpas_analysis/ocean/time_series_transport.py
+++ b/mpas_analysis/ocean/time_series_transport.py
@@ -28,13 +28,11 @@ from mpas_analysis.shared.plot import timeseries_analysis_plot, savefig, \
 from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
-    get_files_year_month, decode_strings, get_region_mask
+    get_files_year_month, decode_strings
 
 from mpas_analysis.shared.html import write_image_xml
 
 from mpas_analysis.shared.transects import ComputeTransectMasksSubtask
-
-from mpas_analysis.shared.regions import get_feature_list
 
 
 class TimeSeriesTransport(AnalysisTask):  # {{{
@@ -81,17 +79,14 @@ class TimeSeriesTransport(AnalysisTask):  # {{{
 
         years = [year for year in range(startYear, endYear + 1)]
 
-        transportTransectFileName = \
-            get_region_mask(config, 'transportTransects20200621.geojson')
-
         transectsToPlot = config.getExpression('timeSeriesTransport',
                                                'transectsToPlot')
-        if 'all' in transectsToPlot:
-            transectsToPlot = get_feature_list(transportTransectFileName)
 
         masksSubtask = ComputeTransectMasksSubtask(
-            self, transportTransectFileName,
-            outFileSuffix='transportTransects20200621')
+            parentTask=self, transectGroup='Transport Transects')
+
+        transectsToPlot = masksSubtask.expand_transect_names(transectsToPlot)
+        transportTransectFileName = masksSubtask.geojsonFileName
 
         self.add_subtask(masksSubtask)
 

--- a/mpas_analysis/shared/regions/__init__.py
+++ b/mpas_analysis/shared/regions/__init__.py
@@ -1,5 +1,5 @@
 from mpas_analysis.shared.regions.compute_region_masks_subtask \
-    import ComputeRegionMasksSubtask, get_feature_list
+    import ComputeRegionMasksSubtask, get_feature_list, get_region_info
 
 from mpas_analysis.shared.regions.compute_region_masks \
     import ComputeRegionMasks

--- a/mpas_analysis/shared/regions/compute_region_masks.py
+++ b/mpas_analysis/shared/regions/compute_region_masks.py
@@ -13,8 +13,6 @@ from mpas_analysis.shared.analysis_task import AnalysisTask
 from mpas_analysis.shared.regions.compute_region_masks_subtask \
     import ComputeRegionMasksSubtask
 
-from mpas_analysis.shared.io.utility import get_region_mask
-
 
 class ComputeRegionMasks(AnalysisTask):
     """
@@ -52,21 +50,17 @@ class ComputeRegionMasks(AnalysisTask):
 
         self.regionMaskSubtasks = {}
 
-    def add_mask_subtask(self, geojsonFileName, outFileSuffix, obsFileName=None,
-                         lonVar='lon', latVar='lat', meshName=None,
-                         useMpasMaskCreator=True):
+    def add_mask_subtask(self, regionGroup, obsFileName=None, lonVar='lon',
+                         latVar='lat', meshName=None, useMpasMaskCreator=True):
         """
         Construct the analysis task and adds it as a subtask of the
         ``parentTask``.
 
         Parameters
         ----------
-        geojsonFileName : str
-            A geojson file, typically from the MPAS ``geometric_features``
-            repository, defining the shapes to be masked
-
-        outFileSuffix : str
-            The suffix for the resulting mask file
+        regionGroup : str
+            The name of one of the supported region groups (see
+            :py:func:`mpas_analysis.shared.regions.get_region_mask()`)
 
         obsFileName : str, optional
             The name of an observations file to create masks for.  But default,
@@ -94,11 +88,10 @@ class ComputeRegionMasks(AnalysisTask):
         if meshName is None:
             meshName = config.get('input', 'mpasMeshName')
 
-        maskFileName = get_region_mask(
-            config, '{}_{}.nc'.format(meshName, outFileSuffix))
+        key = '{} {}'.format(meshName, regionGroup)
 
-        if maskFileName not in self.regionMaskSubtasks:
-            subtaskName = '{}_{}'.format(meshName, outFileSuffix)
+        if key not in self.regionMaskSubtasks:
+
             subprocessCount = config.getWithDefault('execute',
                                                     'parallelTaskCount',
                                                     default=1)
@@ -110,14 +103,13 @@ class ComputeRegionMasks(AnalysisTask):
                 subprocessCount = 1
 
             maskSubtask = ComputeRegionMasksSubtask(
-                self, geojsonFileName, outFileSuffix,
-                featureList=None, subtaskName=subtaskName,
+                self, regionGroup=regionGroup, meshName=meshName,
                 subprocessCount=subprocessCount, obsFileName=obsFileName,
-                lonVar=lonVar, latVar=latVar, meshName=meshName,
+                lonVar=lonVar, latVar=latVar,
                 useMpasMaskCreator=useMpasMaskCreator)
 
             self.add_subtask(maskSubtask)
 
-            self.regionMaskSubtasks[maskFileName] = maskSubtask
+            self.regionMaskSubtasks[key] = maskSubtask
 
-        return self.regionMaskSubtasks[maskFileName]
+        return self.regionMaskSubtasks[key]

--- a/mpas_analysis/shared/transects/__init__.py
+++ b/mpas_analysis/shared/transects/__init__.py
@@ -1,2 +1,2 @@
 from mpas_analysis.shared.transects.compute_transect_masks_subtask \
-    import ComputeTransectMasksSubtask
+    import ComputeTransectMasksSubtask, get_transect_info


### PR DESCRIPTION
This merge makes it easier to add new region masks to MPAS-Analysis by defining a dictionary to define a new mask.  The mask is defined by:
* a region (or transect) group name
* a prefix (so far, just a mangling of the region name: `Antarctic Regions` --> `antarcticRegions`)
* a date (today's date if adding or updating a cached mask file)
* a function for creating the feature collection with the regions for each mask, which should come from `geometric_features.aggregation`

If a mask file for the MPAS mesh already exists, it will be used.  If not and if a geojson file already exists in the `diagnostics` or `customDiagnostics` directory tree with the name `<prefix><date>.geojson`, it will be used to create the mask file.  If neither exists, the function from `geometric_features.aggregation` will be used to create the geojson file and then the mask file(s) in the output `masks` directory.  These could later be copied into the `diagnostics` (or `customDiagnostics`) directory if desired.

All of the ocean tasks that use region and transect masks have been updated to use this functionality.  This means that, instead of specifying a `regionMaskSuffix` in some configuration options, the user should now specify the region name.  MPAS-Analysis knows what the appropriate date is from the dictionary of possible region groups.