### PR TITLE
Update docs and example configs for E3SM-Unified 1.5.0

### DIFF
--- a/config.example
+++ b/config.example
@@ -68,6 +68,19 @@ ncclimoParallelMode = serial
 # serial, the default)
 mapMpiTasks = 1
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or in
+# serial but with a command).
+mapParallelExec = None
+# Typically, use this instead if running E3SM-Unified on a compute node
+# mapParallelExec = srun
+
+# "None" if ncremap should perform remapping without a command, or "srun"
+# possibly with some flags if it should be run with that command
+ncremapParallelExec = None
+# Use this if running E3SM-Unified on a compute node on Chrysalis or Anvil
+# ncremapParallelExec = srun
+
 
 [diagnostics]
 ## config options related to observations, mapping files and region files used

--- a/configs/alcf/job_script.cooley.18to6.bash
+++ b/configs/alcf/job_script.cooley.18to6.bash
@@ -13,8 +13,7 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
 
-source /lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/load_latest_e3sm_unified.sh
-export HDF5_USE_FILE_LOCKING=FALSE
+source /lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/load_latest_e3sm_unified_cooley.sh
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/alcf/job_script.cooley.30to10.bash
+++ b/configs/alcf/job_script.cooley.30to10.bash
@@ -13,8 +13,7 @@
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
 
-source /lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/load_latest_e3sm_unified.sh
-export HDF5_USE_FILE_LOCKING=FALSE
+source /lus/theta-fs0/projects/ccsm/acme/tools/e3sm-unified/load_latest_e3sm_unified_cooley.sh
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed

--- a/configs/compy/job_script.compy.bash
+++ b/configs/compy/job_script.compy.bash
@@ -9,7 +9,7 @@
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 
-source /compyfs/software/e3sm-unified/load_latest_e3sm_unified.sh
+source /share/apps/E3SM/conda_envs/load_latest_e3sm_unified_compy.sh
 
 srun --mpi=pmi2 -N 1 -n 1 mpas_analysis config.run_name_here
 

--- a/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
+++ b/configs/cori/config.20171201.default.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl
@@ -28,7 +28,17 @@ parallelTaskCount = 1
 # the parallelism mode in ncclimo ("serial" or "bck")
 # Set this to "bck" (background parallelism) if running on a machine that can
 # handle 12 simultaneous processes, one for each monthly climatology.
-ncclimoParallelMode = serial
+ncclimoParallelMode = bck
+
+# the number of total threads to use when ncclimo runs in "bck" or "mpi" mode.
+# Reduce this number if ncclimo is crashing (maybe because it is out of memory).
+# The number of threads must be a factor of 12 (1, 2, 3, 4, 6 or 12).
+ncclimoThreads = 3
+
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
 
 [diagnostics]
 ## config options related to observations, mapping files and region files used

--- a/configs/cori/config.20180129.DECKv1b_piControl.ne30_oEC.edison
+++ b/configs/cori/config.20180129.DECKv1b_piControl.ne30_oEC.edison
@@ -30,6 +30,11 @@ parallelTaskCount = 4
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/cori/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
+++ b/configs/cori/config.20180209.GMPAS-IAF.T62_oRRS30to10v3wLI.cori-knl.afterSalinityFix
@@ -30,6 +30,11 @@ parallelTaskCount = 4
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/cori/config.20180511.GMPAS-IAF.T62_oEC60to30v3wLI.edison
+++ b/configs/cori/config.20180511.GMPAS-IAF.T62_oEC60to30v3wLI.edison
@@ -30,6 +30,11 @@ parallelTaskCount = 6
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/cori/config.20180514.G.oQU240wLI.edison
+++ b/configs/cori/config.20180514.G.oQU240wLI.edison
@@ -30,6 +30,11 @@ parallelTaskCount = 8
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
+++ b/configs/cori/config.20190225.GMPAS-DIB-IAF-ISMF.T62_oEC60to30v3wLI.cori-knl
@@ -30,6 +30,11 @@ parallelTaskCount = 6
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/cori/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
+++ b/configs/cori/config.B_low_res_ice_shelves_1696_JWolfe_layout_Edison
@@ -30,6 +30,11 @@ parallelTaskCount = 1
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = serial
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/cori/job_script.cori-haswell.bash
+++ b/configs/cori/job_script.cori-haswell.bash
@@ -30,8 +30,7 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 
 export OMP_NUM_THREADS=1
 
-source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_latest_e3sm_unified.sh
-export HDF5_USE_FILE_LOCKING=FALSE
+source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_cori-haswell.sh
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed
@@ -43,10 +42,6 @@ if [ ! -f $run_config_file ]; then
 fi
 
 # For an E3SM cryosphere run, include configs/polarRegions.conf, or exclude
-# this extra config file for defalut parameters
+# this extra config file for default parameters
 srun -N 1 -n 1 mpas_analysis configs/polarRegions.conf $run_config_file
-
-# If running from the conda package, use this instead:
-#srun -N 1 -n 1 mpas_analysis $run_config_file
-
 

--- a/configs/cori/job_script.cori-knl.bash
+++ b/configs/cori/job_script.cori-knl.bash
@@ -30,8 +30,7 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 
 export OMP_NUM_THREADS=1
 
-source /global/cfs/cdirs/e3sm/software/anaconda_envs/load_latest_e3sm_unified.sh
-export HDF5_USE_FILE_LOCKING=FALSE
+source /global/common/software/e3sm/anaconda_envs/load_latest_e3sm_unified_cori-knl.sh
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed
@@ -43,9 +42,6 @@ if [ ! -f $run_config_file ]; then
 fi
 
 # For an E3SM cryosphere run, include configs/polarRegions.conf, or exclude
-# this extra config file for defalut parameters
+# this extra config file for default parameters
 srun -N 1 -n 1 mpas_analysis configs/polarRegions.conf $run_config_file
-
-# if using the mpas_analysis conda package instead of the git repo
-# srun -N 1 -n 1 mpas_analysis $run_config_file
 

--- a/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
+++ b/configs/lanl/config.20170207.MPAS-SeaIce.QU60km_polar.wolf
@@ -30,6 +30,11 @@ parallelTaskCount = 6
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/lanl/config.BGCphaeo4.testrun
+++ b/configs/lanl/config.BGCphaeo4.testrun
@@ -30,6 +30,11 @@ preprocessedReferenceRunName = B1850C5_ne30_v0.4
 parallelTaskCount = 6
 ncclimoParallelMode = bck
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/lanl/config.CONUS.100km.NAEC60to30cr8.20181218
+++ b/configs/lanl/config.CONUS.100km.NAEC60to30cr8.20181218
@@ -23,6 +23,11 @@ mainRunName = CONUS.100km.NAEC60to30cr8.20181218
 parallelTaskCount = 6
 ncclimoParallelMode = serial
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [input]
 ## options related to reading in the results to be analyzed
 

--- a/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
+++ b/configs/lanl/config.GMPAS-OECO-ODMS-IAF.oRRS30to10v3
@@ -30,6 +30,11 @@ preprocessedReferenceRunName = B1850C5_ne30_v0.4
 parallelTaskCount = 6
 ncclimoParallelMode = bck
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/lanl/config.MatchBoth_orig
+++ b/configs/lanl/config.MatchBoth_orig
@@ -30,6 +30,11 @@ parallelTaskCount = 6
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
+mapParallelExec = srun
+
 [diagnostics]
 ## config options related to observations, mapping files and region files used
 ## by MPAS-Analysis in diagnostics computations.

--- a/configs/lanl/job_script.lanl.bash
+++ b/configs/lanl/job_script.lanl.bash
@@ -24,18 +24,11 @@ cd $SLURM_SUBMIT_DIR   # optional, since this is the default behavior
 
 export OMP_NUM_THREADS=1
 
-module unload python e3sm-unified
-module use /usr/projects/climate/SHARED_CLIMATE/modulefiles/all
-module load e3sm-unified/1.2.0
-export HDF5_USE_FILE_LOCKING=FALSE
+source /usr/projects/climate/SHARED_CLIMATE/anaconda_envs/load_latest_e3sm_unified_grizzly.sh
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed
 run_config_file="config.run_name_here"
-# command to run a serial job on a single node on edison
-command="mpas_analysis"
-# to use the verison of mpas_analysis from a conda package instead, use:
-#command="mpas_analysis"
 # one parallel task per node by default
 parallel_task_count=12
 # ncclimo can run with 1 (serial) or 12 (bck) threads
@@ -66,5 +59,5 @@ ncclimoParallelMode = $ncclimo_mode
 
 EOF
 
-$command $run_config_file $job_config_file
+mpas_analysis $run_config_file $job_config_file
 

--- a/configs/lcrc/20201025.GMPAS-IAF.T62_oQU240wLI.anvil.cfg
+++ b/configs/lcrc/20201025.GMPAS-IAF.T62_oQU240wLI.anvil.cfg
@@ -30,9 +30,14 @@ parallelTaskCount = 6
 # handle 12 simultaneous processes, one for each monthly climatology.
 ncclimoParallelMode = bck
 
-# "None" if ESMF should perform remapping in serial without a command, or one of# "srun" or "mpirun" if it should be run in parallel  (or in serial but with a
-# command)
+# "None" if ESMF should perform mapping file generation in serial without a
+# command, or one of "srun" or "mpirun" if it should be run in parallel (or ins
+# serial but with a command)
 mapParallelExec = srun
+
+# "None" if ncremap should perform remapping without a command, or "srun"
+# possibly with some flags if it should be run with that command
+ncremapParallelExec = srun
 
 [diagnostics]
 ## config options related to observations, mapping files and region files used

--- a/configs/lcrc/job_script.anvil.bash
+++ b/configs/lcrc/job_script.anvil.bash
@@ -10,8 +10,7 @@
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 
-source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified.sh
-export HDF5_USE_FILE_LOCKING=FALSE
+source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_anvil.sh
 
 srun -N 1 -n 1 mpas_analysis configs/polarRegions.conf 20201025.GMPAS-IAF.T62_oQU240wLI.anvil.cfg
 

--- a/configs/lcrc/job_script.chrysalis.bash
+++ b/configs/lcrc/job_script.chrysalis.bash
@@ -8,8 +8,7 @@
 cd $SLURM_SUBMIT_DIR
 export OMP_NUM_THREADS=1
 
-source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified.sh
-export HDF5_USE_FILE_LOCKING=FALSE
+source /lcrc/soft/climate/e3sm-unified/load_latest_e3sm_unified_chrysalis.sh
 
 srun -N 1 -n 1 mpas_analysis configs/polarRegions.conf 20201025.GMPAS-IAF.T62_oQU240wLI.anvil.cfg
 

--- a/configs/olcf/job_script.olcf.bash
+++ b/configs/olcf/job_script.olcf.bash
@@ -25,8 +25,7 @@
 
 cd $PBS_O_WORKDIR
 
-source /ccs/proj/cli900/sw/rhea/e3sm-unified/load_latest_e3sm_unified.csh
-export HDF5_USE_FILE_LOCKING=FALSE
+source /ccs/proj/cli900/sw/andes/e3sm-unified/load_latest_e3sm_unified_andes.csh
 
 # MPAS/ACME job to be analyzed, including paths to simulation data and
 # observations. Change this name and path as needed


### PR DESCRIPTION
The example job scripts now refer to the location where E3SM-Unified 1.5.0 will be installed on each supported machine.  The config options include those needed to support system MPI (on machines where that is part of E3SM-Unified) on compute nodes. These are the parallel executables that are prefixes to the command line for generating mapping files and for calling ncremap (either `srun` or the default `None`, depending on the machine).

The documentation has also been updated to describe the parallel prefixes.