### PR TITLE
Add capability to limit the lengths of plot titles

### DIFF
--- a/docs/tasks/timeSeriesOHCAnomaly.rst
+++ b/docs/tasks/timeSeriesOHCAnomaly.rst
@@ -88,7 +88,7 @@ depth integrated time series will be read in with a file prefix given by
 except of debugging purposes.
 
 Recently, a right-hand axis and an associated set of lines has been added to the
-OHC anomaly time series.  This axis and these lines shows the equivalent
+OHC anomaly time series.  This axis and these lines show the equivalent
 top-of-atmosphere energy flux (:math:`W/m^2`) that the ocean heat anomaly would
 induce.
 

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -458,6 +458,10 @@ def run_analysis(config, analyses):  # {{{
 
     mainRunName = config.get('runs', 'mainRunName')
 
+    if len(mainRunName) > 55:
+        print('Warning: The main run name is quite long and will be'
+              'truncated in some plots: \n{}\n\n'.format(mainRunName))
+
     configFileName = '{}/config.{}'.format(logsDirectory, mainRunName)
 
     configFile = open(configFileName, 'w')

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -296,14 +296,14 @@ plotTitles = ['Arctic', 'Equatorial (15S-15N)', 'Southern Ocean', 'Nino 3',
 ## modules
 
 # title and axis font properties for single-panel plots
-titleFontSize = 20
+titleFontSize = 16
 titleFontColor = black
 titleFontWeight = normal
-axisFontSize = 16
+axisFontSize = 12
 
 # title and axis font properties for three-panel plots
-threePanelTitleFontSize = 20
-threePanelPlotTitleFontSize = 16
+threePanelTitleFontSize = 16
+threePanelPlotTitleFontSize = 14
 threePanelTitleFontColor = black
 threePanelTitleFontWeight = normal
 threePanelAxisFontSize = 12

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -261,7 +261,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             write_netcdf(annualClimatology, outFileName)
 
         # **** Plot MHT ****
-        maxTitleLength = 80
+        maxTitleLength = 70
         self.logger.info('   Plot global MHT...')
         # Plot 1D MHT (zonally averaged, depth integrated)
         x = binBoundaryMerHeatTrans

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -18,6 +18,7 @@ import os
 
 from mpas_analysis.shared.plot import plot_vertical_section, plot_1D, savefig
 
+
 from mpas_analysis.shared.io.utility import make_directories, build_obs_path
 from mpas_analysis.shared.io import write_netcdf
 
@@ -260,6 +261,7 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
             write_netcdf(annualClimatology, outFileName)
 
         # **** Plot MHT ****
+        maxTitleLength = 80
         self.logger.info('   Plot global MHT...')
         # Plot 1D MHT (zonally averaged, depth integrated)
         x = binBoundaryMerHeatTrans
@@ -323,7 +325,8 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
         plot_1D(config, xArrays, fieldArrays, errArrays,
                 lineColors=lineColors, lineWidths=lineWidths,
                 legendText=legendText, title=title, xlabel=xLabel,
-                ylabel=yLabel, fileout=figureName, xLim=xLimGlobal)
+                ylabel=yLabel, fileout=figureName, xLim=xLimGlobal,
+                maxTitleLength=maxTitleLength)
 
         self._write_xml(filePrefix)
 
@@ -352,7 +355,8 @@ class MeridionalHeatTransport(AnalysisTask):  # {{{
                                   title=title, xlabel=xLabel, ylabel=yLabel,
                                   xLim=xLimGlobal,
                                   yLim=depthLimGlobal, invertYAxis=False,
-                                  movingAveragePoints=movingAveragePoints)
+                                  movingAveragePoints=movingAveragePoints,
+                                  maxTitleLength=maxTitleLength)
 
             savefig(outFileName)
 

--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -46,6 +46,7 @@ from mpas_analysis.shared.climatology import compute_climatology, \
     get_masked_mpas_climatology_file_name
 
 from mpas_analysis.shared.plot.colormap import register_custom_colormaps
+from mpas_analysis.shared.plot.title import limit_title
 
 
 class RegionalTSDiagrams(AnalysisTask):  # {{{
@@ -1039,6 +1040,7 @@ class PlotRegionTSDiagramSubtask(AnalysisTask):
             z = plotFields[index]['z']
             volume = plotFields[index]['vol']
             title = plotFields[index]['title']
+            title = limit_title(title, max_title_length=60)
 
             CS = plt.contour(SP, PT, neutralDensity, contours, linewidths=1.,
                              colors='k', zorder=2)

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -756,7 +756,8 @@ class PlotMOCClimatologySubtask(AnalysisTask):  # {{{
                 diffTitle=diffTitle,
                 xlabel=xLabel,
                 ylabel=yLabel,
-                movingAveragePoints=movingAveragePointsClimatological)
+                movingAveragePoints=movingAveragePointsClimatological,
+                maxTitleLength=70)
 
             savefig(outFileName)
 
@@ -1378,7 +1379,8 @@ class PlotMOCTimeSeriesSubtask(AnalysisTask):  # {{{
         self.logger.info('   Plot time series of max Atlantic MOC at 26.5N...')
         xLabel = 'Time [years]'
         yLabel = '[Sv]'
-        title = r'Max Atlantic MOC at $26.5\degree$N\n {}'.format(mainRunName)
+        title = '{}\n{}'.format(r'Max Atlantic MOC at $26.5\degree$N',
+                                mainRunName)
         filePrefix = self.filePrefix
 
         outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
@@ -1415,7 +1417,8 @@ class PlotMOCTimeSeriesSubtask(AnalysisTask):  # {{{
                                  lineColors=lineColors, lineWidths=lineWidths,
                                  legendText=legendText,
                                  firstYearXTicks=firstYearXTicks,
-                                 yearStrideXTicks=yearStrideXTicks)
+                                 yearStrideXTicks=yearStrideXTicks,
+                                 maxTitleLength=90)
 
         savefig(outFileName)
 

--- a/mpas_analysis/shared/plot/climatology_map.py
+++ b/mpas_analysis/shared/plot/climatology_map.py
@@ -29,6 +29,7 @@ import cartopy
 from cartopy.util import add_cyclic_point
 
 from mpas_analysis.shared.plot.colormap import setup_colormap
+from mpas_analysis.shared.plot.title import limit_title
 
 
 def plot_polar_comparison(
@@ -51,7 +52,8 @@ def plot_polar_comparison(
         titleFontSize=None,
         figsize=None,
         dpi=None,
-        vertical=False):
+        vertical=False,
+        maxTitleLength=60):
     """
     Plots a data set around either the north or south pole.
 
@@ -108,6 +110,10 @@ def plot_polar_comparison(
     vertical : bool, optional
         whether the subplots should be stacked vertically rather than
         horizontally
+
+    maxTitleLength : int, optional
+        the maximum number of characters in the title, beyond which it is
+        truncated with a trailing ellipsis
     """
     # Authors
     # -------
@@ -122,6 +128,7 @@ def plot_polar_comparison(
         data_crs = cartopy.crs.PlateCarree()
         ax.set_extent(extent, crs=data_crs)
 
+        title = limit_title(title, maxTitleLength)
         ax.set_title(title, y=1.06, **plottitle_font)
 
         gl = ax.gridlines(crs=data_crs, color='k', linestyle=':', zorder=5,
@@ -182,7 +189,7 @@ def plot_polar_comparison(
         subplots = [311, 312, 313]
     else:
         if figsize is None:
-            figsize = (22, 8.5)
+            figsize = (22, 7.5)
         subplots = [131, 132, 133]
 
     fig = plt.figure(figsize=figsize, dpi=dpi)
@@ -247,7 +254,8 @@ def plot_global_comparison(
         figsize=None,
         dpi=None,
         lineWidth=1,
-        lineColor='black'):
+        lineColor='black',
+        maxTitleLength=70):
     """
     Plots a data set as a longitude/latitude map.
 
@@ -302,6 +310,10 @@ def plot_global_comparison(
 
     lineColor : str, optional
         the color of contour lines (if specified)
+
+    maxTitleLength : int, optional
+        the maximum number of characters in the title, beyond which it is
+        truncated with a trailing ellipsis
     """
     # Authors
     # -------
@@ -312,6 +324,7 @@ def plot_global_comparison(
 
         ax.set_extent(extent, crs=projection)
 
+        title = limit_title(title, maxTitleLength)
         ax.set_title(title, y=1.06, **plottitle_font)
 
         gl = ax.gridlines(crs=projection, color='k', linestyle=':', zorder=5,
@@ -420,7 +433,8 @@ def plot_polar_projection_comparison(
         lineWidth=0.5,
         lineColor='black',
         vertical=False,
-        hemisphere='north'):
+        hemisphere='north',
+        maxTitleLength=55):
     """
     Plots a data set as a longitude/latitude map.
 
@@ -483,6 +497,13 @@ def plot_polar_projection_comparison(
     vertical : bool, optional
         whether the subplots should be stacked vertically rather than
         horizontally
+
+    hemisphere : {'north', 'south'}, optional
+        the hemisphere to plot
+
+    maxTitleLength : int, optional
+        the maximum number of characters in the title, beyond which it is
+        truncated with a trailing ellipsis
     """
     # Authors
     # -------
@@ -491,6 +512,7 @@ def plot_polar_projection_comparison(
     def plot_panel(ax, title, array, colormap, norm, levels, ticks, contours,
                    lineWidth, lineColor):
 
+        title = limit_title(title, maxTitleLength)
         ax.set_title(title, y=1.06, **plottitle_font)
 
         ax.set_extent(extent, crs=projection)

--- a/mpas_analysis/shared/plot/oned.py
+++ b/mpas_analysis/shared/plot/oned.py
@@ -110,7 +110,9 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
         if legendText is None:
             label = None
         else:
-            label = limit_title(legendText[dsIndex], maxTitleLength)
+            label = legendText[dsIndex]
+            if label is not None:
+                label = limit_title(label, maxTitleLength)
             plotLegend = True
         if lineColors is None:
             color = 'k'

--- a/mpas_analysis/shared/plot/oned.py
+++ b/mpas_analysis/shared/plot/oned.py
@@ -24,6 +24,8 @@ from __future__ import absolute_import, division, print_function, \
 
 import matplotlib.pyplot as plt
 
+from mpas_analysis.shared.plot.title import limit_title
+
 
 def plot_1D(config, xArrays, fieldArrays, errArrays,
             lineColors=None, lineStyles=None, markers=None, lineWidths=None,
@@ -32,7 +34,8 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
             figsize=(10, 4), dpi=None,
             xLim=None,
             yLim=None,
-            invertYAxis=False):  # {{{
+            invertYAxis=False,
+            maxTitleLength=80):  # {{{
     """
     Plots a 1D line plot with error bars if available.
 
@@ -82,6 +85,10 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
 
     invertYAxis : logical, optional
         if True, invert Y axis
+
+    maxTitleLength : int, optional
+        the maximum number of characters in the title and legend, beyond which
+        they are truncated with a trailing ellipsis
     """
     # Authors
     # -------
@@ -103,7 +110,7 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
         if legendText is None:
             label = None
         else:
-            label = legendText[dsIndex]
+            label = limit_title(legendText[dsIndex], maxTitleLength)
             plotLegend = True
         if lineColors is None:
             color = 'k'
@@ -139,6 +146,7 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
                   'color': config.get('plot', 'titleFontColor'),
                   'weight': config.get('plot', 'titleFontWeight')}
     if title is not None:
+        title = limit_title(title, max_title_length=maxTitleLength)
         plt.title(title, **title_font)
     if xlabel is not None:
         plt.xlabel(xlabel, **axis_font)
@@ -153,12 +161,10 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
     if yLim:
         plt.ylim(yLim)
 
-    if (fileout is not None):
+    if fileout is not None:
         plt.savefig(fileout, dpi=dpi, bbox_inches='tight', pad_inches=0.1)
 
-    plt.close()
-
-    return  # }}}
+    plt.close()  # }}}
 
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python

--- a/mpas_analysis/shared/plot/time_series.py
+++ b/mpas_analysis/shared/plot/time_series.py
@@ -28,6 +28,7 @@ from mpas_analysis.shared.timekeeping.utility import date_to_days
 from mpas_analysis.shared.constants import constants
 
 from mpas_analysis.shared.plot.ticks import plot_xtick_format
+from mpas_analysis.shared.plot.title import limit_title
 
 
 def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
@@ -37,7 +38,8 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
                              titleFontSize=None, figsize=(15, 6), dpi=None,
                              firstYearXTicks=None, yearStrideXTicks=None,
                              maxXTicks=20, obsMean=None, obsUncertainty=None,
-                             obsLegend=None, legendLocation='lower left'):
+                             obsLegend=None, legendLocation='lower left',
+                             maxTitleLength=90):
     """
     Plots the list of time series data sets.
 
@@ -108,6 +110,10 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
 
     legendLocation : str, optional
         The location of the legend (see ``pyplot.legend()`` for details)
+
+    maxTitleLength : int, optional
+        the maximum number of characters in the title, beyond which it is
+        truncated with a trailing ellipsis
 
     Returns
     -------
@@ -229,6 +235,7 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
         plt.plot(x, np.zeros(np.size(x)), 'k-', linewidth=1.2, zorder=1)
 
     if title is not None:
+        title = limit_title(title, maxTitleLength)
         plt.title(title, **title_font)
     if xlabel is not None:
         plt.xlabel(xlabel, **axis_font)
@@ -243,7 +250,7 @@ def timeseries_analysis_plot_polar(config, dsvalues, title,
                                    lineStyles=None, markers=None,
                                    lineWidths=None, legendText=None,
                                    titleFontSize=None, figsize=(15, 6),
-                                   dpi=None):
+                                   dpi=None, maxTitleLength=90):
     """
     Plots the list of time series data sets on a polar plot.
 
@@ -278,6 +285,10 @@ def timeseries_analysis_plot_polar(config, dsvalues, title,
     dpi : int, optional
         the number of dots per inch of the figure, taken from section ``plot``
         option ``dpi`` in the config file by default
+
+    maxTitleLength : int, optional
+        the maximum number of characters in the title, beyond which it is
+        truncated with a trailing ellipsis
 
     Returns
     -------
@@ -355,6 +366,7 @@ def timeseries_analysis_plot_polar(config, dsvalues, title,
     ax.set_xticklabels(constants.abrevMonthNames, minor=True)
 
     if titleFontSize is None:
+        title = limit_title(title, maxTitleLength)
         titleFontSize = config.get('plot', 'titleFontSize')
 
     title_font = {'size': titleFontSize,

--- a/mpas_analysis/shared/plot/time_series.py
+++ b/mpas_analysis/shared/plot/time_series.py
@@ -153,7 +153,9 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
         if legendText is None:
             label = None
         else:
-            label = limit_title(legendText[dsIndex], maxTitleLength)
+            label = legendText[dsIndex]
+            if label is not None:
+                label = limit_title(label, maxTitleLength)
             labelCount += 1
         if lineColors is None:
             color = 'k'
@@ -319,7 +321,9 @@ def timeseries_analysis_plot_polar(config, dsvalues, title,
         if legendText is None:
             label = None
         else:
-            label = limit_title(legendText[dsIndex], maxTitleLength)
+            label = legendText[dsIndex]
+            if label is not None:
+                label = limit_title(label, maxTitleLength)
             labelCount += 1
         if lineColors is None:
             color = 'k'

--- a/mpas_analysis/shared/plot/time_series.py
+++ b/mpas_analysis/shared/plot/time_series.py
@@ -112,8 +112,8 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
         The location of the legend (see ``pyplot.legend()`` for details)
 
     maxTitleLength : int, optional
-        the maximum number of characters in the title, beyond which it is
-        truncated with a trailing ellipsis
+        the maximum number of characters in the title and legend, beyond which
+        they are truncated with a trailing ellipsis
 
     Returns
     -------
@@ -153,7 +153,7 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
         if legendText is None:
             label = None
         else:
-            label = legendText[dsIndex]
+            label = limit_title(legendText[dsIndex], maxTitleLength)
             labelCount += 1
         if lineColors is None:
             color = 'k'
@@ -287,8 +287,8 @@ def timeseries_analysis_plot_polar(config, dsvalues, title,
         option ``dpi`` in the config file by default
 
     maxTitleLength : int, optional
-        the maximum number of characters in the title, beyond which it is
-        truncated with a trailing ellipsis
+        the maximum number of characters in the title and legend, beyond which
+        they are truncated with a trailing ellipsis
 
     Returns
     -------
@@ -319,7 +319,7 @@ def timeseries_analysis_plot_polar(config, dsvalues, title,
         if legendText is None:
             label = None
         else:
-            label = legendText[dsIndex]
+            label = limit_title(legendText[dsIndex], maxTitleLength)
             labelCount += 1
         if lineColors is None:
             color = 'k'

--- a/mpas_analysis/shared/plot/title.py
+++ b/mpas_analysis/shared/plot/title.py
@@ -17,10 +17,11 @@ def limit_title(title, max_title_length):
     title : str
         The title after limiting each line's length
     """
-    parts = list()
-    for part in title.split('\n'):
-        if len(part) > max_title_length:
-            part = '{}...'.format(part[0:max_title_length])
-        parts.append(part)
-    title = '\n'.join(parts)
+    if title is not None:
+        parts = list()
+        for part in title.split('\n'):
+            if len(part) > max_title_length:
+                part = '{}...'.format(part[0:max_title_length])
+            parts.append(part)
+        title = '\n'.join(parts)
     return title

--- a/mpas_analysis/shared/plot/title.py
+++ b/mpas_analysis/shared/plot/title.py
@@ -1,0 +1,26 @@
+
+def limit_title(title, max_title_length):
+    """
+    Limit the length of each line of a tile to the given number of characters,
+    adding an ellipsis if a given line is too long.
+
+    Parameters
+    ----------
+    title : str
+        The title to limit
+
+    max_title_length : str
+        The maximum length of each line of the title
+
+    Returns
+    -------
+    title : str
+        The title after limiting each line's length
+    """
+    parts = list()
+    for part in title.split('\n'):
+        if len(part) > max_title_length:
+            part = '{}...'.format(part[0:max_title_length])
+        parts.append(part)
+    title = '\n'.join(parts)
+    return title

--- a/mpas_analysis/shared/plot/title.py
+++ b/mpas_analysis/shared/plot/title.py
@@ -9,7 +9,7 @@ def limit_title(title, max_title_length):
     title : str
         The title to limit
 
-    max_title_length : str
+    max_title_length : int
         The maximum length of each line of the title
 
     Returns

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -28,6 +28,7 @@ from mpas_analysis.shared.timekeeping.utility import date_to_days
 
 from mpas_analysis.shared.plot.colormap import setup_colormap
 from mpas_analysis.shared.plot.ticks import plot_xtick_format
+from mpas_analysis.shared.plot.title import limit_title
 
 
 def plot_vertical_section_comparison(
@@ -75,7 +76,8 @@ def plot_vertical_section_comparison(
         labelContours=False,
         contourLabelPrecision=1,
         resultSuffix='Result',
-        diffSuffix='Difference'):
+        diffSuffix='Difference',
+        maxTitleLength=70):
     """
     Plots vertical section plots in a three-panel format, comparing model data
     (in modelArray) to some reference dataset (in refArray), which can be
@@ -269,6 +271,10 @@ def plot_vertical_section_comparison(
         a suffix added to the config options related to colormap information
         for the difference field
 
+    maxTitleLength : int, optional
+        the maximum number of characters in the title, beyond which it is
+        truncated with a trailing ellipsis
+
     Returns
     -------
     fig : ``matplotlib.figure.Figure``
@@ -393,7 +399,8 @@ def plot_vertical_section_comparison(
         comparisonContourLineStyle=comparisonContourLineStyle,
         comparisonContourLineColor=comparisonContourLineColor,
         labelContours=labelContours,
-        contourLabelPrecision=contourLabelPrecision)
+        contourLabelPrecision=contourLabelPrecision,
+        maxTitleLength=maxTitleLength)
 
     axes.append(ax)
 
@@ -434,7 +441,8 @@ def plot_vertical_section_comparison(
             calendar=calendar,
             backgroundColor=backgroundColor,
             labelContours=labelContours,
-            contourLabelPrecision=contourLabelPrecision)
+            contourLabelPrecision=contourLabelPrecision,
+            maxTitleLength=maxTitleLength)
 
         axes.append(ax)
 
@@ -474,7 +482,8 @@ def plot_vertical_section_comparison(
             calendar=calendar,
             backgroundColor=backgroundColor,
             labelContours=labelContours,
-            contourLabelPrecision=contourLabelPrecision)
+            contourLabelPrecision=contourLabelPrecision,
+            maxTitleLength=maxTitleLength)
 
         axes.append(ax)
 
@@ -531,7 +540,8 @@ def plot_vertical_section(
         comparisonContourLineStyle=None,
         comparisonContourLineColor=None,
         labelContours=False,
-        contourLabelPrecision=1):  # {{{
+        contourLabelPrecision=1,
+        maxTitleLength=70):  # {{{
     """
     Plots a data set as a x distance (latitude, longitude,
     or spherical distance) vs depth map (vertical section).
@@ -725,6 +735,10 @@ def plot_vertical_section(
     contourLabelPrecision : int, optional
         the precision (in terms of number of figures to the right of the
         decimal point) of contour labels
+
+    maxTitleLength : int, optional
+        the maximum number of characters in the title, beyond which it is
+        truncated with a trailing ellipsis
 
     Returns
     -------
@@ -962,10 +976,13 @@ def plot_vertical_section(
         ax.legend([h1[0], h2[0]], [originalFieldName, comparisonFieldName],
                   loc='upper center', bbox_to_anchor=(0.5, -0.25), ncol=1)
 
-    if (title is not None):
+    if title is not None:
         if plotAsContours and labelContours \
            and contourComparisonFieldArray is None:
+            title = limit_title(title, maxTitleLength-(3+len(colorbarLabel)))
             title = title + " (" + colorbarLabel + ")"
+        else:
+            title = limit_title(title, maxTitleLength)
         if titleFontSize is None:
             titleFontSize = config.get('plot', 'titleFontSize')
         title_font = {'size': titleFontSize,


### PR DESCRIPTION
This should prevent very long run names from changing the sizes of figures.

Some default font sizes were also reduced and figure sizes adjusted to allow for longer panel titles and better relative font size between titles and axes.

closes #765