### PR TITLE
Improve model vs. obs transects on the native MPAS mesh

### DIFF
--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -445,19 +445,36 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         if remap:
             triangulation_args = None
-            dOutline = None
-            zOutline = None
+            dOutlineModel = None
+            zOutlineModel = None
         else:
             triangulation_args = self._get_ds_triangulation(
                 remappedModelClimatology)
-            dOutline, zOutline = get_outline_segments(remappedModelClimatology)
+            dOutlineModel, zOutlineModel = \
+                get_outline_segments(remappedModelClimatology)
 
         if remappedRefClimatology is None:
             refOutput = None
             bias = None
         else:
+            # todo: add a check to make sure the reference is on the same MPAS
+            #   mesh
             refOutput = remappedRefClimatology[self.refFieldName]
             bias = modelOutput - refOutput
+
+        if remappedRefClimatology is None or self.controlConfig is None:
+            # we don't want to use the same outline as the model for obs
+            dOutlineRef = None
+            zOutlineRef = None
+            dOutlineDiff = None
+            zOutlineDiff = None
+        else:
+            # we *do* want to use the same outline if we're comparing with
+            # another model run
+            dOutlineRef = dOutlineModel
+            zOutlineRef = zOutlineModel
+            dOutlineDiff = dOutlineModel
+            zOutlineDiff = zOutlineModel
 
         filePrefix = self.filePrefix
         outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
@@ -574,8 +591,12 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             xCoords=xs,
             zCoord=z,
             triangulation_args=triangulation_args,
-            xOutline=dOutline,
-            zOutline=zOutline,
+            xOutlineModel=dOutlineModel,
+            zOutlineModel=zOutlineModel,
+            xOutlineRef=dOutlineRef,
+            zOutlineRef=zOutlineRef,
+            xOutlineDiff=dOutlineDiff,
+            zOutlineDiff=zOutlineDiff,
             colorbarLabel=self.unitsLabel,
             xlabels=xLabels,
             ylabel=yLabel,

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -445,12 +445,12 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         if remap:
             triangulation_args = None
-            dOutlineModel = None
-            zOutlineModel = None
+            dOutline = None
+            zOutline = None
         else:
             triangulation_args = self._get_ds_triangulation(
                 remappedModelClimatology)
-            dOutlineModel, zOutlineModel = \
+            dOutline, zOutline = \
                 get_outline_segments(remappedModelClimatology)
 
         if remappedRefClimatology is None:
@@ -461,20 +461,6 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             #   mesh
             refOutput = remappedRefClimatology[self.refFieldName]
             bias = modelOutput - refOutput
-
-        if remappedRefClimatology is None or self.controlConfig is None:
-            # we don't want to use the same outline as the model for obs
-            dOutlineRef = None
-            zOutlineRef = None
-            dOutlineDiff = None
-            zOutlineDiff = None
-        else:
-            # we *do* want to use the same outline if we're comparing with
-            # another model run
-            dOutlineRef = dOutlineModel
-            zOutlineRef = zOutlineModel
-            dOutlineDiff = dOutlineModel
-            zOutlineDiff = zOutlineModel
 
         filePrefix = self.filePrefix
         outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
@@ -591,12 +577,12 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             xCoords=xs,
             zCoord=z,
             triangulation_args=triangulation_args,
-            xOutlineModel=dOutlineModel,
-            zOutlineModel=zOutlineModel,
-            xOutlineRef=dOutlineRef,
-            zOutlineRef=zOutlineRef,
-            xOutlineDiff=dOutlineDiff,
-            zOutlineDiff=zOutlineDiff,
+            xOutlineModel=dOutline,
+            zOutlineModel=zOutline,
+            xOutlineRef=dOutline,
+            zOutlineRef=zOutline,
+            xOutlineDiff=dOutline,
+            zOutlineDiff=zOutline,
             colorbarLabel=self.unitsLabel,
             xlabels=xLabels,
             ylabel=yLabel,
@@ -608,6 +594,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
             invertYAxis=False,
             backgroundColor='#d9bf96',
+            invalidColor='#eddabb',
             xLim=self.horizontalBounds,
             yLim=self.verticalBounds,
             compareAsContours=compareAsContours,
@@ -626,7 +613,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         suptitle.set_position((pos[0] - 0.05, pos[1]))
 
         if not remap:
-            # add open air ice shelves
+            # add open air and ice shelves
             d = remappedModelClimatology.dNode.values.ravel()
             ssh = remappedModelClimatology.ssh.values.ravel()
             mask = ssh < 0.

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -445,31 +445,14 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         if remap:
             triangulation_args = None
-            dOutlineModel = None
-            zOutlineModel = None
         else:
             triangulation_args = self._get_ds_triangulation(
                 remappedModelClimatology)
-            dOutlineModel, zOutlineModel = \
-                get_outline_segments(remappedModelClimatology)
-
-        if self.controlConfig is None:
-            dOutlineRef = None
-            zOutlineRef = None
-            dOutlineDiff = None
-            zOutlineDiff = None
-        else:
-            dOutlineRef = dOutlineModel
-            zOutlineRef = zOutlineModel
-            dOutlineDiff = dOutlineModel
-            zOutlineDiff = zOutlineModel
 
         if remappedRefClimatology is None:
             refOutput = None
             bias = None
         else:
-            # todo: add a check to make sure the reference is on the same MPAS
-            #   mesh
             refOutput = remappedRefClimatology[self.refFieldName]
             bias = modelOutput - refOutput
 
@@ -588,12 +571,6 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             xCoords=xs,
             zCoord=z,
             triangulation_args=triangulation_args,
-            xOutlineModel=dOutlineModel,
-            zOutlineModel=zOutlineModel,
-            xOutlineRef=dOutlineRef,
-            zOutlineRef=zOutlineRef,
-            xOutlineDiff=dOutlineDiff,
-            zOutlineDiff=zOutlineDiff,
             colorbarLabel=self.unitsLabel,
             xlabels=xLabels,
             ylabel=yLabel,
@@ -606,6 +583,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             invertYAxis=False,
             backgroundColor='#d9bf96',
             invalidColor='#d9bf96',
+            outlineValid=False,
             xLim=self.horizontalBounds,
             yLim=self.verticalBounds,
             compareAsContours=compareAsContours,
@@ -636,8 +614,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             mask = ssh < 0.
             for ax in axes:
                 ax.fill_between(d, ssh, numpy.zeros(ssh.shape), where=mask,
-                                interpolate=True, color=color,
-                                edgecolor='black', linewidth=1.)
+                                interpolate=True, color=color)
 
         # make a red start axis and green end axis to correspond to the dots
         # in the inset

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -21,7 +21,6 @@ from __future__ import absolute_import, division, print_function, \
 
 import xarray as xr
 import numpy
-from matplotlib.tri import Triangulation
 
 from geometric_features import FeatureCollection
 
@@ -53,8 +52,8 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
     transectName : str
         The name of the transect to plot
 
-    remapMpasClimatologySubtask : ``RemapMpasClimatologySubtask``
-        The subtask for remapping the MPAS climatology that this subtask
+    computeTransectsSubtask : ``ComputeTransectsSubtask``
+        The subtask for computing the MPAS climatology that this subtask
         will plot
 
     plotObs : bool, optional
@@ -76,12 +75,6 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
     mpasFieldName : str
         The name of the variable in the MPAS timeSeriesStatsMonthly output
-
-    obsFieldName : str
-        The name of the variable to use from the observations file
-
-    observationTitleLabel : str
-        the title of the observations subplot
 
     diffTitleLabel : str, optional
         the title of the difference subplot
@@ -114,7 +107,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
     # Xylar Asay-Davis, Greg Streletz
 
     def __init__(self, parentTask, season, transectName, fieldName,
-                 remapMpasClimatologySubtask, plotObs=True,
+                 computeTransectsSubtask, plotObs=True,
                  controlConfig=None, horizontalBounds=None):
         # {{{
         '''
@@ -136,8 +129,8 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         fieldName : str
             The name of the field to plot (for use in the subtask name only)
 
-        remapMpasClimatologySubtask : ``RemapMpasClimatologySubtask``
-            The subtask for remapping the MPAS climatology that this subtask
+        computeTransectsSubtask : ``ComputeTransectsSubtask``
+            The subtask for computing the MPAS climatology that this subtask
             will plot
 
         plotObs : bool, optional
@@ -157,7 +150,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         self.season = season
         self.transectName = transectName
-        self.remapMpasClimatologySubtask = remapMpasClimatologySubtask
+        self.computeTransectsSubtask = computeTransectsSubtask
         self.plotObs = plotObs
         self.controlConfig = controlConfig
         if horizontalBounds is not None and len(horizontalBounds) == 2:
@@ -179,7 +172,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         # this task should not run until the remapping subtasks are done, since
         # it relies on data from those subtasks
-        self.run_after(remapMpasClimatologySubtask)
+        self.run_after(computeTransectsSubtask)
         # }}}
 
     def set_plot_info(self, outFileLabel, fieldNameInTitle, mpasFieldName,
@@ -325,7 +318,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         # first read the model climatology
         remappedFileName = \
-            self.remapMpasClimatologySubtask.get_remapped_file_name(
+            self.computeTransectsSubtask.get_remapped_file_name(
                 season=season, comparisonGridName=transectName)
 
         remappedModelClimatology = xr.open_dataset(remappedFileName)
@@ -333,9 +326,9 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         # now the observations or control run
         if self.plotObs:
             verticalComparisonGridName = \
-                self.remapMpasClimatologySubtask.verticalComparisonGridName
+                self.computeTransectsSubtask.verticalComparisonGridName
             remappedFileName = \
-                self.remapMpasClimatologySubtask.obsDatasets.get_out_file_name(
+                self.computeTransectsSubtask.obsDatasets.get_out_file_name(
                     transectName,
                     verticalComparisonGridName)
             remappedRefClimatology = xr.open_dataset(remappedFileName)
@@ -348,7 +341,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
                     remappedRefClimatology, monthValues, maskVaries=True)
 
         elif self.controlConfig is not None:
-            climatologyName = self.remapMpasClimatologySubtask.climatologyName
+            climatologyName = self.computeTransectsSubtask.climatologyName
             remappedFileName = \
                 get_remapped_mpas_climatology_file_name(
                     self.controlConfig, season=season,
@@ -387,7 +380,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         mainRunName = config.get('runs', 'mainRunName')
 
-        remap = self.remapMpasClimatologySubtask.remap
+        remap = self.computeTransectsSubtask.remap
 
         if remap:
             x = 1e-3*remappedModelClimatology.x

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -613,22 +613,20 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
         suptitle.set_position((pos[0] - 0.05, pos[1]))
 
         if not remap:
-            # add open air and ice shelves
+            # add open ocean or ice shelves
             d = remappedModelClimatology.dNode.values.ravel()
             ssh = remappedModelClimatology.ssh.values.ravel()
+            if 'landIceFraction' in remappedModelClimatology:
+                # plot ice in light blue
+                color = '#e1eaf7'
+            else:
+                # plot open ocean in white
+                color = 'white'
             mask = ssh < 0.
             for ax in axes:
                 ax.fill_between(d, ssh, numpy.zeros(ssh.shape), where=mask,
-                                interpolate=True, color='white',
+                                interpolate=True, color=color,
                                 edgecolor='black', linewidth=1.)
-            if 'landIceFraction' in remappedModelClimatology:
-                landIceFraction = remappedModelClimatology.landIceFraction
-                landIceMask = landIceFraction.values.ravel() > 0.25
-                mask = numpy.logical_and(landIceMask, ssh < 0.)
-                for ax in axes:
-                    ax.fill_between(d, ssh, numpy.zeros(ssh.shape), where=mask,
-                                    interpolate=False, color='#e1eaf7',
-                                    edgecolor='black', linewidth=1.)
 
         # make a red start axis and green end axis to correspond to the dots
         # in the inset

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -445,13 +445,24 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
 
         if remap:
             triangulation_args = None
-            dOutline = None
-            zOutline = None
+            dOutlineModel = None
+            zOutlineModel = None
         else:
             triangulation_args = self._get_ds_triangulation(
                 remappedModelClimatology)
-            dOutline, zOutline = \
+            dOutlineModel, zOutlineModel = \
                 get_outline_segments(remappedModelClimatology)
+
+        if self.controlConfig is None:
+            dOutlineRef = None
+            zOutlineRef = None
+            dOutlineDiff = None
+            zOutlineDiff = None
+        else:
+            dOutlineRef = dOutlineModel
+            zOutlineRef = zOutlineModel
+            dOutlineDiff = dOutlineModel
+            zOutlineDiff = zOutlineModel
 
         if remappedRefClimatology is None:
             refOutput = None
@@ -577,12 +588,12 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             xCoords=xs,
             zCoord=z,
             triangulation_args=triangulation_args,
-            xOutlineModel=dOutline,
-            zOutlineModel=zOutline,
-            xOutlineRef=dOutline,
-            zOutlineRef=zOutline,
-            xOutlineDiff=dOutline,
-            zOutlineDiff=zOutline,
+            xOutlineModel=dOutlineModel,
+            zOutlineModel=zOutlineModel,
+            xOutlineRef=dOutlineRef,
+            zOutlineRef=zOutlineRef,
+            xOutlineDiff=dOutlineDiff,
+            zOutlineDiff=zOutlineDiff,
             colorbarLabel=self.unitsLabel,
             xlabels=xLabels,
             ylabel=yLabel,
@@ -594,7 +605,7 @@ class PlotTransectSubtask(AnalysisTask):  # {{{
             upperXAxisTickLabelPrecision=upperXAxisTickLabelPrecision,
             invertYAxis=False,
             backgroundColor='#d9bf96',
-            invalidColor='#eddabb',
+            invalidColor='#d9bf96',
             xLim=self.horizontalBounds,
             yLim=self.verticalBounds,
             compareAsContours=compareAsContours,

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -928,7 +928,8 @@ def plot_vertical_section(
             # also outline the domain if provided
             plt.plot(xOutline, zOutline, color='black', linewidth=1)
         else:
-            # do a contour to outline the boundary between valid and invalid values
+            # do a contour to outline the boundary between valid and invalid
+            # values
             landMask = np.isnan(field.values).ravel()
             plt.tricontour(unmaskedTriangulation, landMask, levels=[0.0001],
                            colors='black', linewidths=1)

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -41,8 +41,12 @@ def plot_vertical_section_comparison(
         xCoords=None,
         zCoord=None,
         triangulation_args=None,
-        xOutline=None,
-        zOutline=None,
+        xOutlineModel=None,
+        zOutlineModel=None,
+        xOutlineRef=None,
+        zOutlineRef=None,
+        xOutlineDiff=None,
+        zOutlineDiff=None,
         colorbarLabel=None,
         xlabels=None,
         ylabel=None,
@@ -122,10 +126,18 @@ def plot_vertical_section_comparison(
         If this option is provided, ``xCoords`` is only used for tick marks if
         more than one x axis is requested, and ``zCoord`` will be ignored.
 
-    xOutline, zOutline : numpy.ndarray, optional
+    xOutlineModel, zOutlineModel : numpy.ndarray, optional
         pairs of points defining line segments that are used to outline the
-        valid region of the mesh if ``outlineValid = True`` and
-        ``triangulation_args`` is not ``None``
+        valid region of the mesh for the model panel if ``outlineValid = True``
+        and ``triangulation_args`` is not ``None``
+
+    xOutlineRef, zOutlineRef : numpy.ndarray, optional
+        Same as ``xOutlineModel`` and ``zOutlineModel`` but for the reference
+        panel
+
+    xOutlineDiff, zOutlineDiff : numpy.ndarray, optional
+        Same as ``xOutlineModel`` and ``zOutlineModel`` but for the difference
+        panel
 
     colorMapSectionName : str
         section name in ``config`` where color map info can be found.
@@ -383,8 +395,8 @@ def plot_vertical_section_comparison(
         xCoords=xCoords,
         zCoord=zCoord,
         triangulation_args=triangulation_args,
-        xOutline=xOutline,
-        zOutline=zOutline,
+        xOutline=xOutlineModel,
+        zOutline=zOutlineModel,
         suffix=resultSuffix,
         colorbarLabel=colorbarLabel,
         title=title,
@@ -431,8 +443,8 @@ def plot_vertical_section_comparison(
             xCoords=xCoords,
             zCoord=zCoord,
             triangulation_args=triangulation_args,
-            xOutline=xOutline,
-            zOutline=zOutline,
+            xOutline=xOutlineRef,
+            zOutline=zOutlineRef,
             suffix=resultSuffix,
             colorbarLabel=colorbarLabel,
             title=refTitle,
@@ -473,8 +485,8 @@ def plot_vertical_section_comparison(
             xCoords=xCoords,
             zCoord=zCoord,
             triangulation_args=triangulation_args,
-            xOutline=xOutline,
-            zOutline=zOutline,
+            xOutline=xOutlineDiff,
+            zOutline=zOutlineDiff,
             suffix=diffSuffix,
             colorbarLabel=colorbarLabel,
             title=diffTitle,
@@ -857,7 +869,7 @@ def plot_vertical_section(
     colormapDict = setup_colormap(config, colorMapSectionName,
                                   suffix=suffix)
 
-    if outlineValid and xOutline is not None or zOutline is not None:
+    if outlineValid and xOutline is not None and zOutline is not None:
         # we might have some invalid cells that are inside the outline.  Let's
         # make them white
         zeroArray = xr.zeros_like(field)
@@ -902,7 +914,7 @@ def plot_vertical_section(
         if xOutline is None or zOutline is None:
             # set the color for NaN or masked regions, and draw a black
             # outline around them; technically, the contour level used should
-            # be 1.0, but the contours don't show up when using 1.0, so 0.999
+            # be 0.0, but the contours don't show up when using 0.0, so 0.0001
             # is used instead
             landMask = np.isnan(field.values).ravel()
             plt.tricontour(unmaskedTriangulation, landMask, levels=[0.0001],

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -924,14 +924,15 @@ def plot_vertical_section(
     ax = plt.gca()
     ax.set_facecolor(backgroundColor)
     if outlineValid:
-        # do a contour to outline the boundary between valid and invalid values
-        landMask = np.isnan(field.values).ravel()
-        plt.tricontour(unmaskedTriangulation, landMask, levels=[0.0001],
-                       colors='black', linewidths=1)
-
         if xOutline is not None and zOutline is not None:
             # also outline the domain if provided
             plt.plot(xOutline, zOutline, color='black', linewidth=1)
+        else:
+            # do a contour to outline the boundary between valid and invalid values
+            landMask = np.isnan(field.values).ravel()
+            plt.tricontour(unmaskedTriangulation, landMask, levels=[0.0001],
+                           colors='black', linewidths=1)
+
 
     # plot contours, if they were requested
     contourLevels = colormapDict['contours']


### PR DESCRIPTION
After some discussion below, the most straightforward solution seems to be to remove the line between the topography and the colormap, and make the `NaN` color the same as the background color.

![image](https://user-images.githubusercontent.com/4179064/150652067-9643cc90-3251-482d-b430-990b1315bf6d.png)

closes #849 