### PR TITLE
Switch to MPAS-Tools python command-line tools for region mask creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ conda create -n mpas-analysis python=3.8 numpy scipy "matplotlib>=3.0.2" \
     netCDF4 "xarray>=0.14.1" dask bottleneck lxml "nco>=4.8.1" pyproj \
     pillow cmocean progressbar2 requests setuptools shapely "cartopy>=0.18.0" \
     cartopy_offlinedata "geometric_features>=0.1.13" gsw "pyremap<0.1.0" \
-    "mpas_tools>=0.0.15" pandas python-dateutil six
+    "mpas_tools>=0.3.0" pandas python-dateutil six
 conda activate mpas-analysis
 ```
 

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -43,7 +43,7 @@ requirements:
     - geometric_features >=0.3.0
     - gsw
     - pyremap <0.1.0
-    - mpas_tools >=0.0.15
+    - mpas_tools >=0.3.0
     - pandas
     - python-dateutil
     - six

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -22,39 +22,41 @@ requirements:
     - pip
   run:
     - python >=3.7
-    - numpy
-    - scipy
-    - matplotlib-base >=3.0.2
-    - netcdf4
-    - xarray >=0.14.1
-    - dask
     - bottleneck
-    - lxml
-    - nco >=4.8.1
-    - pillow
-    - cmocean
-    - progressbar2
-    - requests
-    - pyproj
-    - setuptools
-    - shapely
     - cartopy >=0.18.0
     - cartopy_offlinedata
+    - cmocean
+    - dask
     - geometric_features >=0.3.0
     - gsw
-    - pyremap <0.1.0
+    - lxml
+    - matplotlib-base >=3.0.2
     - mpas_tools >=0.3.0
+    - nco >=4.8.1
+    - netcdf4
+    - numpy
     - pandas
+    - pillow
+    - progressbar2
+    - pyproj
+    - pyremap <0.1.0
     - python-dateutil
+    - requests
+    - scipy
+    - setuptools
+    - shapely
     - six
+    - xarray >=0.14.1
 
 test:
   requires:
     - pytest
+    - pip
   imports:
     - mpas_analysis
     - pytest
   commands:
+    - pip check
     - pytest --pyargs mpas_analysis
     - mpas_analysis --help
     - download_analysis_data --help

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -194,7 +194,11 @@ texinfo_documents = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-    'xarray': ('http://xarray.pydata.org/en/stable/', None)}
+    'xarray': ('http://xarray.pydata.org/en/stable/', None),
+    'geometric_features':
+        ('http://mpas-dev.github.io/geometric_features/stable/', None),
+    'mpas_tools':
+        ('http://mpas-dev.github.io/MPAS-Tools/stable/', None)}
 
 
 # Build some custom rst files

--- a/docs/config/execute.rst
+++ b/docs/config/execute.rst
@@ -26,6 +26,11 @@ control how tasks are executed within an MPAS-Analysis run::
   # serial, the default)
   mapMpiTasks = 1
 
+  # Multiprocessing method used in python mask creation ("forkserver", "fork" or
+  # "spawn").  We have found that "spawn" is the only one that works in python
+  # 3.7 on Anvil so this is the default
+  multiprocessingMethod = spawn
+
 Parallel Tasks
 --------------
 
@@ -70,5 +75,25 @@ Again, when running MPAS-Analysis on login nodes of supercomputing facilities,
 it is important to be aware of the policies regarding using shared resources.
 On login nodes, ``bck`` may only be appropriate with ``ncclimoThreads`` set to a
 small number and ``mpi`` mode may not work at all.
+
+Parallel Mask Creation
+----------------------
+
+Tasks that involve :ref:`config_region_groups` can generate the masks for each
+region in the group on the fly.  This is done with the mask generation
+command-line tools form MPAS-Tools (see 
+`Mask Creation with Python Multiprocessing <http://mpas-dev.github.io/MPAS-Tools/stable/mesh_conversion.html#mask-creation-with-pthon-multiprocessing>`_),
+which support 3 modes of parallelism: "spawn", "fork" and "forkserver". For
+technical details on these modes, see
+`Contexts and start methods <https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods>`_.
+We have found that "spawn" seems to be the most reliable option on Anvil under
+python 3.7 and 3.8.  Any of these methods works well under python 3.8 but only
+"spawn" was reliable under python 3.7.  Therefore, we use "spawn" as the
+default.
+
+As we gain more experience with this setting, we may update config files for
+specific machines to have different defaults.
+
+
 
 .. _`NetCDF Operators (NCO) package`: http://nco.sourceforge.net/nco.html

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -68,6 +68,11 @@ ncclimoThreads = 12
 # serial, the default)
 mapMpiTasks = 1
 
+# Multiprocessing method used in python mask creation ("forkserver", "fork" or
+# "spawn").  We have found that "spawn" is the only one that works in python
+# 3.7 on Anvil so this is the default
+multiprocessingMethod = spawn
+
 
 [diagnostics]
 ## config options related to observations, mapping files and region files used

--- a/mpas_analysis/shared/regions/compute_region_masks.py
+++ b/mpas_analysis/shared/regions/compute_region_masks.py
@@ -51,7 +51,7 @@ class ComputeRegionMasks(AnalysisTask):
         self.regionMaskSubtasks = {}
 
     def add_mask_subtask(self, regionGroup, obsFileName=None, lonVar='lon',
-                         latVar='lat', meshName=None, useMpasMaskCreator=True):
+                         latVar='lat', meshName=None, useMpasMaskCreator=False):
         """
         Construct the analysis task and adds it as a subtask of the
         ``parentTask``.

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -11,19 +11,14 @@
 
 import os
 import xarray as xr
-import numpy
-import shapely.geometry
 import json
-from multiprocessing import Pool
-import progressbar
-from functools import partial
-import mpas_tools.conversion
 
 from geometric_features import read_feature_collection, GeometricFeatures
 from geometric_features.aggregation import get_aggregator_by_name
+import mpas_tools.conversion
+from mpas_tools.logging import check_call
 
 from mpas_analysis.shared.analysis_task import AnalysisTask
-
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories, get_region_mask
 from mpas_analysis.shared.io import write_netcdf
@@ -47,8 +42,8 @@ def get_feature_list(geojsonFileName):
 
 
 def compute_mpas_region_masks(geojsonFileName, meshFileName, maskFileName,
-                              featureList=None, logger=None, processCount=1,
-                              chunkSize=1000, showProgress=True,
+                              logger=None, processCount=1, 
+                              multiprocessingMethod='spawn', chunkSize=1000,
                               useMpasMaskCreator=False, dir=None):
     """
     Build a region mask file from the given MPAS mesh and geojson file defining
@@ -62,53 +57,23 @@ def compute_mpas_region_masks(geojsonFileName, meshFileName, maskFileName,
         fcMask = read_feature_collection(geojsonFileName)
         dsMasks = mpas_tools.conversion.mask(dsMesh=dsMesh, fcMask=fcMask,
                                              logger=logger, dir=dir)
+        write_netcdf(dsMasks, maskFileName)
 
     else:
-        with xr.open_dataset(meshFileName) as dsMesh:
-            dsMesh = dsMesh[['lonCell', 'latCell']]
-            latCell = numpy.rad2deg(dsMesh.latCell.values)
-
-            # transform longitudes to [-180, 180)
-            lonCell = numpy.mod(numpy.rad2deg(dsMesh.lonCell.values) + 180.,
-                                360.) - 180.
-
-        # create shapely geometry for lonCell and latCell
-        cellPoints = [shapely.geometry.Point(x, y) for x, y in
-                      zip(lonCell, latCell)]
-
-        regionNames, masks, properties, nChar = compute_region_masks(
-            geojsonFileName, cellPoints, maskFileName, featureList, logger,
-            processCount, chunkSize, showProgress)
-
-        nCells = len(cellPoints)
-
-        # create a new data array for masks and another for mask names
-        if logger is not None:
-            logger.info('  Creating and writing masks dataset...')
-        nRegions = len(regionNames)
-        dsMasks = xr.Dataset()
-        dsMasks['regionCellMasks'] = (('nRegions', 'nCells'),
-                                      numpy.zeros((nRegions, nCells), dtype=bool))
-        dsMasks['regionNames'] = (('nRegions'),
-                                  numpy.zeros((nRegions),
-                                              dtype='|S{}'.format(nChar)))
-
-        for index in range(nRegions):
-            regionName = regionNames[index]
-            mask = masks[index]
-            dsMasks['regionCellMasks'][index, :] = mask
-            dsMasks['regionNames'][index] = regionName
-
-        for propertyName in properties:
-            dsMasks[propertyName] = (('nRegions'), properties[propertyName])
-
-    write_netcdf(dsMasks, maskFileName)
+        args = ['compute_mpas_region_masks',
+                '-m', meshFileName,
+                '-g', geojsonFileName,
+                '-o', maskFileName,
+                '-t', 'cell',
+                '--chunk_size', '{}'.format(chunkSize),
+                '--process_count', '{}'.format(processCount),
+                '--multiprocessing_method', '{}'.format(multiprocessingMethod)]
+        check_call(args=args, logger=logger)
 
 
-def compute_lon_lat_region_masks(geojsonFileName, lon, lat, maskFileName,
-                                 featureList=None, logger=None, processCount=1,
-                                 chunkSize=1000, showProgress=True,
-                                 lonDim='lon', latDim='lat'):
+def compute_lon_lat_region_masks(gridFileName, lonVar, latVar, geojsonFileName,
+                                 maskFileName, logger=None, processCount=1,
+                                 multiprocessingMethod='spawn', chunkSize=1000):
     """
     Build a region mask file from the given lon, lat and geojson file defining
     a set of regions.
@@ -116,163 +81,17 @@ def compute_lon_lat_region_masks(geojsonFileName, lon, lat, maskFileName,
     if os.path.exists(maskFileName):
         return
 
-    nLon = len(lon)
-    nLat = len(lat)
-
-    # make sure -180 <= lon < 180
-    lon = numpy.mod(lon + 180., 360.) - 180.
-
-    if lonDim != latDim:
-        lon, lat = numpy.meshgrid(lon, lat)
-
-    # create shapely geometry for lonCell and latCell
-    cellPoints = [shapely.geometry.Point(x, y) for x, y in
-                  zip(lon.ravel(), lat.ravel())]
-
-    regionNames, masks, properties, nChar = compute_region_masks(
-        geojsonFileName, cellPoints, maskFileName, featureList, logger,
-        processCount, chunkSize, showProgress)
-
-    # create a new data array for masks and another for mask names
-    if logger is not None:
-        logger.info('  Creating and writing masks dataset...')
-    nRegions = len(regionNames)
-    dsMasks = xr.Dataset()
-    if lonDim == latDim:
-        dsMasks['regionCellMasks'] = (('nRegions', lonDim),
-                                      numpy.zeros((nRegions, nLon),
-                                                  dtype=bool))
-    else:
-        dsMasks['regionCellMasks'] = (('nRegions', latDim, lonDim),
-                                      numpy.zeros((nRegions, nLat, nLon),
-                                                  dtype=bool))
-
-    dsMasks['regionNames'] = (('nRegions'),
-                              numpy.zeros((nRegions),
-                                          dtype='|S{}'.format(nChar)))
-
-    for index in range(nRegions):
-        regionName = regionNames[index]
-        mask = masks[index]
-        if lonDim == latDim:
-            dsMasks['regionCellMasks'][index, :] = mask
-        else:
-            dsMasks['regionCellMasks'][index, :] = mask.reshape([nLat, nLon])
-        dsMasks['regionNames'][index] = regionName
-
-    for propertyName in properties:
-        dsMasks['{}Regions'.format(propertyName)] = \
-            (('nRegions'), properties[propertyName])
-
-    write_netcdf(dsMasks, maskFileName)
-
-
-def compute_region_masks(geojsonFileName, cellPoints, maskFileName,
-                         featureList=None, logger=None, processCount=1,
-                         chunkSize=1000, showProgress=True):
-    """
-    Build a region mask file from the given mesh and geojson file defining
-    a set of regions.
-    """
-    if os.path.exists(maskFileName):
-        return
-
-    if logger is not None:
-        logger.info('Creating masks file {}'.format(maskFileName))
-
-    if featureList is None:
-        # get a list of features for use by other tasks (e.g. to determine
-        # plot names)
-        featureList = get_feature_list(geojsonFileName)
-
-    nCells = len(cellPoints)
-
-    with open(geojsonFileName) as f:
-        featureData = json.load(f)
-
-    regionNames = []
-    for feature in featureData['features']:
-        name = feature['properties']['name']
-        if name not in featureList:
-            continue
-        regionNames.append(name)
-
-    propertyNames = set()
-    for feature in featureData['features']:
-        for propertyName in feature['properties']:
-            if propertyName not in ['name', 'author', 'tags', 'component',
-                                    'object']:
-                propertyNames.add(propertyName)
-
-    properties = {}
-    for propertyName in propertyNames:
-        properties[propertyName] = []
-        for feature in featureData['features']:
-            if propertyName in feature['properties']:
-                propertyVal = feature['properties'][propertyName]
-                properties[propertyName].append(propertyVal)
-            else:
-                properties[propertyName].append('')
-
-    if logger is not None:
-        logger.info('  Computing masks from {}...'.format(geojsonFileName))
-
-    masks = []
-
-    nChar = 0
-    for feature in featureData['features']:
-        name = feature['properties']['name']
-        if name not in featureList:
-            continue
-
-        if logger is not None:
-            logger.info('      {}'.format(name))
-
-        shape = shapely.geometry.shape(feature['geometry'])
-        if processCount == 1:
-            mask = _contains(shape, cellPoints)
-        else:
-            nChunks = int(numpy.ceil(nCells / chunkSize))
-            chunks = []
-            indices = [0]
-            for iChunk in range(nChunks):
-                start = iChunk * chunkSize
-                end = min((iChunk + 1) * chunkSize, nCells)
-                chunks.append(cellPoints[start:end])
-                indices.append(end)
-
-            partial_func = partial(_contains, shape)
-            pool = Pool(processCount)
-
-            if showProgress:
-                widgets = ['  ', progressbar.Percentage(), ' ',
-                           progressbar.Bar(), ' ', progressbar.ETA()]
-                bar = progressbar.ProgressBar(widgets=widgets,
-                                              max_value=nChunks).start()
-            else:
-                bar = None
-
-            mask = numpy.zeros((nCells,), bool)
-            for iChunk, maskChunk in \
-                    enumerate(pool.imap(partial_func, chunks)):
-                mask[indices[iChunk]:indices[iChunk + 1]] = maskChunk
-                if showProgress:
-                    bar.update(iChunk + 1)
-            if showProgress:
-                bar.finish()
-            pool.terminate()
-
-        nChar = max(nChar, len(name))
-
-        masks.append(mask)
-
-    return regionNames, masks, properties, nChar  # }}}
-
-
-def _contains(shape, cellPoints):
-    mask = numpy.array([shape.contains(point) for point in cellPoints],
-                       dtype=bool)
-    return mask
+    args = ['compute_lon_lat_region_masks',
+            '-m', gridFileName,
+            '--lon', lonVar,
+            '--lat', latVar,
+            '-g', geojsonFileName,
+            '-o', maskFileName,
+            '-t', 'cell',
+            '--chunk_size', '{}'.format(chunkSize),
+            '--process_count', '{}'.format(processCount),
+            '--multiprocessing_method', '{}'.format(multiprocessingMethod)]
+    check_call(args=args, logger=logger)
 
 
 class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
@@ -296,9 +115,6 @@ class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
 
     outFileSuffix : str
         The suffix for the resulting mask file
-
-    featureList : list of str
-        A list of features to include or ``None`` for all features
 
     maskFileName : str
         The name of the output mask file
@@ -371,7 +187,6 @@ class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
             tags=[])
 
         self.regionGroup = regionGroup
-        self.featureList = None
         self.subprocessCount = subprocessCount
 
         self.obsFileName = obsFileName
@@ -469,7 +284,7 @@ class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
 
         if not os.path.exists(self.maskFileName):
             # no cached mask file, so let's see if there's already one in the
-            # masks subfolder of the output directory
+            # masks subdirectory of the output directory
 
             maskSubdirectory = build_config_full_path(self.config, 'output',
                                                       'maskSubdirectory')
@@ -496,10 +311,8 @@ class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
         # make the geojson file if it doesn't exist
         self.make_region_mask()
 
-        if self.featureList is None:
-            # get a list of features for use by other tasks (e.g. to determine
-            # plot names)
-            self.featureList = get_feature_list(self.geojsonFileName)
+        multiprocessingMethod = self.config.get('execute',
+                                                'multiprocessingMethod')
 
         if self.useMpasMesh:
 
@@ -509,27 +322,16 @@ class ComputeRegionMasksSubtask(AnalysisTask):  # {{{
 
             compute_mpas_region_masks(
                 self.geojsonFileName, self.obsFileName, self.maskFileName,
-                self.featureList, self.logger, self.subprocessCount,
-                showProgress=False, useMpasMaskCreator=self.useMpasMaskCreator,
+                self.logger, self.subprocessCount,
+                multiprocessingMethod=multiprocessingMethod,
+                useMpasMaskCreator=self.useMpasMaskCreator,
                 dir=maskSubdirectory)
         else:
-
-            dsGrid = xr.open_dataset(self.obsFileName)
-            latVar = dsGrid[self.latVar]
-            lonVar = dsGrid[self.lonVar]
-            if len(latVar.dims) > 1 or len(lonVar.dims) > 1:
-                raise ValueError('Masking does not support multidimensional'
-                                 'lat/lon with dims {}'.format(latVar.dims))
-
-            latDim = latVar.dims[0]
-            lonDim = lonVar.dims[0]
-            lat = latVar.values
-            lon = lonVar.values
-
             compute_lon_lat_region_masks(
-                self.geojsonFileName, lon, lat, self.maskFileName,
-                self.featureList, self.logger, self.subprocessCount,
-                showProgress=False, lonDim=lonDim, latDim=latDim)
+                self.obsFileName, self.lonVar, self.latVar,
+                self.geojsonFileName, self.maskFileName, self.logger,
+                self.subprocessCount,
+                multiprocessingMethod=multiprocessingMethod)
 
     # }}}
 

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -42,7 +42,7 @@ def get_feature_list(geojsonFileName):
 
 
 def compute_mpas_region_masks(geojsonFileName, meshFileName, maskFileName,
-                              logger=None, processCount=1, 
+                              logger=None, processCount=1,
                               multiprocessingMethod='spawn', chunkSize=1000,
                               useMpasMaskCreator=False, dir=None):
     """

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,28 @@ import os
 import re
 
 
+install_requires = \
+    ['bottleneck',
+     'cartopy>=0.18.0',
+     'cmocean',
+     'dask',
+     'gsw',
+     'lxml',
+     'matplotlib >=3.0.2',
+     'netcdf4',
+     'numpy',
+     'pandas',
+     'pillow',
+     'progressbar2',
+     'pyproj',
+     'python-dateutil',
+     'requests',
+     'scipy',
+     'setuptools',
+     'shapely',
+     'six',
+     'xarray>=0.14.1']
+
 here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'mpas_analysis', '__init__.py')) as f:
     init_file = f.read()
@@ -31,7 +53,7 @@ setup(name='mpas_analysis',
       author_email='mpas-developers@googlegroups.com',
       license='BSD',
       classifiers=[
-          'Development Status :: 3 - Alpha',
+          'Development Status :: 5 - Production/Stable',
           'License :: OSI Approved :: BSD License',
           'Operating System :: OS Independent',
           'Intended Audience :: Science/Research',
@@ -40,6 +62,7 @@ setup(name='mpas_analysis',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
           'Topic :: Scientific/Engineering',
       ],
       packages=find_packages(),
@@ -52,10 +75,7 @@ setup(name='mpas_analysis',
                     'mpas_analysis.shared.plot':
                         ['ScientificColourMaps5/*/*.txt',
                          'SciVisColorColormaps/*.xml']},
-      install_requires=['numpy', 'scipy', 'matplotlib', 'netCDF4', 'xarray',
-                        'dask', 'lxml',
-                        'pyproj', 'pillow', 'cmocean', 'progressbar2',
-                        'requests', 'shapely', 'cartopy', 'geometric_features'],
+      install_requires=install_requires,
       entry_points={'console_scripts':
                     ['mpas_analysis = mpas_analysis.__main__:main',
                      'download_analysis_data = '


### PR DESCRIPTION
Simulations with large meshes and without cached region masks have been hanging.  This PR is expected to make mask creation reliable and efficient for large meshes.

All region mask creation is with the command-line tools.  Transport transects are still done with `mpas_tools.mesh.conversion.mask` (which uses the `MpasMaskCreator.x` c++ tool) because the `edgeSign` variable produced by this approach is needed, and the python tool for creating transect masks doesn't yet produce `edgeSign`.

A new config option is added, `[execute]/multiprocessingMethod`, which specifies which python multiprocessing method (`spawn`, `fork` or `forkserver`) is used.  For now, `spawn` seems to work well on all machines.  `fork` and `forkserver` were found to not work well on Anvil with python 3.7 (but were fine with python 3.8).  All methods and python versions worked fine on Chrysalis.  Only `spawn` has been tested on other machines so far.

This merge also includes some significant clean-up to the `setup.py` and `recipe/meta.yaml` including alphabetizing the dependencies, adding all that are available on pypi to `setup.py`, and adding `pip check` to make sure the expected dependencies are in the environment. (conda-forge is trying to add `pip check` to as many packages as possible: https://github.com/conda-forge/conda-forge.github.io/issues/962.)

A bit of clean-up and enhancements to the testing suites uncovered while testing this PR has also been included.
