### PR TITLE
Constrain to exclude python 3.10

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -18,10 +18,10 @@ build:
 
 requirements:
   host:
-    - python >=3.7
+    - python >=3.7,<3.10
     - pip
   run:
-    - python >=3.7
+    - python >=3.7,<3.10
     - bottleneck
     - cartopy >=0.18.0
     - cartopy_offlinedata

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -2,7 +2,7 @@
 # $ conda create --name <env> --file <this file>
 
 # Base
-python>=3.7
+python>=3.7,<3.10
 bottleneck
 cartopy >=0.18.0
 cartopy_offlinedata


### PR DESCRIPTION
conda-forge clearly isn't ready for it yet.