### PR TITLE
Add python 3.10 support and testing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,12 +21,12 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
       Python38:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python310:
+        python.version: '3.10'
 
   steps:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
@@ -63,7 +63,7 @@ jobs:
       conda create --yes --quiet --name docs -c ${CONDA_PREFIX}/conda-bld/ \
           python=$PYTHON_VERSION mpas-analysis sphinx mock sphinx_rtd_theme \
           tabulate m2r
-    condition: eq(variables['python.version'], '3.8')
+    condition: eq(variables['python.version'], '3.9')
     displayName: Create Anaconda docs environment
 
   - bash: |
@@ -128,7 +128,7 @@ jobs:
         fi
         popd || exit 1
       fi
-    condition: eq(variables['python.version'], '3.8')
+    condition: eq(variables['python.version'], '3.9')
     displayName: build and deploy docs
 
 - job:
@@ -137,8 +137,8 @@ jobs:
     vmImage: 'ubuntu-latest'
   strategy:
     matrix:
-      Python38:
-        python.version: '3.8'
+      Python39:
+        python.version: '3.9'
 
   steps:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"
@@ -178,12 +178,12 @@ jobs:
     vmImage: 'macOS-latest'
   strategy:
     matrix:
-      Python37:
-        python.version: '3.7'
       Python38:
         python.version: '3.8'
       Python39:
         python.version: '3.9'
+      Python310:
+        python.version: '3.10'
 
   steps:
   - bash: echo "##vso[task.prependpath]$CONDA/bin"

--- a/ci/python3.10.yaml
+++ b/ci/python3.10.yaml
@@ -5,4 +5,4 @@ pin_run_as_build:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.7.* *_cpython
+- 3.10.* *_cpython

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -18,10 +18,10 @@ build:
 
 requirements:
   host:
-    - python >=3.7,<3.10
+    - python >=3.7
     - pip
   run:
-    - python >=3.7,<3.10
+    - python >=3.7
     - bottleneck
     - cartopy >=0.18.0
     - cartopy_offlinedata

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -2,7 +2,7 @@
 # $ conda create --name <env> --file <this file>
 
 # Base
-python>=3.7,<3.10
+python>=3.7
 bottleneck
 cartopy >=0.18.0
 cartopy_offlinedata


### PR DESCRIPTION
This merge also removes python 3.7 from testing and makes python 3.9 the version for creating documentation and testing xarray's master branch