### PR TITLE
Various fixes and updates to test suites

### DIFF
--- a/configs/compy/test_suite/job_script.bash
+++ b/configs/compy/test_suite/job_script.bash
@@ -6,6 +6,8 @@
 #SBATCH --output=mpas_analysis.o%j
 #SBATCH --error=mpas_analysis.e%j
 
+set -e
+
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 
@@ -16,10 +18,10 @@ export HDF5_USE_FILE_LOCKING=FALSE
 echo env: test_env
 echo configs: ../../configs/polarRegions.conf ../main.cfg
 
-mpas_analysis --list
-mpas_analysis --plot_colormaps
-mpas_analysis --setup_only ../../configs/polarRegions.conf ../main.cfg
-mpas_analysis --purge ../../configs/polarRegions.conf ../main.cfg --verbose
-mpas_analysis --html_only ../../configs/polarRegions.conf ../main.cfg
+srun -N 1 -n 1 python -m mpas_analysis --list
+srun -N 1 -n 1 python -m mpas_analysis --plot_colormaps
+srun -N 1 -n 1 python -m mpas_analysis --setup_only ../../configs/polarRegions.conf ../main.cfg
+srun -N 1 -n 1 python -m mpas_analysis --purge ../../configs/polarRegions.conf ../main.cfg --verbose
+srun -N 1 -n 1 python -m mpas_analysis --html_only ../../configs/polarRegions.conf ../main.cfg
 
 chmod -R ugo+rX /compyfs/www/asay932/analysis_testing/

--- a/configs/compy/test_suite/job_script_no_polar_regions.bash
+++ b/configs/compy/test_suite/job_script_no_polar_regions.bash
@@ -6,6 +6,8 @@
 #SBATCH --output=mpas_analysis.o%j
 #SBATCH --error=mpas_analysis.e%j
 
+set -e
+
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 

--- a/configs/compy/test_suite/test_suite.bash
+++ b/configs/compy/test_suite/test_suite.bash
@@ -4,6 +4,9 @@ set -e
 
 machine=compy
 
+main_py=3.9
+alt_py=3.8
+
 export HDF5_USE_FILE_LOCKING=FALSE
 
 source ${HOME}/miniconda3/etc/profile.d/conda.sh
@@ -16,7 +19,7 @@ rm -rf ${HOME}/miniconda3/conda-bld
 conda build ci/recipe
 
 # create the test conda envs
-for py in 3.7 3.8
+for py in ${main_py} ${alt_py}
 do
     env=test_mpas_analysis_py${py}
     conda remove -y --all -n ${env}
@@ -28,7 +31,7 @@ do
 done
 
 # create another env for testing xarray master branch
-py=3.8
+py=${main_py}
 env=test_mpas_analysis_xarray_master
 conda create --yes --quiet --name ${env} --use-local python=${py} \
     mpas-analysis pytest
@@ -46,7 +49,7 @@ cd ${machine}_test_suite
 template_path=../configs/${machine}/test_suite
 job_template_path=${template_path}
 
-for py in 3.7 3.8
+for py in ${main_py} ${alt_py}
 do
     env=test_mpas_analysis_py${py}
     run=main_py${py}
@@ -59,7 +62,7 @@ do
 done
 
 
-py=3.8
+py=${main_py}
 env=test_mpas_analysis_py${py}
 
 run=wc_defaults
@@ -117,21 +120,21 @@ sed -e "s/main.cfg/${config}/g" -e "s/test_env/${env}/g" \
 
 
 # submit the jobs
-for run in main_py3.7 wc_defaults no_ncclimo no_polar_regions \
-    mesh_rename xarray_master
-do
-    cd ${run}
-    sbatch job_script.bash
-    cd ..
-done
-
-cd main_py3.8
+cd main_py${main_py}
 RES=$(sbatch job_script.bash)
 cd ..
 
 cd main_vs_ctrl
 sbatch --dependency=afterok:${RES##* } job_script.bash
 cd ..
+
+for run in main_py${alt_py} wc_defaults no_ncclimo no_polar_regions \
+    mesh_rename xarray_master
+do
+    cd ${run}
+    sbatch job_script.bash
+    cd ..
+done
 
 cd ..
 

--- a/configs/cori/test_suite/job_script.bash
+++ b/configs/cori/test_suite/job_script.bash
@@ -9,6 +9,8 @@
 #SBATCH --error=mpas_analysis.e%j
 #SBATCH -L cscratch1,SCRATCH,project
 
+set -e
+
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 
@@ -19,10 +21,10 @@ export HDF5_USE_FILE_LOCKING=FALSE
 echo env: test_env
 echo configs: ../../configs/polarRegions.conf ../main.cfg
 
-mpas_analysis --list
-mpas_analysis --plot_colormaps
-mpas_analysis --setup_only ../../configs/polarRegions.conf ../main.cfg
-mpas_analysis --purge ../../configs/polarRegions.conf ../main.cfg --verbose
-mpas_analysis --html_only ../../configs/polarRegions.conf ../main.cfg
+srun -N 1 -n 1 python -m mpas_analysis --list
+srun -N 1 -n 1 python -m mpas_analysis --plot_colormaps
+srun -N 1 -n 1 python -m mpas_analysis --setup_only ../../configs/polarRegions.conf ../main.cfg
+srun -N 1 -n 1 python -m mpas_analysis --purge ../../configs/polarRegions.conf ../main.cfg --verbose
+srun -N 1 -n 1 python -m mpas_analysis --html_only ../../configs/polarRegions.conf ../main.cfg
 
 chmod -R ugo+rX /global/cfs/cdirs/e3sm/www/xylar/analysis_testing/

--- a/configs/cori/test_suite/job_script_no_polar_regions.bash
+++ b/configs/cori/test_suite/job_script_no_polar_regions.bash
@@ -9,6 +9,8 @@
 #SBATCH --error=mpas_analysis.e%j
 #SBATCH -L cscratch1,SCRATCH,project
 
+set -e
+
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 

--- a/configs/cori/test_suite/test_suite.bash
+++ b/configs/cori/test_suite/test_suite.bash
@@ -4,6 +4,9 @@ set -e
 
 machine=cori
 
+main_py=3.9
+alt_py=3.8
+
 export HDF5_USE_FILE_LOCKING=FALSE
 
 source ${HOME}/miniconda3/etc/profile.d/conda.sh
@@ -16,7 +19,7 @@ rm -rf ${HOME}/miniconda3/conda-bld
 conda build ci/recipe
 
 # create the test conda envs
-for py in 3.7 3.8
+for py in ${main_py} ${alt_py}
 do
     env=test_mpas_analysis_py${py}
     conda remove -y --all -n ${env}
@@ -28,7 +31,7 @@ do
 done
 
 # create another env for testing xarray master branch
-py=3.8
+py=${main_py}
 env=test_mpas_analysis_xarray_master
 conda create --yes --quiet --name ${env} --use-local python=${py} \
     mpas-analysis pytest
@@ -38,7 +41,7 @@ pytest
 conda deactivate
 
 # test building the docs
-py=3.8
+py=${main_py}
 conda activate test_mpas_analysis_py${py}
 cd docs
 make clean
@@ -58,7 +61,7 @@ cd ${machine}_test_suite
 template_path=../configs/${machine}/test_suite
 job_template_path=${template_path}
 
-for py in 3.7 3.8
+for py in ${main_py} ${alt_py}
 do
     env=test_mpas_analysis_py${py}
     run=main_py${py}
@@ -71,7 +74,7 @@ do
 done
 
 
-py=3.8
+py=${main_py}
 env=test_mpas_analysis_py${py}
 
 run=wc_defaults
@@ -129,21 +132,21 @@ sed -e "s/main.cfg/${config}/g" -e "s/test_env/${env}/g" \
 
 
 # submit the jobs
-for run in main_py3.7 wc_defaults no_ncclimo no_polar_regions \
-    mesh_rename xarray_master
-do
-    cd ${run}
-    sbatch job_script.bash
-    cd ..
-done
-
-cd main_py3.8
+cd main_py${main_py}
 RES=$(sbatch job_script.bash)
 cd ..
 
 cd main_vs_ctrl
 sbatch --dependency=afterok:${RES##* } job_script.bash
 cd ..
+
+for run in main_py${alt_py} wc_defaults no_ncclimo no_polar_regions \
+    mesh_rename xarray_master
+do
+    cd ${run}
+    sbatch job_script.bash
+    cd ..
+done
 
 cd ..
 

--- a/configs/lcrc/test_suite/anvil/job_script.bash
+++ b/configs/lcrc/test_suite/anvil/job_script.bash
@@ -7,6 +7,8 @@
 #SBATCH --output=mpas_analysis.o%j
 #SBATCH --error=mpas_analysis.e%j
 
+set -e
+
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 
@@ -17,9 +19,9 @@ export HDF5_USE_FILE_LOCKING=FALSE
 echo env: test_env
 echo configs: ../../configs/polarRegions.conf ../main.cfg
 
-mpas_analysis --list
-mpas_analysis --plot_colormaps
-mpas_analysis --setup_only ../../configs/polarRegions.conf ../main.cfg
-mpas_analysis --purge ../../configs/polarRegions.conf ../main.cfg --verbose
-mpas_analysis --html_only ../../configs/polarRegions.conf ../main.cfg
+srun -N 1 -n 1 python -m mpas_analysis --list
+srun -N 1 -n 1 python -m mpas_analysis --plot_colormaps
+srun -N 1 -n 1 python -m mpas_analysis --setup_only ../../configs/polarRegions.conf ../main.cfg
+srun -N 1 -n 1 python -m mpas_analysis --purge ../../configs/polarRegions.conf ../main.cfg --verbose
+srun -N 1 -n 1 python -m mpas_analysis --html_only ../../configs/polarRegions.conf ../main.cfg
 

--- a/configs/lcrc/test_suite/anvil/job_script_no_polar_regions.bash
+++ b/configs/lcrc/test_suite/anvil/job_script_no_polar_regions.bash
@@ -7,6 +7,8 @@
 #SBATCH --output=mpas_analysis.o%j
 #SBATCH --error=mpas_analysis.e%j
 
+set -e
+
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 

--- a/configs/lcrc/test_suite/chrysalis/job_script.bash
+++ b/configs/lcrc/test_suite/chrysalis/job_script.bash
@@ -5,6 +5,8 @@
 #SBATCH --output=mpas_analysis.o%j
 #SBATCH --error=mpas_analysis.e%j
 
+set -e
+
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 
@@ -15,9 +17,9 @@ export HDF5_USE_FILE_LOCKING=FALSE
 echo env: test_env
 echo configs: ../../configs/polarRegions.conf ../main.cfg
 
-mpas_analysis --list
-mpas_analysis --plot_colormaps
-mpas_analysis --setup_only ../../configs/polarRegions.conf ../main.cfg
-mpas_analysis --purge ../../configs/polarRegions.conf ../main.cfg --verbose
-mpas_analysis --html_only ../../configs/polarRegions.conf ../main.cfg
+srun -N 1 -n 1 python -m mpas_analysis --list
+srun -N 1 -n 1 python -m mpas_analysis --plot_colormaps
+srun -N 1 -n 1 python -m mpas_analysis --setup_only ../../configs/polarRegions.conf ../main.cfg
+srun -N 1 -n 1 python -m mpas_analysis --purge ../../configs/polarRegions.conf ../main.cfg --verbose
+srun -N 1 -n 1 python -m mpas_analysis --html_only ../../configs/polarRegions.conf ../main.cfg
 

--- a/configs/lcrc/test_suite/chrysalis/job_script_no_polar_regions.bash
+++ b/configs/lcrc/test_suite/chrysalis/job_script_no_polar_regions.bash
@@ -5,6 +5,8 @@
 #SBATCH --output=mpas_analysis.o%j
 #SBATCH --error=mpas_analysis.e%j
 
+set -e
+
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 


### PR DESCRIPTION
Make sure jobs stop on errors.  Previously, the webpages were being generated even when there were errors, which wasn't usually helpful.

Use `srun` calls and `python -m` consistently throughout.

Update suites to py 3.8 and 3.9

Build 3.9 envs before 3.8

Run 3.9 job before others (because of `main_vs_ctrl` job dependency that takes the longest)