### PR TITLE
Select time-series colors from config options

### DIFF
--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -271,6 +271,17 @@ startYear = 1
 endYear = end
 
 
+# line colors for the main, control and obs curves
+# see https://matplotlib.org/stable/gallery/color/named_colors.html
+# and https://matplotlib.org/stable/tutorials/colors/colors.html
+mainColor = black
+controlColor = tab:red
+obsColor1 = tab:blue
+obsColor2 = tab:orange
+obsColor3 = tab:green
+obsColor4 = tab:purple
+obsColor5 = tab:cyan
+
 [index]
 ## options related to producing nino index.
 

--- a/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
+++ b/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
@@ -307,7 +307,7 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
         widths = [5, 3, 3, 3, 3, 3, 3]
         points = [None, None, None, 300, 300, 300, 300]
 
-        color = 'k'
+        color = config.get('timeSeries', 'mainColor')
 
         xLabel = 'Time [years]'
         yLabel = self.yAxisLabel
@@ -443,7 +443,7 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
                                       endDate=controlEndDate)
             dsRef = dsRef.isel(nOceanRegionsTmp=regionIndex)
 
-            color = 'r'
+            color = config.get('timeSeries', 'controlColor')
 
             for rangeIndex in range(len(topDepths)):
                 top = topDepths[rangeIndex]

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -1445,7 +1445,8 @@ class PlotMOCTimeSeriesSubtask(AnalysisTask):  # {{{
             yearStrideXTicks = None
 
         fields = [dsMOCTimeSeries.mocAtlantic26]
-        lineColors = ['k']
+        lineColors = [config.get('timeSeries', 'mainColor')]
+
         lineWidths = [2]
         legendText = [mainRunName]
 
@@ -1453,7 +1454,7 @@ class PlotMOCTimeSeriesSubtask(AnalysisTask):  # {{{
 
             dsRefMOC = self._load_moc(self.controlConfig)
             fields.append(dsRefMOC.mocAtlantic26)
-            lineColors.append('r')
+            lineColors.append(config.get('timeSeries', 'controlColor'))
             lineWidths.append(2)
             controlRunName = self.controlConfig.get('runs', 'mainRunName')
             legendText.append(controlRunName)

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -643,12 +643,12 @@ class PlotMeltSubtask(AnalysisTask):
         outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
         fields = [timeSeries]
-        lineColors = ['k']
+        lineColors = [config.get('timeSeries', 'mainColor')]
         lineWidths = [2.5]
         legendText = [mainRunName]
         if plotControl:
             fields.append(refTotalMeltFlux.isel(nRegions=self.regionIndex))
-            lineColors.append('r')
+            lineColors.append(config.get('timeSeries', 'controlColor'))
             lineWidths.append(1.2)
             legendText.append(controlRunName)
 
@@ -694,12 +694,12 @@ class PlotMeltSubtask(AnalysisTask):
         outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
         fields = [timeSeries]
-        lineColors = ['k']
+        lineColors = [config.get('timeSeries', 'mainColor')]
         lineWidths = [2.5]
         legendText = [mainRunName]
         if plotControl:
             fields.append(refMeltRates.isel(nRegions=self.regionIndex))
-            lineColors.append('r')
+            lineColors.append(config.get('timeSeries', 'controlColor'))
             lineWidths.append(1.2)
             legendText.append(controlRunName)
 

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -1157,17 +1157,19 @@ class PlotRegionTimeSeriesSubtask(AnalysisTask):
             outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
             fields = [mainArray]
-            lineColors = ['k']
+            lineColors = [config.get('timeSeries', 'mainColor')]
             lineWidths = [2.5]
             legendText = [mainRunName]
             if plotControl:
                 fields.append(refArray)
-                lineColors.append('r')
+                lineColors.append(config.get('timeSeries', 'controlColor'))
                 lineWidths.append(1.2)
                 legendText.append(controlRunName)
 
             if varName in ['temperature', 'salinity']:
-                obsColors = ['b', 'g', 'm']
+                obsColors = [
+                    config.get('timeSeries', 'obsColor{}'.format(index + 1))
+                    for index in range(5)]
                 daysInMonth = constants.daysInMonth
                 for obsName in self.obsSubtasks:
                     obsFileName = self.obsSubtasks[obsName].outFileName

--- a/mpas_analysis/ocean/time_series_sst.py
+++ b/mpas_analysis/ocean/time_series_sst.py
@@ -240,7 +240,7 @@ class TimeSeriesSST(AnalysisTask):
 
             outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
-            lineColors = ['k']
+            lineColors = [config.get('timeSeries', 'mainColor')]
             lineWidths = [3]
 
             fields = [SST]
@@ -249,7 +249,7 @@ class TimeSeriesSST(AnalysisTask):
             if dsRefSST is not None:
                 refSST = dsRefSST[varName].isel(nOceanRegions=regionIndex)
                 fields.append(refSST)
-                lineColors.append('r')
+                lineColors.append(config.get('timeSeries', 'controlColor'))
                 lineWidths.append(1.5)
                 controlRunName = self.controlConfig.get('runs', 'mainRunName')
                 legendText.append(controlRunName)

--- a/mpas_analysis/ocean/time_series_transport.py
+++ b/mpas_analysis/ocean/time_series_transport.py
@@ -618,7 +618,7 @@ class PlotTransportSubtask(AnalysisTask):
         outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
 
         fields = [transport]
-        lineColors = ['k']
+        lineColors = [config.get('timeSeries', 'mainColor')]
         lineWidths = [2.5]
         meanString = 'mean={:.2f} $\pm$ {:.2f}'.format(trans_mean, trans_std)
         if plotControl:
@@ -627,7 +627,7 @@ class PlotTransportSubtask(AnalysisTask):
                 self._load_transport(self.controlConfig)
             refMeanString = 'mean={:.2f} $\pm$ {:.2f}'.format(ref_mean, ref_std)
             fields.append(ref_transport)
-            lineColors.append('r')
+            lineColors.append(config.get('timeSeries', 'controlColor'))
             lineWidths.append(1.2)
             legendText = ['{} ({})'.format(mainRunName, meanString),
                           '{} ({})'.format(controlRunName, refMeanString)]

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -430,12 +430,12 @@ class TimeSeriesSeaIce(AnalysisTask):
                 key = (hemisphere, variableName)
                 dsvalues = [plotVars[key]]
                 legendText = [mainRunName]
-                lineColors = ['k']
+                lineColors = [config.get('timeSeries', 'mainColor')]
                 lineWidths = [3]
                 if compareWithObservations and key in obsLegend.keys():
                     dsvalues.append(obs[key])
                     legendText.append(obsLegend[key])
-                    lineColors.append('b')
+                    lineColors.append(config.get('timeSeries', 'obsColor1'))
                     lineWidths.append(1.2)
                 if preprocessedReferenceRunName != 'None':
                     dsvalues.append(preprocessed[key])
@@ -446,7 +446,8 @@ class TimeSeriesSeaIce(AnalysisTask):
                 if self.controlConfig is not None:
                     dsvalues.append(plotVarsRef[key])
                     legendText.append(controlRunName)
-                    lineColors.append('r')
+                    lineColors.append(config.get('timeSeries',
+                                                 'controlColor'))
                     lineWidths.append(1.2)
 
                 if config.has_option(sectionName, 'firstYearXTicks'):

--- a/mpas_analysis/shared/plot/time_series.py
+++ b/mpas_analysis/shared/plot/time_series.py
@@ -188,7 +188,8 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
         end = np.amax(maxDays)
         obsTimes = np.linspace(start, end, obsCount + 2)[1:-1]
         obsSymbols = ['o', '^', 's', 'D', '*']
-        obsColors = ['b', 'g', 'c', 'm', 'r']
+        obsColors = [config.get('timeSeries', 'obsColor{}'.format(index+1))
+                     for index in range(5)]
         for iObs in range(obsCount):
             if obsMean[iObs] is not None:
                 symbol = obsSymbols[np.mod(iObs, len(obsSymbols))]

--- a/mpas_analysis/shared/plot/time_series.py
+++ b/mpas_analysis/shared/plot/time_series.py
@@ -194,11 +194,11 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
             if obsMean[iObs] is not None:
                 symbol = obsSymbols[np.mod(iObs, len(obsSymbols))]
                 color = obsColors[np.mod(iObs, len(obsColors))]
-                fmt = '{}{}'.format(color, symbol)
                 plt.errorbar(obsTimes[iObs],
                              obsMean[iObs],
                              yerr=obsUncertainty[iObs],
-                             fmt=fmt,
+                             fmt=symbol,
+                             color=color,
                              ecolor=color,
                              capsize=0,
                              label=obsLegend[iObs])
@@ -210,7 +210,7 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
                 boxY = obsMean[iObs] + \
                     boxHalfHeight * np.array([-1, -1, 1, 1, -1])
 
-                plt.plot(boxX, boxY, '{}-'.format(color), linewidth=3)
+                plt.plot(boxX, boxY, '-', color=color, linewidth=3)
                 labelCount += 1
 
     if labelCount > 1:


### PR DESCRIPTION
Rather than hard-coding the main time series to be red, the control to be black, etc. these are now config options.