### PR TITLE
Break hovmollerOceanRegions into its own task

### DIFF
--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -182,9 +182,35 @@ colormapIndicesDifference = [0, 28, 57, 85, 113, 128, 128, 142, 170, 198, 227,
 colorbarLevelsDifference = [-0.5, -0.2, -0.1, -0.05, -0.02, 0,  0.02, 0.05,
                             0.1, 0.2, 0.5]
 
+
 [oceanRegionalProfiles]
 ## options related to plotting vertical profiles of regional means (and
 ## variability) of 3D MPAS fields
+
+regionGroups = ['Antarctic Regions']
+
+
+[profilesAntarcticRegions]
+## options related to plotting vertical profiles Antarctic regions
+
+
+# a list of dictionaries for each field to plot.  The dictionary includes
+# prefix (used for file names, task names and sections) as well as the mpas
+# name of the field, units for colorbars and a the name as it should appear
+# in figure titles and captions.
+fields =
+    [{'prefix': 'potentialTemperature',
+      'mpas': 'timeMonthly_avg_activeTracers_temperature',
+      'units': r'$\degree$C',
+      'titleName': 'Potential Temperature'},
+     {'prefix': 'salinity',
+      'mpas': 'timeMonthly_avg_activeTracers_salinity',
+      'units': r'PSU',
+      'titleName': 'Salinity'},
+     {'prefix': 'potentialDensity',
+      'mpas': 'timeMonthly_avg_potentialDensity',
+      'units': r'kg m$^{-3}$',
+      'titleName': 'Potential Density'}]
 
 # Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
@@ -192,9 +218,6 @@ seasons =  ['ANN']
 
 # minimum and maximum depth of profile plots, or empty for the full depth range
 depthRange = [-600., 0.]
-
-# The name of a region group defining the region for each profile
-regionGroup = Antarctic Regions
 
 # a list of region names from the region masks file to plot
 regionNames = ["Southern Ocean 60S", "Weddell Sea Shelf",
@@ -205,17 +228,48 @@ regionNames = ["Southern Ocean 60S", "Weddell Sea Shelf",
                "Western Ross Sea Deep",  "East Antarctic Seas Shelf",
                "East Antarctic Seas Deep"]
 
-# Make Hovmoller plots of fields vs time and depth?
-plotHovmoller = True
-
-# web gallery options
-hovmollerGalleryGroup = Antarctic Regional Time Series vs Depths
-
 # web gallery options
 profileGalleryGroup = Antarctic Regional Profiles
 
+[hovmollerOceanRegions]
+## options related to plotting Hovmoller diagrams (depth vs. time plots) of
+## regional means of 3D MPAS fields
 
-[temperatureOceanRegionalHovmoller]
+# the names of region groups to plot, each with its own section below
+regionGroups = ['Antarctic Regions']
+
+
+[hovmollerAntarcticRegions]
+## options related to plotting Hovmoller diagrams of Antarctic Regions
+
+# a list of dictionaries for each field to plot.  The dictionary includes
+# prefix (used for file names, task names and sections) as well as the MPAS
+# name of the field, units for colorbars and a the name as it should appear
+# in figure titles and captions.
+fields =
+    [{'prefix': 'potentialTemperature',
+      'mpas': 'timeMonthly_avg_activeTracers_temperature',
+      'units': r'$\degree$C',
+      'titleName': 'Potential Temperature'},
+     {'prefix': 'salinity',
+      'mpas': 'timeMonthly_avg_activeTracers_salinity',
+      'units': r'PSU',
+      'titleName': 'Salinity'},
+     {'prefix': 'potentialDensity',
+      'mpas': 'timeMonthly_avg_potentialDensity',
+      'units': r'kg m$^{-3}$',
+      'titleName': 'Potential Density'}]
+
+# a list of region names from the region masks file to plot
+regionNames = ["Southern Ocean 60S", "Weddell Sea Shelf",
+               "Weddell Sea Deep", "Bellingshausen Sea Shelf",
+               "Bellingshausen Sea Deep", "Amundsen Sea Shelf",
+               "Amundsen Sea Deep", "Eastern Ross Sea Shelf",
+               "Eastern Ross Sea Deep", "Western Ross Sea Shelf",
+               "Western Ross Sea Deep",  "East Antarctic Seas Shelf",
+               "East Antarctic Seas Deep"]
+
+[hovmollerOceanRegionsPotentialTemperature]
 ## options related to plotting time series of temperature vs. depth in ocean
 ## regions
 
@@ -229,8 +283,7 @@ movingAverageMonths = 12
 # limits on depth, the full range by default
 yLim = [-600., -5.]
 
-
-[salinityOceanRegionalHovmoller]
+[hovmollerOceanRegionsSalinity]
 ## options related to plotting time series of salinity vs. depth in ocean
 ## regions
 
@@ -245,7 +298,7 @@ movingAverageMonths = 12
 yLim = [-600., -5.]
 
 
-[potentialDensityOceanRegionalHovmoller]
+[hovmollerOceanRegionsPotentialDensity]
 ## options related to plotting time series of potential density vs. depth in
 ## ocean regions
 

--- a/configs/polarRegions.conf
+++ b/configs/polarRegions.conf
@@ -269,6 +269,15 @@ regionNames = ["Southern Ocean 60S", "Weddell Sea Shelf",
                "Western Ross Sea Deep",  "East Antarctic Seas Shelf",
                "East Antarctic Seas Deep"]
 
+# whether to compute an anomaly with respect to the start of the time series
+computeAnomaly = False
+
+# Number of points over which to compute moving average(e.g., for monthly
+# output, movingAverageMonths=12 corresponds to a 12-month moving average
+# window)
+movingAverageMonths = 12
+
+
 [hovmollerOceanRegionsPotentialTemperature]
 ## options related to plotting time series of temperature vs. depth in ocean
 ## regions

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -210,8 +210,12 @@ def build_analysis_list(config, controlConfig):  # {{{
     analyses.append(ocean.GeojsonTransects(config, oceanClimatolgyTasks['avg'],
                                            controlConfig))
 
-    analyses.append(ocean.OceanRegionalProfiles(config, oceanRegionMasksTask,
-                                                controlConfig))
+    oceanRegionalProfiles = ocean.OceanRegionalProfiles(
+        config, oceanRegionMasksTask, controlConfig)
+    analyses.append(oceanRegionalProfiles)
+
+    analyses.append(ocean.HovmollerOceanRegions(
+        config, oceanRegionMasksTask, oceanRegionalProfiles, controlConfig))
 
     # Sea Ice Analyses
     seaIceClimatolgyTask = MpasClimatologyTask(config=config,

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -3006,15 +3006,18 @@ regionNames = ["Atlantic_Basin", "Pacific_Basin", "Indian_Basin",
                "Global Ocean", "Global Ocean 65N to 65S",
                "Global Ocean 15S to 15N"]
 
-
-[hovmollerOceanRegionsPotentialTemperature]
-## options related to plotting time series of temperature vs. depth in ocean
-## regions
+# whether to compute an anomaly with respect to the start of the time series
+computeAnomaly = False
 
 # Number of points over which to compute moving average(e.g., for monthly
 # output, movingAverageMonths=12 corresponds to a 12-month moving average
 # window)
 movingAverageMonths = 12
+
+
+[hovmollerOceanRegionsPotentialTemperature]
+## options related to plotting time series of temperature vs. depth in ocean
+## regions
 
 # colormap
 colormapNameResult = RdYlBu_r
@@ -3056,11 +3059,6 @@ contourLevels = 'none'
 ## options related to plotting time series of salinity vs. depth in ocean
 ## regions
 
-# Number of points over which to compute moving average(e.g., for monthly
-# output, movingAverageMonths=12 corresponds to a 12-month moving average
-# window)
-movingAverageMonths = 12
-
 # colormap
 colormapNameResult = haline
 # whether the colormap is indexed or continuous
@@ -3100,11 +3098,6 @@ contourLevels = 'none'
 [hovmollerOceanRegionsPotentialDensity]
 ## options related to plotting time series of potential density vs. depth in
 ## ocean regions
-
-# Number of points over which to compute moving average(e.g., for monthly
-# output, movingAverageMonths=12 corresponds to a 12-month moving average
-# window)
-movingAverageMonths = 12
 
 # colormap
 colormapNameResult = Spectral_r

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1289,7 +1289,7 @@ variables = [{'name': 'temperature',
 # zmin = -1000
 # zmax = -400
 
-# Obserational data sets to compare against
+# Observational data sets to compare against
 obs = ['SOSE', 'WOA18']
 
 
@@ -2929,12 +2929,19 @@ galleryLabel = Chlorophyll
 ## options related to plotting vertical profiles of regional means (and
 ## variability) of 3D MPAS fields
 
+# The name of a region group defining the region for each profile
+regionGroups = ['Ocean Basins']
+
+
+[profilesOceanBasins]
+## options related to plotting vertical profiles ocean basins
+
 # a list of dictionaries for each field to plot.  The dictionary includes
 # prefix (used for file names, task names and sections) as well as the mpas
 # name of the field, units for colorbars and a the name as it should appear
 # in figure titles and captions.
 fields =
-    [{'prefix': 'temperature',
+    [{'prefix': 'potentialTemperature',
       'mpas': 'timeMonthly_avg_activeTracers_temperature',
       'units': r'$\degree$C',
       'titleName': 'Potential Temperature'},
@@ -2954,8 +2961,44 @@ seasons =  ['JFM', 'JAS', 'ANN']
 # minimum and maximum depth of profile plots, or empty for the full depth range
 depthRange = []
 
-# The name of a region group defining the region for each profile
-regionGroup = Ocean Basins
+# a list of region names from the region masks file to plot
+regionNames = ["Atlantic_Basin", "Pacific_Basin", "Indian_Basin",
+               "Arctic_Basin", "Southern_Ocean_Basin", "Mediterranean_Basin",
+               "Global Ocean", "Global Ocean 65N to 65S",
+               "Global Ocean 15S to 15N"]
+
+# web gallery options
+profileGalleryGroup = Ocean Basin Profiles
+
+
+[hovmollerOceanRegions]
+## options related to plotting Hovmoller diagrams (depth vs. time plots) of
+## regional means of 3D MPAS fields
+
+# the names of region groups to plot, each with its own section below
+regionGroups = ['Ocean Basins']
+
+
+[hovmollerOceanBasins]
+## options related to plotting Hovmoller diagrams of ocean basins
+
+# a list of dictionaries for each field to plot.  The dictionary includes
+# prefix (used for file names, task names and sections) as well as the MPAS
+# name of the field, units for colorbars and a the name as it should appear
+# in figure titles and captions.
+fields =
+    [{'prefix': 'potentialTemperature',
+      'mpas': 'timeMonthly_avg_activeTracers_temperature',
+      'units': r'$\degree$C',
+      'titleName': 'Potential Temperature'},
+     {'prefix': 'salinity',
+      'mpas': 'timeMonthly_avg_activeTracers_salinity',
+      'units': r'PSU',
+      'titleName': 'Salinity'},
+     {'prefix': 'potentialDensity',
+      'mpas': 'timeMonthly_avg_potentialDensity',
+      'units': r'kg m$^{-3}$',
+      'titleName': 'Potential Density'}]
 
 # a list of region names from the region masks file to plot
 regionNames = ["Atlantic_Basin", "Pacific_Basin", "Indian_Basin",
@@ -2963,24 +3006,15 @@ regionNames = ["Atlantic_Basin", "Pacific_Basin", "Indian_Basin",
                "Global Ocean", "Global Ocean 65N to 65S",
                "Global Ocean 15S to 15N"]
 
-# Make Hovmoller plots of fields vs time and depth?
-plotHovmoller = False
 
-# web gallery options
-hovmollerGalleryGroup = Ocean Basin Time Series vs Depths
-
-# web gallery options
-profileGalleryGroup = Ocean Basin Profiles
-
-
-[temperatureOceanRegionalHovmoller]
+[hovmollerOceanRegionsPotentialTemperature]
 ## options related to plotting time series of temperature vs. depth in ocean
 ## regions
 
 # Number of points over which to compute moving average(e.g., for monthly
 # output, movingAverageMonths=12 corresponds to a 12-month moving average
 # window)
-movingAverageMonths = 1
+movingAverageMonths = 12
 
 # colormap
 colormapNameResult = RdYlBu_r
@@ -3018,14 +3052,14 @@ contourLevels = 'none'
 # yLim = [-6000., 0.]
 
 
-[salinityOceanRegionalHovmoller]
+[hovmollerOceanRegionsSalinity]
 ## options related to plotting time series of salinity vs. depth in ocean
 ## regions
 
 # Number of points over which to compute moving average(e.g., for monthly
 # output, movingAverageMonths=12 corresponds to a 12-month moving average
 # window)
-movingAverageMonths = 1
+movingAverageMonths = 12
 
 # colormap
 colormapNameResult = haline
@@ -3063,14 +3097,14 @@ contourLevels = 'none'
 # yLim = [-6000., 0.]
 
 
-[potentialDensityOceanRegionalHovmoller]
+[hovmollerOceanRegionsPotentialDensity]
 ## options related to plotting time series of potential density vs. depth in
 ## ocean regions
 
 # Number of points over which to compute moving average(e.g., for monthly
 # output, movingAverageMonths=12 corresponds to a 12-month moving average
 # window)
-movingAverageMonths = 1
+movingAverageMonths = 12
 
 # colormap
 colormapNameResult = Spectral_r

--- a/mpas_analysis/ocean/__init__.py
+++ b/mpas_analysis/ocean/__init__.py
@@ -50,3 +50,6 @@ from mpas_analysis.ocean.geojson_transects import GeojsonTransects
 
 from mpas_analysis.ocean.ocean_regional_profiles import \
     OceanRegionalProfiles
+
+from mpas_analysis.ocean.hovmoller_ocean_regions import \
+    HovmollerOceanRegions

--- a/mpas_analysis/ocean/hovmoller_ocean_regions.py
+++ b/mpas_analysis/ocean/hovmoller_ocean_regions.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+# This software is open source software available under the BSD-3 license.
+#
+# Copyright (c) 2020 Triad National Security, LLC. All rights reserved.
+# Copyright (c) 2020 Lawrence Livermore National Security, LLC. All rights
+# reserved.
+# Copyright (c) 2020 UT-Battelle, LLC. All rights reserved.
+#
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at
+# https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
+#
+
+from mpas_analysis.shared import AnalysisTask
+from mpas_analysis.ocean.plot_hovmoller_subtask import PlotHovmollerSubtask
+
+
+class HovmollerOceanRegions(AnalysisTask):  # {{{
+    """
+    Compute and plot a Hovmoller diagram (depth vs. time) for regionally
+    analyzed data.  The mean of the data are computed over each region at each
+    depth and time.
+    """
+    # Authors
+    # -------
+    # Xylar Asay-Davis
+
+    def __init__(self, config, regionMasksTask, oceanRegionalProfilesTask,
+                 controlConfig=None):  # {{{
+        """
+        Construct the analysis task.
+
+        Parameters
+        ----------
+        config :  instance of MpasAnalysisConfigParser
+            Contains configuration options
+
+        regionMasksTask : ``ComputeRegionMasks``
+            A task for computing region masks
+
+        oceanRegionalProfilesTask : mpas_analysis.ocean.OceanRegionalProfiles
+            A task for computing ocean regional profiles
+
+        controlConfig :  ``MpasAnalysisConfigParser``, optional
+            Configuration options for a control run (if any)
+        """
+        # Authors
+        # -------
+        # Xylar Asay-Davis
+
+        # first, call the constructor from the base class (AnalysisTask)
+        super(HovmollerOceanRegions, self).__init__(
+            config=config,
+            taskName='hovmollerOceanRegions',
+            componentName='ocean',
+            tags=['profiles', 'timeSeries', 'hovmoller'])
+
+        startYear = config.getint('timeSeries', 'startYear')
+        endYear = config.get('timeSeries', 'endYear')
+        if endYear == 'end':
+            # a valid end year wasn't found, so likely the run was not found,
+            # perhaps because we're just listing analysis tasks
+            endYear = startYear
+        else:
+            endYear = int(endYear)
+
+        regionGroups = config.getExpression('hovmollerOceanRegions',
+                                            'regionGroups')
+
+        for regionGroup in regionGroups:
+            suffix = regionGroup[0].upper() + regionGroup[1:].replace(' ', '')
+            regionGroupSection = 'hovmoller{}'.format(suffix)
+            regionNames = config.getExpression(regionGroupSection,
+                                               'regionNames')
+            if len(regionNames) == 0:
+                return
+
+            fields = config.getExpression(regionGroupSection, 'fields')
+
+            masksSubtask = regionMasksTask.add_mask_subtask(regionGroup)
+            masksFile = masksSubtask.geojsonFileName
+            timeSeriesName = masksSubtask.outFileSuffix
+
+            regionNames = masksSubtask.expand_region_names(regionNames)
+
+            self.masksSubtask = masksSubtask
+
+            oceanRegionalProfilesTask.add_region_group(
+                regionMasksTask, regionGroup, regionNames,
+                fields, startYear, endYear)
+
+            combineSubtask = oceanRegionalProfilesTask.combineSubtasks[
+                regionGroup][(startYear, endYear)]
+
+            for field in fields:
+                prefix = field['prefix']
+                suffix = prefix[0].upper() + prefix[1:]
+                for regionName in regionNames:
+                    subtaskName = 'plotHovmoller_{}_{}'.format(
+                        prefix, regionName.replace(' ', '_'))
+                    inFileName = \
+                        '{}/regionalProfiles_{}_{:04d}-{:04d}.nc'.format(
+                            timeSeriesName, timeSeriesName,
+                            startYear, endYear)
+                    titleName = field['titleName']
+                    caption = 'Time series of {} {} vs ' \
+                              'depth'.format(regionName.replace('_', ' '),
+                                             titleName)
+                    hovmollerSubtask = PlotHovmollerSubtask(
+                        parentTask=self,
+                        regionName=regionName,
+                        inFileName=inFileName,
+                        outFileLabel='{}_hovmoller'.format(prefix),
+                        fieldNameInTitle=titleName,
+                        mpasFieldName='{}_mean'.format(prefix),
+                        unitsLabel=field['units'],
+                        sectionName='hovmollerOceanRegions{}'.format(suffix),
+                        thumbnailSuffix='',
+                        imageCaption=caption,
+                        galleryGroup='{} Time Series vs Depths'.format(
+                            regionGroup),
+                        groupSubtitle=None,
+                        groupLink='ocnreghovs',
+                        galleryName=titleName,
+                        subtaskName=subtaskName,
+                        controlConfig=controlConfig,
+                        regionMaskFile=masksFile)
+                    hovmollerSubtask.run_after(combineSubtask)
+                    self.add_subtask(hovmollerSubtask)
+
+        # }}}
+    # }}}
+
+# vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -98,7 +98,7 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
 
             masksSubtask = self.masksSubtasks[regionGroup]
 
-            timeSeriesName = masksSubtask.outFileSuffix
+            timeSeriesName = regionGroup.replace(' ', '')
 
             for field in fields:
                 for regionName in regionNames:
@@ -136,7 +136,7 @@ class OceanRegionalProfiles(AnalysisTask):  # {{{
         if regionGroup not in self.combineSubtasks:
             self.combineSubtasks[regionGroup] = dict()
 
-        timeSeriesName = masksSubtask.outFileSuffix
+        timeSeriesName = regionGroup.replace(' ', '')
 
         if seasons is None:
             seasons = []
@@ -275,7 +275,7 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):  # {{{
         startDate = '{:04d}-01-01_00:00:00'.format(self.startYear)
         endDate = '{:04d}-12-31_23:59:59'.format(self.endYear)
 
-        timeSeriesName = self.masksSubtask.outFileSuffix
+        timeSeriesName = self.masksSubtask.regionGroup.replace(' ', '')
 
         outputDirectory = '{}/{}/'.format(
             build_config_full_path(self.config, 'output',

--- a/mpas_analysis/ocean/plot_hovmoller_subtask.py
+++ b/mpas_analysis/ocean/plot_hovmoller_subtask.py
@@ -295,7 +295,7 @@ class PlotHovmollerSubtask(AnalysisTask):
         xLabel = 'Time (years)'
         yLabel = 'Depth (m)'
 
-        title = '{}, {}'.format(self.fieldNameInTitle, regionNameInTitle)
+        title = '{}\n{}'.format(self.fieldNameInTitle, regionNameInTitle)
 
         outFileName = '{}/{}.png'.format(self.plotsDirectory, self.filePrefix)
 

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -482,9 +482,9 @@ def plot_vertical_section_comparison(
         if thirdXAxisData is not None and refArray is None:
             plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.0, 0.0, 1.0, 0.98])
         else:
-            plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.0, 0.0, 1.0, 0.9])
+            plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.0, 0.0, 1.0, 0.95])
     else:
-        plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.01, 0.0, 1.0, 0.93])
+        plt.tight_layout(pad=0.0, h_pad=2.0, rect=[0.01, 0.0, 1.0, 0.97])
 
     return fig, axes, suptitle
 

--- a/mpas_analysis/shared/time_series/anomaly.py
+++ b/mpas_analysis/shared/time_series/anomaly.py
@@ -36,8 +36,8 @@ def compute_moving_avg_anomaly_from_start(timeSeriesFileName, variableList,
     variableList :  list of str
         variable names to include in the resulting data set
 
-    simulationStartTime :  str
-        the start date of the simulation
+    anomalyStartTime, anomalyEndTime :  str
+        the start and end times of the reference point for the anomaly
 
     startDate, endDate :  str
         the start and end dates of the time series


### PR DESCRIPTION
The new `hovmollerOceanRegions` task also supports anomalies relative to the first year of the time series with `computeAnomaly = True` in the configuration section for the region group.  For this to be useful, the user will probably need to change the ranges of the color maps.

Also, this merge makes the `oceanRegionalProfiles` task support multiple region groups.  This capability is still a little clumsy and could be improved further in the future.  Each field only has one section in the config file, meaning the user can't currently set different temperature ranges for different region groups.

To support both of these changes, the `oceanRegionalProfiles` task now has a functionality for adding a new range of years and/or region group (creating all of the subtasks to compute the appropriate years and combine them into profiles and/or Hovmoller datasets).

Some config sections have been renamed to support these changes, and `configs/polarTegions.conf` has been updated accordingly.