### PR TITLE
 Add ncremap parallel exec 

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "MPAS-Analysis" %}
-{% set version = "1.4.0rc1" %}
+{% set version = "1.4.0rc3" %}
 
 package:
   name: {{ name|lower }}
@@ -39,7 +39,7 @@ requirements:
     - pillow
     - progressbar2
     - pyproj
-    - pyremap >=0.0.12,<0.1.0
+    - pyremap >=0.0.13,<0.1.0
     - python-dateutil
     - requests
     - scipy

--- a/configs/compy/config.20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy
+++ b/configs/compy/config.20190711.testLuke.A_WCYCL1850S.ne30_oECv3.compy
@@ -30,6 +30,19 @@ parallelTaskCount = 6
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+# the number of MPI tasks to use in creating mapping files (1 means tasks run in
+# serial, the default)
+mapMpiTasks = 6
+
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun --mpi=pmi2
+
+# "None" if ncremap should perform remapping without a command, or "srun"
+# possibly with some flags if it should be run with that command
+ncremapParallelExec = srun --mpi=pmi2
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/compy/job_script.compy.bash
+++ b/configs/compy/job_script.compy.bash
@@ -1,15 +1,4 @@
 #!/bin/bash -l
-# This software is open source software available under the BSD-3 license.
-#
-# Copyright (c) 2020 Triad National Security, LLC. All rights reserved.
-# Copyright (c) 2020 Lawrence Livermore National Security, LLC. All rights
-# reserved.
-# Copyright (c) 2020 UT-Battelle, LLC. All rights reserved.
-#
-# Additional copyright and license information can be found in the LICENSE file
-# distributed with this code, or at
-# https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-
 #SBATCH --nodes=1
 #SBATCH --time=1:00:00
 #SBATCH --account=e3sm
@@ -21,18 +10,6 @@ cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 
 source /compyfs/software/e3sm-unified/load_latest_e3sm_unified.sh
-export HDF5_USE_FILE_LOCKING=FALSE
 
-# MPAS/ACME job to be analyzed, including paths to simulation data and
-# observations. Change this name and path as needed
-run_config_file="config.run_name_here"
-
-if [ ! -f $run_config_file ]; then
-    echo "File $run_config_file not found!"
-    exit 1
-fi
-
-
-
-srun -N 1 -n 1 mpas_analysis $run_config_file
+srun --mpi=pmi2 -N 1 -n 1 mpas_analysis config.run_name_here
 

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -20,7 +20,7 @@ pandas
 pillow
 progressbar2
 pyproj
-pyremap>=0.0.12,<0.1.0
+pyremap>=0.0.13,<0.1.0
 python-dateutil
 requests
 scipy
@@ -30,6 +30,7 @@ six
 xarray>=0.14.1
 
 # Development
+git
 pip
 pytest
 

--- a/mpas_analysis/config.default
+++ b/mpas_analysis/config.default
@@ -68,10 +68,16 @@ ncclimoThreads = 12
 # serial, the default)
 mapMpiTasks = 1
 
-# "None" if ESMF should perform remapping in serial without a command, or one of# "srun" or "mpirun" if it should be run in parallel  (or in serial but with a
-# command)
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
 mapParallelExec = None
 
+# "None" if ncremap should perform remapping without a command, or "srun"
+# possibly with some flags if it should be run with that command
+ncremapParallelExec = None
+
+# Multiprocessing method used in python mask creation ("forkserver", "fork" or
 # Multiprocessing method used in python mask creation ("forkserver", "fork" or
 # "spawn").  We have found that "spawn" is the only one that works in python
 # 3.7 on Anvil so this is the default

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -361,6 +361,11 @@ def remap_and_write_climatology(config, climatologyDataSet,
     else:
         renormalizationThreshold = config.getfloat(
             'climatology', 'renormalizationThreshold')
+        parallel_exec = config.get(
+            'execute', 'ncremapParallelExec')
+        if parallel_exec == 'None':
+            parallel_exec = None
+
         if useNcremap:
             if not os.path.exists(climatologyFileName):
                 write_netcdf(climatologyDataSet, climatologyFileName)
@@ -368,7 +373,8 @@ def remap_and_write_climatology(config, climatologyDataSet,
                                 outFileName=remappedFileName,
                                 overwrite=True,
                                 renormalize=renormalizationThreshold,
-                                logger=logger)
+                                logger=logger,
+                                parallel_exec=parallel_exec)
             remappedClimatology = xr.open_dataset(remappedFileName)
         else:
 

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -588,12 +588,18 @@ class RemapMpasClimatologySubtask(AnalysisTask):  # {{{
         renormalizationThreshold = self.config.getfloat(
             'climatology', 'renormalizationThreshold')
 
+        parallel_exec = self.config.get(
+            'execute', 'ncremapParallelExec')
+        if parallel_exec == 'None':
+            parallel_exec = None
+
         if self.useNcremap:
             remapper.remap_file(inFileName=inFileName,
                                 outFileName=outFileName,
                                 overwrite=True,
                                 renormalize=renormalizationThreshold,
-                                logger=self.logger)
+                                logger=self.logger,
+                                parallel_exec=parallel_exec)
 
             remappedClimatology = xr.open_dataset(outFileName)
             remappedClimatology.load()

--- a/mpas_analysis/test/test_mpas_climatology_task/config.QU240
+++ b/mpas_analysis/test/test_mpas_climatology_task/config.QU240
@@ -5,6 +5,7 @@ mainRunName = runName
 parallelTaskCount = 1
 ncclimoParallelMode = serial
 mapParallelExec = None
+ncremapParallelExec = None
 
 [diagnostics]
 baseDirectory = /dir/for/model/output

--- a/mpas_analysis/test/test_remap_obs_clim_subtask/config.remap_obs
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask/config.remap_obs
@@ -1,5 +1,6 @@
 [execute]
 mapParallelExec = None
+ncremapParallelExec = None
 
 [diagnostics]
 baseDirectory = /dir/to/diagnostics


### PR DESCRIPTION
This is needed on compy (and possibly other places) to handle ESMF built with system MPI.

Update compy examples for new system ESMF support.

Update to 1.4.0rc3