### PR TITLE
Fallback to slow file copy on exception

### DIFF
--- a/mpas_analysis/shared/html/image_xml.py
+++ b/mpas_analysis/shared/html/image_xml.py
@@ -14,14 +14,13 @@ from __future__ import absolute_import, division, print_function, \
 
 import os
 import sys
-import shutil
 import socket
 import subprocess
 import datetime
 from lxml import etree
 from PIL import Image
 
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_config_full_path, copyfile
 
 
 def write_image_xml(config, filePrefix, componentName, componentSubdirectory,
@@ -129,8 +128,8 @@ def write_image_xml(config, filePrefix, componentName, componentSubdirectory,
 
         plotsDirectory = build_config_full_path(config, 'output',
                                                 'plotsSubdirectory')
-        shutil.copyfile('{}/{}'.format(plotsDirectory, imageFileName),
-                        '{}/{}'.format(componentDirectory, imageFileName))
+        copyfile('{}/{}'.format(plotsDirectory, imageFileName),
+                 '{}/{}'.format(componentDirectory, imageFileName))
 
         imageSize, thumbnailSize, orientation = _generate_thumbnails(
             imageFileName, componentDirectory)

--- a/mpas_analysis/shared/html/pages.py
+++ b/mpas_analysis/shared/html/pages.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import, division, print_function, \
 
 import pkg_resources
 from os import makedirs
-from shutil import copyfile
 from lxml import etree
 from collections import OrderedDict
 import subprocess
@@ -22,7 +21,7 @@ import os
 import sys
 
 import mpas_analysis
-from mpas_analysis.shared.io.utility import build_config_full_path
+from mpas_analysis.shared.io.utility import build_config_full_path, copyfile
 
 
 def generate_html(config, analyses, controlConfig, customConfigFiles):

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -23,6 +23,8 @@ import random
 import string
 from datetime import datetime
 import numpy
+import shutil
+import warnings
 
 
 def paths(*args):  # {{{
@@ -361,5 +363,16 @@ def decode_strings(da):
 
     return strings
 
+
+def copyfile(src, dst):
+    """ Copy a file, retrying if temporarily unavailable """
+
+    try:
+        shutil.copyfile(src, dst)
+    except BlockingIOError:
+        # this is an occasional problem on Chrysalis.  Try a slow copy
+        warnings.warn('Making a slow copy from {} to {}'.format(src, dst))
+        with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
+            shutil.copyfileobj(fsrc, fdst)
 
 # vim: foldmethod=marker ai ts=4 sts=4 et sw=4 ft=python


### PR DESCRIPTION
This is needed on Chrysalis, where PNG file copies are occasionally failing with:
```
BlockingIOError: [Errno 11] Resource temporarily unavailable
```