### PR TITLE
Add region groups for Arctic ocean and sea-ice regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ environment with the following packages:
  * shapely
  * cartopy >= 0.18.0
  * cartopy\_offlinedata
- * geometric\_features >= 0.1.12
+ * geometric\_features >= 0.1.13
  * gsw
  * pyremap < 0.1.0
  * mpas\_tools >= 0.0.15
@@ -78,7 +78,7 @@ conda config --set channel_priority strict
 conda create -n mpas-analysis python=3.8 numpy scipy "matplotlib>=3.0.2" \
     netCDF4 "xarray>=0.14.1" dask bottleneck lxml "nco>=4.8.1" pyproj \
     pillow cmocean progressbar2 requests setuptools shapely "cartopy>=0.18.0" \
-    cartopy_offlinedata "geometric_features>=0.1.12" gsw "pyremap<0.1.0" \
+    cartopy_offlinedata "geometric_features>=0.1.13" gsw "pyremap<0.1.0" \
     "mpas_tools>=0.0.15" pandas python-dateutil six
 conda activate mpas-analysis
 ```

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - shapely
     - cartopy >=0.18.0
     - cartopy_offlinedata
-    - geometric_features >=0.1.12
+    - geometric_features >=0.1.13
     - gsw
     - pyremap <0.1.0
     - mpas_tools >=0.0.15

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -22,6 +22,8 @@ import mpas_tools.conversion
 from geometric_features import read_feature_collection, GeometricFeatures
 from geometric_features.aggregation.ocean import basins, subbasins, antarctic, \
     ice_shelves
+from geometric_features.aggregation.ocean import arctic as arctic_ocean
+from geometric_features.aggregation.seaice import arctic as arctic_seaice
 
 from mpas_analysis.shared.analysis_task import AnalysisTask
 
@@ -39,7 +41,8 @@ def get_region_info(regionGroup, config):
     ----------
     regionGroup : str
         The name of a region group to get mask features for, one of
-        'Antarctic Regions', 'Ocean Basins', 'Ice Shelves', or 'Ocean Subbasins'
+        'Antarctic Regions', 'Arctic Ocean Regions', 'Arctic Sea Ice Regions',
+        'Ocean Basins', 'Ice Shelves', or 'Ocean Subbasins'
 
     config :  mpas_analysis.configuration.MpasAnalysisConfigParser
         Configuration options
@@ -60,6 +63,12 @@ def get_region_info(regionGroup, config):
     regions = {'Antarctic Regions': {'prefix': 'antarcticRegions',
                                      'date': '20200621',
                                      'function': antarctic},
+               'Arctic Ocean Regions': {'prefix': 'arcticOceanRegions',
+                                        'date': '20201130',
+                                        'function': arctic_ocean},
+               'Arctic Sea Ice Regions': {'prefix': 'arcticSeaIceRegions',
+                                          'date': '20201130',
+                                          'function': arctic_seaice},
                'Ocean Basins': {'prefix': 'oceanBasins',
                                 'date': '20200621',
                                 'function': basins},


### PR DESCRIPTION
This merge adds `Arctic Ocean Regions` and `Arctic Sea Ice Regions` as new region groups that can be used to perform regional analysis.  It requires the latest changes from `geometric_features` (https://github.com/MPAS-Dev/geometric_features/pull/158).

closes #712