### PR TITLE
Improve performance of  timeSeriesTransport task

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -1316,6 +1316,10 @@ movingAverageMonths = 1
 
 # yearStrideXTicks = 1
 
+# The number of parallel tasks occupied by each timeSeriesTransport task.
+# Analysis may run faster for large meshes when this value is set to 2 or 3
+subprocessCount = 1
+
 
 [regionalTSDiagrams]
 ## options related to plotting T/S diagrams of ocean regions


### PR DESCRIPTION
The optimizations include precomputing transect indices and load time series data files before extracting specific transects and computing on them, rather trying to extract transects and then load only that data.
