### PR TITLE
Remove extra factor of landIceFraciton in melt fluxes

### DIFF
--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -440,15 +440,16 @@ class AntarcticMeltTableSubtask(AnalysisTask):
                     self.runStreams.readpath('restart')[0]
 
                 dsRestart = xr.open_dataset(restartFileName)
-                areaCell = \
-                    dsRestart.landIceFraction.isel(Time=0) * dsRestart.areaCell
+                landIceFraction = dsRestart.landIceFraction.isel(Time=0)
+                areaCell = dsRestart.areaCell
 
                 # convert from kg/s to kg/yr
                 totalMeltFlux = constants.sec_per_year * \
                     (cellMasks * areaCell * freshwaterFlux).sum(dim='nCells')
                 totalMeltFlux.compute()
 
-                totalArea = (cellMasks * areaCell).sum(dim='nCells')
+                totalArea = \
+                    (landIceFraction * cellMasks * areaCell).sum(dim='nCells')
 
                 # from kg/m^2/yr to m/yr
                 meltRates = ((1. / constants.rho_fw) *

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -293,8 +293,8 @@ class ComputeMeltSubtask(AnalysisTask):  # {{{
             mpasTimeSeriesTask.runStreams.readpath('restart')[0]
 
         dsRestart = xarray.open_dataset(restartFileName)
-        areaCell = \
-            dsRestart.landIceFraction.isel(Time=0) * dsRestart.areaCell
+        landIceFraction = dsRestart.landIceFraction.isel(Time=0)
+        areaCell = dsRestart.areaCell
 
         regionMaskFileName = self.masksSubtask.maskFileName
 
@@ -336,7 +336,8 @@ class ComputeMeltSubtask(AnalysisTask):  # {{{
                 totalMeltFlux = constants.sec_per_year * \
                     (cellMask * areaCell * freshwaterFlux).sum(dim='nCells')
 
-                totalArea = (cellMask * areaCell).sum(dim='nCells')
+                totalArea = \
+                    (landIceFraction * cellMask * areaCell).sum(dim='nCells')
 
                 # from kg/m^2/yr to m/yr
                 meltRates[regionIndex] = ((1. / constants.rho_fw) *


### PR DESCRIPTION
Both melt fluxes and melt rates have been computed incorrectly. Freshwater fluxes were being multiplied by `landIceFraction` in MPAS analysis but this factor is already part of these fluxes from MPAS-Ocean, so the extra factor is incorrect.

This bug was present in both melt flux and melt rate time series, and also in melt flux and melt rate tables.