### PR TITLE
Switch to using geometric_features aggregation lookup

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - shapely
     - cartopy >=0.18.0
     - cartopy_offlinedata
-    - geometric_features >=0.1.13
+    - geometric_features >=0.3.0
     - gsw
     - pyremap <0.1.0
     - mpas_tools >=0.0.15

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -284,7 +284,6 @@ Regions
    compute_region_masks.ComputeRegionMasks
    compute_region_masks_subtask.ComputeRegionMasksSubtask
    compute_region_masks_subtask.get_feature_list
-   compute_region_masks_subtask.get_region_info
 
 Timekeeping
 -----------

--- a/docs/config/regions.rst
+++ b/docs/config/regions.rst
@@ -41,7 +41,7 @@ Currently, seven analysis tasks (:ref:`task_climatologyMapAntarcticMelt`,
 :ref:`task_timeSeriesAntarcticMelt`, and :ref:`task_timeSeriesOceanRegions`)
 use masks that define regions in an MPAS mesh as part of their analysis.  Most
 of these region group are defined in
-:py:func:`mpas_analysis.shared.regions.compute_region_masks_subtask.get_region_info()`.
+:py:func:`geometric_features.aggregation.get_aggregator_by_name()`.
 Several tasks (:ref:`task_hovmollerOceanRegions`,
 :ref:`task_oceanRegionalProfiles`, :ref:`task_regionalTSDiagrams`, and
 :ref:`task_timeSeriesOceanRegions`) can use any of the defined region groups.

--- a/docs/tasks/hovmollerOceanRegions.rst
+++ b/docs/tasks/hovmollerOceanRegions.rst
@@ -184,7 +184,7 @@ The following configuration options are available for this task:
 
 The ``[hovmollerOceanRegions]`` section contains a list of ``regionGroups``,
 one or more of the :ref:`config_region_groups` defined in
-:py:func:`mpas_analysis.shared.regions.compute_region_masks_subtask.get_region_info()`.
+:py:func:`geometric_features.aggregation.get_aggregator_by_name()`.
 
 For each region group, there is a corresponding section
 ``[hovmoller<RegionGroup>]``, where ``<RegionGroup>`` is the name of the region

--- a/docs/tasks/oceanRegionalProfiles.rst
+++ b/docs/tasks/oceanRegionalProfiles.rst
@@ -66,7 +66,7 @@ The following configuration options are available for this task:
 
 The ``[oceanRegionalProfiles]`` section contains a list of ``regionGroups``,
 one or more of the :ref:`config_region_groups` defined in
-:py:func:`mpas_analysis.shared.regions.compute_region_masks_subtask.get_region_info()`.
+:py:func:`geometric_features.aggregation.get_aggregator_by_name()`.
 
 For each region group, there is a corresponding section
 ``[profiles<RegionGroup>]``, where ``<RegionGroup>`` is the name of the region

--- a/mpas_analysis/shared/regions/__init__.py
+++ b/mpas_analysis/shared/regions/__init__.py
@@ -1,5 +1,5 @@
 from mpas_analysis.shared.regions.compute_region_masks_subtask \
-    import ComputeRegionMasksSubtask, get_feature_list, get_region_info
+    import ComputeRegionMasksSubtask, get_feature_list
 
 from mpas_analysis.shared.regions.compute_region_masks \
     import ComputeRegionMasks

--- a/mpas_analysis/shared/transects/__init__.py
+++ b/mpas_analysis/shared/transects/__init__.py
@@ -1,2 +1,2 @@
 from mpas_analysis.shared.transects.compute_transect_masks_subtask \
-    import ComputeTransectMasksSubtask, get_transect_info
+    import ComputeTransectMasksSubtask


### PR DESCRIPTION
This will allow the same process to be used in MPAS-Analysis and compass for creating region masks, meaning the correct region masks for MPAS-Analysis can be generated along with new meshes in compass.