### PR TITLE
Fix masking of surface climatologies

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - pillow
     - progressbar2
     - pyproj
-    - pyremap >=0.0.13,<0.1.0
+    - pyremap >=0.0.14,<0.1.0
     - python-dateutil
     - requests
     - scipy

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -21,7 +21,7 @@ pandas
 pillow
 progressbar2
 pyproj
-pyremap>=0.0.13,<0.1.0
+pyremap>=0.0.14,<0.1.0
 python-dateutil
 requests
 scipy

--- a/mpas_analysis/shared/plot/climatology_map.py
+++ b/mpas_analysis/shared/plot/climatology_map.py
@@ -67,7 +67,7 @@ def plot_polar_comparison(
         the configuration, containing a [plot] section with options that
         control plotting
 
-    Lons, Lats : numpy.ndarray
+    lon, lat : float arrays
         longitude and latitude arrays
 
     modelArray, refArray : numpy.ndarray
@@ -663,6 +663,13 @@ def _add_stats(modelArray, refArray, diffArray, Lats, axes):
         ax=axes[0], loc='upper')
 
     if refArray is not None:
+        if isinstance(modelArray, np.ma.MaskedArray):
+            # make sure we're using the MPAS land mask for all 3 sets of stats
+            mask = modelArray.mask
+            if isinstance(refArray, np.ma.MaskedArray):
+                # mask invalid where either model or ref array is invalid
+                mask = np.logical_or(mask, refArray.mask)
+            refArray = np.ma.array(refArray, mask=mask)
         modelAnom = modelArray - modelMean
         modelVar = np.average(modelAnom ** 2, weights=weights)
         refMean = np.average(refArray, weights=weights)


### PR DESCRIPTION
What should be fill values were coming through as zeros.  A temporary fix is to use `validMask` to assign fill values.

closes #860 