### PR TITLE
Rename the example meshes to new E3SMv2 names

### DIFF
--- a/config.example
+++ b/config.example
@@ -105,7 +105,8 @@ oceanStreamsFileName = run/streams.ocean
 seaIceNamelistFileName = run/mpassi_in
 seaIceStreamsFileName = run/streams.seaice
 
-# names of ocean and sea ice meshes (e.g. oEC60to30, oQU240, oRRS30to10, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = mesh
 
 

--- a/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/acme1/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -54,7 +54,8 @@ oceanHistorySubdirectory = archive/ocn/hist
 # subdirectory for sea ice history files
 seaIceHistorySubdirectory = archive/ice/hist
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/alcf/20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta.yrs41-50.conf
+++ b/configs/alcf/20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta.yrs41-50.conf
@@ -47,7 +47,8 @@ baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_3/diagnostics
 # directory containing model results
 baseDirectory = /lus/theta-fs0/projects/OceanClimate_2/sprice/20190405.GMPAS-DIB-IAF-ISMF.T62_oRRS30to10v3wLI.theta/run
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oRRS30to10v3wLI
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
+++ b/configs/alcf/config.20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta
@@ -47,7 +47,8 @@ baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_3/diagnostics
 # directory containing model results
 baseDirectory = /lus/theta-fs0/projects/OceanClimate_2/mpeterse/20171031.tenYearTest.GMPAS-IAF.T62_oEC60to30v3wLI.60layer.theta/run
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3wLI
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
+++ b/configs/alcf/config.20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta
@@ -47,7 +47,8 @@ baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_3/diagnostics
 # directory containing model results
 baseDirectory = /lus/theta-fs0/projects/ClimateEnergy_3/azamatm/E3SM_simulations/20180410.A_WCYCL1950_HR.ne120_oRRS18v3_ICG.theta/run
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oRRS18to6v3
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/compy/config.20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy
+++ b/configs/compy/config.20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy
@@ -47,7 +47,8 @@ baseDirectory = /compyfs/diagnostics
 # directory containing model results
 baseDirectory = /compyfs/wolf966/e3sm_scratch/20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy/run
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/compy/test_suite/ctrl.cfg
+++ b/configs/compy/test_suite/ctrl.cfg
@@ -47,7 +47,8 @@ baseDirectory = /compyfs/diagnostics
 # directory containing model results
 baseDirectory = /compyfs/asay932/analysis_testing/test_output/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/compy/test_suite/main.cfg
+++ b/configs/compy/test_suite/main.cfg
@@ -47,7 +47,8 @@ baseDirectory = /compyfs/diagnostics
 # directory containing model results
 baseDirectory = /compyfs/asay932/analysis_testing/test_output/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/compy/test_suite/main_vs_ctrl.cfg
+++ b/configs/compy/test_suite/main_vs_ctrl.cfg
@@ -47,7 +47,8 @@ baseDirectory = /compyfs/diagnostics
 # directory containing model results
 baseDirectory = /compyfs/asay932/analysis_testing/test_output/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/compy/test_suite/mesh_rename.cfg
+++ b/configs/compy/test_suite/mesh_rename.cfg
@@ -47,7 +47,8 @@ baseDirectory = /compyfs/diagnostics
 # directory containing model results
 baseDirectory = /compyfs/asay932/analysis_testing/test_output/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = new_oQU480
 
 # subdirectory containing restart files

--- a/configs/compy/test_suite/no_ncclimo.cfg
+++ b/configs/compy/test_suite/no_ncclimo.cfg
@@ -47,7 +47,8 @@ baseDirectory = /compyfs/diagnostics
 # directory containing model results
 baseDirectory = /compyfs/asay932/analysis_testing/test_output/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/compy/test_suite/wc_defaults.cfg
+++ b/configs/compy/test_suite/wc_defaults.cfg
@@ -47,7 +47,8 @@ baseDirectory = /compyfs/diagnostics
 # directory containing model results
 baseDirectory = /compyfs/asay932/analysis_testing/test_output/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -47,7 +47,8 @@ baseDirectory = /global/cfs/cdirs/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /global/cscratch1/sd/mpeterse/acme_scratch/20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl/run
 
-# names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oRRS30to10v3wLI
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/cori/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/cori/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -54,7 +54,8 @@ oceanHistorySubdirectory = archive/ocn/hist
 # subdirectory for sea ice history files
 seaIceHistorySubdirectory = archive/ice/hist
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/cori/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
+++ b/configs/cori/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
@@ -54,7 +54,8 @@ oceanHistorySubdirectory = run
 # subdirectory for sea ice history files
 seaIceHistorySubdirectory = run
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oRRS30to10v3wLI
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/cori/config.20180511.GMPAS-IAF.T62_oEC60to30v3wLI.edison
+++ b/configs/cori/config.20180511.GMPAS-IAF.T62_oEC60to30v3wLI.edison
@@ -54,7 +54,8 @@ oceanHistorySubdirectory = run
 # subdirectory for sea ice history files
 seaIceHistorySubdirectory = run
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3wLI
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/cori/config.20180514.G.oQU240wLI.edison
+++ b/configs/cori/config.20180514.G.oQU240wLI.edison
@@ -47,7 +47,8 @@ baseDirectory = /global/cfs/cdirs/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /global/cscratch1/sd/xylar/acme_scratch/edison/20180514.G.oQU240wLI.edison
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU240wLI
 
 # subdirectory containing restart files

--- a/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
+++ b/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
@@ -54,7 +54,8 @@ oceanHistorySubdirectory = /global/cscratch1/sd/dcomeau/acme_scratch/cori-knl/20
 # subdirectory for sea ice history files
 seaIceHistorySubdirectory = /global/cscratch1/sd/dcomeau/acme_scratch/cori-knl/20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl/archive/ice/hist
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3wLI
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/cori/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/cori/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -47,7 +47,8 @@ baseDirectory = /global/cfs/cdirs/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /global/cscratch1/sd/fyke/ACME_simulations/B_low_res_ice_shelves_1696_JWolfe_layout_Edison/run
 
-# names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3wLI
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/cori/test_suite/ctrl.cfg
+++ b/configs/cori/test_suite/ctrl.cfg
@@ -47,7 +47,8 @@ baseDirectory = /global/cfs/cdirs/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /global/cfs/cdirs/e3sm/xylar/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/cori/test_suite/main.cfg
+++ b/configs/cori/test_suite/main.cfg
@@ -47,7 +47,8 @@ baseDirectory = /global/cfs/cdirs/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /global/cfs/cdirs/e3sm/xylar/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/cori/test_suite/main_vs_ctrl.cfg
+++ b/configs/cori/test_suite/main_vs_ctrl.cfg
@@ -47,7 +47,8 @@ baseDirectory = /global/cfs/cdirs/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /global/cfs/cdirs/e3sm/xylar/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/cori/test_suite/mesh_rename.cfg
+++ b/configs/cori/test_suite/mesh_rename.cfg
@@ -47,7 +47,8 @@ baseDirectory = /global/cfs/cdirs/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /global/cfs/cdirs/e3sm/xylar/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = new_oQU480
 
 # subdirectory containing restart files

--- a/configs/cori/test_suite/no_ncclimo.cfg
+++ b/configs/cori/test_suite/no_ncclimo.cfg
@@ -47,7 +47,8 @@ baseDirectory = /global/cfs/cdirs/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /global/cfs/cdirs/e3sm/xylar/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/cori/test_suite/wc_defaults.cfg
+++ b/configs/cori/test_suite/wc_defaults.cfg
@@ -47,7 +47,8 @@ baseDirectory = /global/cfs/cdirs/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /global/cfs/cdirs/e3sm/xylar/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -47,7 +47,8 @@ baseDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostic
 # directory containing model results
 baseDirectory = /net/scratch2/akt/MPAS/rundirs/rundir_QU60km_polar
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = QU60
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/lanl/config.BGCphaeo4.testrun
+++ b/configs/lanl/config.BGCphaeo4.testrun
@@ -48,7 +48,8 @@ baseDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics
 # baseDirectory = /lustre/scratch3/turquoise/lvanroekel/ACME/cases/MatchBoth_orig/run
 baseDirectory = /lustre/scratch3/turquoise/shanlinw/ACME/cases/BGCacme.phaeo4/run
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/lanl/config.CONUS.100km.NAEC60to30cr8.20181218
+++ b/configs/lanl/config.CONUS.100km.NAEC60to30cr8.20181218
@@ -31,7 +31,8 @@ baseDirectory = /lustre/scratch4/turquoise/.mdt2/kehoch/e3sm/mesh_project/transi
 
 #runSubdirectory = /lustre/scratch4/turquoise/.mdt2/kehoch/e3sm/mesh_project/transition/CONUS.100km.NAEC60to30cr8.20181218/ocean/global_ocean/NAEC60to30cr8/spin_up/spin_up1/restarts
 #oceanHistorySubdirectory = analysis_members
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = NAEC60to30cr8
 
 oceanNamelistFileName = namelist.ocean

--- a/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
+++ b/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
@@ -47,7 +47,8 @@ baseDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics
 # directory containing model results
 baseDirectory = /lustre/scratch3/turquoise/rileybrady/ACME/cases/GMPAS-OECO-ODMS-IAF_oRRS30to10v3_grizzly03/run
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oRRS30to10v3
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -47,7 +47,8 @@ baseDirectory = /turquoise/usr/projects/climate/SHARED_CLIMATE/diagnostics
 # directory containing model results
 baseDirectory = /lustre/scratch3/turquoise/lvanroekel/ACME/cases/MatchBoth_orig/run
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/lcrc/20201025.GMPAS-IAF.T62_oQU240wLI.anvil.cfg
+++ b/configs/lcrc/20201025.GMPAS-IAF.T62_oQU240wLI.anvil.cfg
@@ -47,7 +47,8 @@ baseDirectory = /lcrc/group/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /lcrc/group/e3sm/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU240wLI
 
 # subdirectory containing restart files

--- a/configs/lcrc/test_suite/QU480.cfg
+++ b/configs/lcrc/test_suite/QU480.cfg
@@ -47,7 +47,8 @@ baseDirectory = /lcrc/group/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /lcrc/group/e3sm/ac.xylar/acme_scratch/anvil/20200305.A_WCYCL1850.ne4_oQU480.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU480
 
 # subdirectory containing restart files

--- a/configs/lcrc/test_suite/ctrl.cfg
+++ b/configs/lcrc/test_suite/ctrl.cfg
@@ -47,7 +47,8 @@ baseDirectory = /lcrc/group/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /lcrc/group/e3sm/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU240wLI
 
 # subdirectory containing restart files

--- a/configs/lcrc/test_suite/main.cfg
+++ b/configs/lcrc/test_suite/main.cfg
@@ -47,7 +47,8 @@ baseDirectory = /lcrc/group/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /lcrc/group/e3sm/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU240wLI
 
 # subdirectory containing restart files

--- a/configs/lcrc/test_suite/main_vs_ctrl.cfg
+++ b/configs/lcrc/test_suite/main_vs_ctrl.cfg
@@ -47,7 +47,8 @@ baseDirectory = /lcrc/group/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /lcrc/group/e3sm/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU240wLI
 
 # subdirectory containing restart files

--- a/configs/lcrc/test_suite/mesh_rename.cfg
+++ b/configs/lcrc/test_suite/mesh_rename.cfg
@@ -47,7 +47,8 @@ baseDirectory = /lcrc/group/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /lcrc/group/e3sm/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = new_oQU240wLI
 
 # subdirectory containing restart files

--- a/configs/lcrc/test_suite/no_ncclimo.cfg
+++ b/configs/lcrc/test_suite/no_ncclimo.cfg
@@ -47,7 +47,8 @@ baseDirectory = /lcrc/group/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /lcrc/group/e3sm/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU240wLI
 
 # subdirectory containing restart files

--- a/configs/lcrc/test_suite/wc_defaults.cfg
+++ b/configs/lcrc/test_suite/wc_defaults.cfg
@@ -47,7 +47,8 @@ baseDirectory = /lcrc/group/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /lcrc/group/e3sm/ac.xylar/acme_scratch/anvil/20201025.GMPAS-IAF.T62_oQU240wLI.anvil
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU240wLI
 
 # subdirectory containing restart files

--- a/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -47,7 +47,8 @@ baseDirectory = /gpfs/alpine/proj-shared/cli115/diagnostics/
 # directory containing model results
 baseDirectory = /lustre/atlas1/cli115/proj-shared/milena/ACME/simulations/20170313.beta1.A_WCYCL1850S.ne30_oECv3_ICG.edison
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3
 
 # names of namelist and streams files, either a path relative to baseDirectory

--- a/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
+++ b/configs/olcf/config.20170915.beta2.A_WCYCL1850S.ne30_oECv3_ICG.edison
@@ -66,7 +66,8 @@ oceanStreamsFileName = run/streams.ocean
 seaIceNamelistFileName = run/mpas-cice_in
 seaIceStreamsFileName = run/streams.cice
 
-# names of ocean and sea ice meshes (e.g. EC60to30, QU240, RRS30to10, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oEC60to30v3
 
 [output]

--- a/configs/plots/config.drake_contours
+++ b/configs/plots/config.drake_contours
@@ -47,7 +47,8 @@ baseDirectory = /global/cfs/cdirs/e3sm/diagnostics
 # directory containing model results
 baseDirectory = /global/cscratch1/sd/xylar/acme_scratch/edison/20180514.G.oQU240wLI.edison
 
-# names of ocean and sea ice meshes (e.g. oEC60to30v3, oQU240v3, oRRS30to10v3, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = oQU240wLI
 
 # subdirectory containing restart files

--- a/docs/config/input.rst
+++ b/docs/config/input.rst
@@ -32,7 +32,8 @@ these data will be read in::
   seaIceNamelistFileName = mpassi_in
   seaIceStreamsFileName = streams.seaice
 
-  # names of ocean and sea ice meshes (e.g. oEC60to30, oQU240, oRRS30to10, etc.)
+  # name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+  # ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
   mpasMeshName = mesh
 
   # Large datasets can encounter a memory error.  Specification of a maximum

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -318,7 +318,8 @@ of the MPAS-Ocean and MPAS-Seaice mesh.
     seaIceNamelistFileName = run/mpassi_in
     seaIceStreamsFileName = run/streams.seaice
 
-    # names of ocean and sea ice meshes (e.g. oEC60to30, oQU240, oRRS30to10, etc.)
+    # name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+    # ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
     mpasMeshName = oQU480
 
 The ``baseDirectory`` is the path where you untarred the example run.

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -126,7 +126,8 @@ oceanStreamsFileName = streams.ocean
 seaIceNamelistFileName = mpassi_in
 seaIceStreamsFileName = streams.seaice
 
-# names of ocean and sea ice meshes (e.g. oEC60to30, oQU240, oRRS30to10, etc.)
+# name of the ocean and sea-ice mesh (e.g. EC30to60E2r2, WC14to60E2r3,
+# ECwISC30to60E2r1, SOwISC12to60E2r4, oQU240, etc.)
 mpasMeshName = mesh
 
 # maximum number of open files to hold in xarray’s global least-recently-usage


### PR DESCRIPTION
The renaming is in all example config files, `config.default` and the documentation.