### PR TITLE
Reduce ncclimo tasks for Anvil to 6

### DIFF
--- a/mpas_analysis/configuration/anvil.cfg
+++ b/mpas_analysis/configuration/anvil.cfg
@@ -14,7 +14,9 @@ ncclimoParallelMode = bck
 # the number of total threads to use when ncclimo runs in "bck" or "mpi" mode.
 # Reduce this number if ncclimo is crashing (maybe because it is out of memory).
 # The number of threads must be a factor of 12 (1, 2, 3, 4, 6 or 12).
-ncclimoThreads = 12
+
+# Anvil is experiencing out-of-memory errors with 12 tasks so reducing to 6
+ncclimoThreads = 6
 
 # the number of MPI tasks to use in creating mapping files (1 means tasks run in
 # serial, the default)


### PR DESCRIPTION
This is needed because of out-of-memory errors that have been seen in some recent runs.

closes #864 