### PR TITLE
Fix indexing issues with the MOC

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -734,7 +734,7 @@ contourLevelsDifference = np.arange(-5., 6., 2.)
 ## options related to plotting the Global MOC
 
 # Minium value of latitudinal extent for MOC streamfunction plot
-latBinMin = -80.
+latBinMin = -35.
 # Maximum value of latitudinal extent for MOC streamfunction plot
 latBinMax = 70.
 # Size of latitude bins over which MOC streamfunction is integrated

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -731,7 +731,7 @@ colorbarLevelsDifference = [-5, -3, -2, -1, -0.1, 0, 0.1, 1, 2, 3, 5]
 contourLevelsDifference = np.arange(-5., 6., 2.)
 
 [streamfunctionMOCIndoPacific]
-## options related to plotting the Global MOC
+## options related to plotting the IndoPacific MOC
 
 # Minium value of latitudinal extent for MOC streamfunction plot
 latBinMin = -35.

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -746,7 +746,7 @@ colormapNameResult = RdYlBu_r
 # whether the colormap is indexed or continuous
 colormapTypeResult = indexed
 # colormap indices for contour color
-colormapIndicesResult = [0, 40, 80, 110, 140, 170, 200, 230, 255]
+colormapIndicesResult = [0, 20, 40, 80, 110, 140, 170, 200, 230, 242, 255]
 # colorbar levels/values for contour boundaries
 colorbarLevelsResult = [-5, -2, 0, 2, 5, 8, 10, 12, 14, 18]
 # contour line levels (use [] for automatic contour selection, 'none' for no

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -429,8 +429,9 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
         dsMask = xr.open_dataset(self.maskSubtask.maskAndTransectFileName)
         regionIndices = {}
         for iRegion in range(dsMask.sizes['nRegions']):
-            regionInFile = dsMask.regionNames[iRegion].values.astype('U')
-            regionIndices[regionInFile] = iRegion
+            regionInFile = str(dsMask.regionNames[iRegion].values.astype('U'))
+            region = regionInFile.replace('_MOC', '')
+            regionIndices[region] = iRegion
 
         # Create dictionary for MOC climatology (NB: need this form
         # in order to convert it to xarray dataset later in the script)
@@ -1540,8 +1541,9 @@ def _build_region_mask_dict(regionMaskFile, regionNames, mpasMeshName, logger):
 
     regionIndices = {}
     for iRegion in range(dsMask.sizes['nRegions']):
-        regionInFile = dsMask.regionNames[iRegion].values.astype('U')
-        regionIndices[regionInFile] = iRegion
+        regionInFile = str(dsMask.regionNames[iRegion].values.astype('U'))
+        region = regionInFile.replace('_MOC', '')
+        regionIndices[region] = iRegion
 
     dictRegion = {}
     for region in regionNames:
@@ -1554,7 +1556,7 @@ def _build_region_mask_dict(regionMaskFile, regionNames, mpasMeshName, logger):
         transectEdgeGlobalIDs = \
             dsMask.transectEdgeGlobalIDs.isel(nTransects=iRegion).values
         regionCellMask = \
-            dsMask.regionCellMasks.isel(nTransects=iRegion).values
+            dsMask.regionCellMasks.isel(nRegions=iRegion).values
 
         indRegion = np.where(regionCellMask == 1)
         dictRegion[region] = {

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -426,6 +426,12 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
              'timeMonthly_avg_mocStreamvalLatAndDepthRegion':
                  'avgMocStreamfunRegional'})
 
+        dsMask = xr.open_dataset(self.maskSubtask.maskAndTransectFileName)
+        regionIndices = {}
+        for iRegion in range(dsMask.sizes['nRegions']):
+            regionInFile = dsMask.regionNames[iRegion].values.astype('U')
+            regionIndices[regionInFile] = iRegion
+
         # Create dictionary for MOC climatology (NB: need this form
         # in order to convert it to xarray dataset later in the script)
         depth = refZMid
@@ -436,10 +442,9 @@ class ComputeMOCClimatologySubtask(AnalysisTask):  # {{{
             if region == 'Global':
                 mocTop = annualClimatology.avgMocStreamfunGlobal.values
             else:
-                # hard-wire region=0 (Atlantic) for now
-                indRegion = 0
+                indRegion = regionIndices[region]
                 mocVar = annualClimatology.avgMocStreamfunRegional
-                mocTop = mocVar[indRegion, :, :].values
+                mocTop = mocVar.isel(nRegions=indRegion).values
             # Store computed MOC to dictionary
             lat[region] = binBoundaryMocStreamfunction
             moc[region] = mocTop


### PR DESCRIPTION
This merge fixes two issues with indexing regions in the  MOC.

First, the offline MOC calculation was previously assuming the requested regions from the config file were in the same order as the regions in the region masks file.  This is obviously not necessarily the case.  We happen to request the Atlantic and IndoPacific by default (indices 0 and 1) but if we asked for the pacific region, the code before this merge would plot the IndoPacific and call it the Pacific.

Second, the online MOC calculation was always plotting index 0 (the Atlantic) for each region before this fix.

The fix is to read in the regions from the mask file and compute indices for each, then, to use the names of the requested region to look up the correct indices.

closes #789 