### PR TITLE
Update test suite to kill jobs with invalid deps

### DIFF
--- a/suite/run_suite.bash
+++ b/suite/run_suite.bash
@@ -72,7 +72,7 @@ cd ..
 
 cd main_vs_ctrl
 echo main_vs_ctrl
-sbatch --dependency=afterok:${RES##* } job_script.bash
+sbatch --dependency=afterok:${RES##* } job_script.bash --kill-on-invalid-dep=yes
 cd ..
 
 for run in main_py${alt_py} wc_defaults no_ncclimo no_polar_regions \


### PR DESCRIPTION
On Anvil, the test suite has been leaving behind main vs. control jobs when the main job fails.  With a flag (`--kill-on-ivalid-dep=yes`), this shouldn't happen anymore.