### PR TITLE
Switch to python transect masks

### DIFF
--- a/mpas_analysis/ocean/time_series_transport.py
+++ b/mpas_analysis/ocean/time_series_transport.py
@@ -319,9 +319,8 @@ class ComputeTransportSubtask(AnalysisTask):  # {{{
             # select the current transect
             dsMask = dsTransectMask.isel(nTransects=[transectIndex])
             dsMask.load()
-            edgeIndices = dsMask.transectEdgeGlobalIDs - 1
-            edgeIndices = edgeIndices.where(edgeIndices >= 0,
-                                            drop=True).astype(int)
+            edgeIndices = numpy.flatnonzero(dsMask.transectEdgeMasks.values)
+            edgeIndices = edgeIndices[edgeIndices >= 0].astype(int)
             edgeSign = dsMask.transectEdgeMaskSigns.isel(
                 nEdges=edgeIndices)
 
@@ -372,7 +371,7 @@ class ComputeTransportSubtask(AnalysisTask):  # {{{
 
                 # convert from m^3/s to Sv
                 transport = (constants.m3ps_to_Sv * edgeTransport.sum(
-                    dim=['maxEdgesInTransect', 'nVertLevels']))
+                    dim=['nEdges', 'nVertLevels']))
 
                 dsOut = xarray.Dataset()
                 dsOut['transport'] = transport

--- a/mpas_analysis/shared/plot/colormap.py
+++ b/mpas_analysis/shared/plot/colormap.py
@@ -456,8 +456,9 @@ def _read_xml_colormap(xmlFile, mapName):
 
 
 def _register_colormap_and_reverse(mapName, cmap):
-    plt.register_cmap(mapName, cmap)
-    plt.register_cmap('{}_r'.format(mapName), cmap.reversed())
+    if mapName not in plt.colormaps():
+        plt.register_cmap(mapName, cmap)
+        plt.register_cmap('{}_r'.format(mapName), cmap.reversed())
 
 
 def _plot_color_gradients():

--- a/mpas_analysis/shared/transects/compute_transect_masks_subtask.py
+++ b/mpas_analysis/shared/transects/compute_transect_masks_subtask.py
@@ -32,7 +32,7 @@ from mpas_analysis.shared.regions import get_feature_list
 def compute_mpas_transect_masks(geojsonFileName, meshFileName, maskFileName,
                                 logger=None, processCount=1, chunkSize=1000,
                                 subdivisionThreshold=10e3,
-                                useMpasMaskCreator=True,
+                                useMpasMaskCreator=False,
                                 dir=None):
     """
     Build a transect mask file from the given MPAS mesh and geojson file \
@@ -56,10 +56,11 @@ def compute_mpas_transect_masks(geojsonFileName, meshFileName, maskFileName,
                 '-m', meshFileName,
                 '-g', geojsonFileName,
                 '-o', maskFileName,
-                '-t', 'cell',
+                '-t', 'edge',
                 '-s', '{}'.format(subdivisionThreshold),
                 '--chunk_size', '{}'.format(chunkSize),
-                '--process_count', '{}'.format(processCount)]
+                '--process_count', '{}'.format(processCount),
+                '--add_edge_sign']
         check_call(args, logger=logger)
 
 


### PR DESCRIPTION
Now that edge signs are available in python transect masks, we should use these instead.  They are more accurate and should be more efficient to compute for big meshes.

Since the python mask creator doesn't produce a series of edge indices, the computation of the transport has been updated to use the edge masks instead.

A large number of warnings appeared in some log files related to trying to re-add color maps.  A fix to remove these warnings is included here for convenience.