### PR TITLE
Fix the name of the chlorophyll field for comparison

### DIFF
--- a/mpas_analysis/ocean/climatology_map_bgc.py
+++ b/mpas_analysis/ocean/climatology_map_bgc.py
@@ -178,7 +178,7 @@ class ClimatologyMapBGC(AnalysisTask):  # {{{
                 galleryName = None
                 refTitleLabel = 'Control: {}'.format(controlRunName)
 
-                refFieldName = mpasFieldName
+                refFieldName = plotField
                 outFileLabel = fieldName
                 diffTitleLabel = 'Main - Control'
 


### PR DESCRIPTION
The name of the field was `timeMonthly_avg_ecosysTracers_Chl` instead of simply `Chl`.

closes #825 