### PR TITLE
`chmod` common HTML directory in test suite

### DIFF
--- a/suite/job_script.bash
+++ b/suite/job_script.bash
@@ -22,4 +22,5 @@ echo configs: {{ flags }} {{ config }}
 {{ parallel_exec }} mpas_analysis --purge {{ flags }} {{ config }} --verbose
 {{ parallel_exec }} mpas_analysis --html_only {{ flags }} {{ config }}
 
+chmod ugo+rx {{ html_base }}/{{ out_common_dir }}
 chmod -R ugo+rX {{ html_base }}/{{ out_subdir }}

--- a/suite/setup.py
+++ b/suite/setup.py
@@ -130,6 +130,7 @@ def main():
         out_subdir = os.path.join(machine, args.branch, f'main_py{args.python}')
     else:
         out_subdir = os.path.join(machine, args.branch, args.run)
+    out_common_dir = os.path.join(machine, args.branch)
 
     if machine == 'cori-haswell':
         execute_options = \
@@ -185,7 +186,7 @@ def main():
             sbatch=sbatch, conda_base=conda_base, conda_env=conda_env,
             machine=machine, flags=flags, config=config_from_job,
             parallel_exec=parallel_exec, html_base=html_base,
-            out_subdir=out_subdir)
+            out_subdir=out_subdir, out_common_dir=out_common_dir)
         with open(job, 'w') as job_file:
             job_file.write(job_text)
 


### PR DESCRIPTION
Before this fix, each test's directory was given appropriate world read/execute permissions but the common directory that all tests reside in was not necessarily world readable.