### PR TITLE
Add WOCE and SOSE density contour plots

### DIFF
--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -2560,6 +2560,16 @@ normArgsDifference = {'vmin': -0.3, 'vmax': 0.3}
 contourLevelsDifference = []
 
 
+[wocePotentialDensityContourTransects]
+## options related to plotting WOCE transects with potential density contours
+
+# Whether to plot the transect as a single contour plot, as opposed to separate
+# panels for model, reference and difference.
+compareAsContoursOnSinglePlot = True
+
+contourLevelsResult = numpy.linspace(1027.2, 1028.5, 14)
+
+
 [geojsonTransects]
 ## options related to plotting model transects at points determined by a
 ## geojson file.  To generate your own geojson file, go to:

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -2841,9 +2841,10 @@ maxLat = -60
 longitudes = [318., 280., 253., 187., 117., 75., 0.]
 
 # a list of fields top plot for each transect.  All supported fields are listed
-# below.  Note that 'velocityMagnitude' cannot be plotted without
-# 'zonalVelocity' and 'meridionalVelocity' because the components are needed
-# to compute the magnitude.
+# below except 'potentialDensityContour', which is not plotted by default.
+# Note that 'velocityMagnitude' cannot be plotted without 'zonalVelocity' and
+# 'meridionalVelocity' because the components are needed to compute the
+# magnitude.
 fieldList = ['temperature', 'salinity', 'potentialDensity', 'zonalVelocity',
              'meridionalVelocity', 'velocityMagnitude']
 
@@ -3066,6 +3067,15 @@ normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
 # contour lines)
 #contourLevelsDifference = numpy.linspace(-0.2, 0.2, 9)
 contourLevelsDifference = 'none'
+
+[sosePotentialDensityContourTransects]
+## options related to plotting SOSE transects of potential density
+
+# Whether to plot the transect as a single contour plot, as opposed to separate
+# panels for model, reference and difference.
+compareAsContoursOnSinglePlot = True
+
+contourLevelsResult = numpy.linspace(1027.2, 1028., 9)
 
 [climatologyMapBGC]
 ## options related to plotting climatology mpas of BGC

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -2371,6 +2371,10 @@ upperXAxisTickLabelPrecision = 2
 # will be displayed as a heatmap (possibly also with contours)
 compareAsContoursOnSinglePlot = False
 
+# the line width to use for contours on heatmaps and for
+# contours of the model field on contour comparison plots
+contourLineWidth = 1
+
 # the line style to use for contours on heatmaps and for
 # contours of the model field on contour comparison plots
 contourLineStyle = solid
@@ -2391,7 +2395,7 @@ comparisonContourLineColor = red
 labelContoursOnHeatmaps = False
 
 # whether or not to label contours on contour comparison plots
-labelContoursOnContourComparisonPlots = True
+labelContoursOnContourComparisonPlots = False
 
 # the precision to use for contour labels
 contourLabelPrecision = 1

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -2373,7 +2373,7 @@ compareAsContoursOnSinglePlot = False
 
 # the line width to use for contours on heatmaps and for
 # contours of the model field on contour comparison plots
-contourLineWidth = 1
+contourLineWidth = 2
 
 # the line style to use for contours on heatmaps and for
 # contours of the model field on contour comparison plots
@@ -2382,6 +2382,10 @@ contourLineStyle = solid
 # the line color to use for contours on heatmaps and for
 # contours of the model field on contour comparison plots
 contourLineColor = black
+
+# the line width to use for observation or reference model contours in a
+# contour comparison plots
+comparisonContourLineWidth = 1
 
 # the line style to use for contours of the reference field
 # on contour comparison plots

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -2371,9 +2371,8 @@ upperXAxisTickLabelPrecision = 1
 # will be displayed as a heatmap (possibly also with contours)
 compareAsContoursOnSinglePlot = False
 
-# the line width to use for contours on heatmaps and for
-# contours of the model field on contour comparison plots
-contourLineWidth = 2
+# the line width to use for contours on heatmaps
+contourLineWidth = 1
 
 # the line style to use for contours on heatmaps and for
 # contours of the model field on contour comparison plots
@@ -2382,6 +2381,10 @@ contourLineStyle = solid
 # the line color to use for contours on heatmaps and for
 # contours of the model field on contour comparison plots
 contourLineColor = black
+
+# the line width to use for contours of the model field on contour comparison
+# plots
+mainContourLineWidth = 2
 
 # the line width to use for observation or reference model contours in a
 # contour comparison plots

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -2359,7 +2359,7 @@ numUpperTicks = 8
 # for values at upper axis ticks.  This value can be adjusted (in concert
 # with numUpperTicks) to avoid problems with overlapping numbers along the
 # upper axis.
-upperXAxisTickLabelPrecision = 2
+upperXAxisTickLabelPrecision = 1
 
 # Whether or not to compare fields on transects by displaying their contours
 # on a single pane plot.  If True, this will be done;  if False, the fields
@@ -2567,7 +2567,7 @@ contourLevelsDifference = []
 # panels for model, reference and difference.
 compareAsContoursOnSinglePlot = True
 
-contourLevelsResult = numpy.linspace(1027.2, 1028.5, 14)
+contourLevelsResult = [1027.2, 1027.4, 1027.6, 1027.7, 1027.8, 1027.85, 1027.9, 1027.95, 1028.0]
 
 
 [geojsonTransects]
@@ -3089,7 +3089,8 @@ contourLevelsDifference = 'none'
 # panels for model, reference and difference.
 compareAsContoursOnSinglePlot = True
 
-contourLevelsResult = numpy.linspace(1027.2, 1028., 9)
+contourLevelsResult = [1027.2, 1027.4, 1027.6, 1027.7, 1027.8, 1027.85, 1027.9, 1027.95, 1028.0]
+
 
 [climatologyMapBGC]
 ## options related to plotting climatology mpas of BGC

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -515,8 +515,13 @@ class PlotTransectSubtask(AnalysisTask):
         # what line styles and line colors to use, and whether and how
         # to label contours
 
-        compareAsContours = config.getboolean('transects',
-                                              'compareAsContoursOnSinglePlot')
+        if config.has_option(configSectionName,
+                             'compareAsContoursOnSinglePlot'):
+            compareAsContours = config.getboolean(
+                configSectionName, 'compareAsContoursOnSinglePlot')
+        else:
+            compareAsContours = config.getboolean(
+                'transects', 'compareAsContoursOnSinglePlot')
 
         contourLineStyle = config.get('transects', 'contourLineStyle')
         contourLineColor = config.get('transects', 'contourLineColor')

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -523,6 +523,7 @@ class PlotTransectSubtask(AnalysisTask):
             compareAsContours = config.getboolean(
                 'transects', 'compareAsContoursOnSinglePlot')
 
+        contourLineWidth = config.getint('transects', 'contourLineWidth')
         contourLineStyle = config.get('transects', 'contourLineStyle')
         contourLineColor = config.get('transects', 'contourLineColor')
         comparisonContourLineStyle = config.get('transects',
@@ -584,6 +585,7 @@ class PlotTransectSubtask(AnalysisTask):
             xLim=self.horizontalBounds,
             yLim=self.verticalBounds,
             compareAsContours=compareAsContours,
+            lineWidth=contourLineWidth,
             lineStyle=contourLineStyle,
             lineColor=contourLineColor,
             comparisonContourLineStyle=comparisonContourLineStyle,

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -623,7 +623,10 @@ class PlotTransectSubtask(AnalysisTask):
             ax.spines['left'].set_linewidth(4)
             ax.spines['right'].set_linewidth(4)
 
-        add_inset(fig, fc, width=1.5, height=1.5, xbuffer=0.1, ybuffer=0.1)
+        if compareAsContours:
+            add_inset(fig, fc, width=1.2, height=1.2, xbuffer=0.1, ybuffer=0.1)
+        else:
+            add_inset(fig, fc, width=1.5, height=1.5, xbuffer=0.1, ybuffer=0.1)
 
         savefig(outFileName, config, tight=False)
 

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -525,12 +525,13 @@ class PlotTransectSubtask(AnalysisTask):
             compareAsContours = config.getboolean(
                 'transects', 'compareAsContoursOnSinglePlot')
 
-        contourLineWidth = config.getfloat('transects', 'contourLineWidth')
         contourLineStyle = config.get('transects', 'contourLineStyle')
         comparisonContourLineStyle = config.get('transects',
                                                 'comparisonContourLineStyle')
 
         if compareAsContours:
+            contourLineWidth = \
+                config.getfloat('transects', 'mainContourLineWidth')
             contourLineColor = None
             comparisonContourLineColor = None
             contourColormap = PlotTransectSubtask._get_contour_colormap()
@@ -539,6 +540,7 @@ class PlotTransectSubtask(AnalysisTask):
             comparisonContourLineWidth = \
                 config.getfloat('transects', 'comparisonContourLineWidth')
         else:
+            contourLineWidth = config.getfloat('transects', 'contourLineWidth')
             contourLineColor = config.get('transects', 'contourLineColor')
             comparisonContourLineColor = None
             contourColormap = None

--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -525,7 +525,7 @@ class PlotTransectSubtask(AnalysisTask):
             compareAsContours = config.getboolean(
                 'transects', 'compareAsContoursOnSinglePlot')
 
-        contourLineWidth = config.getint('transects', 'contourLineWidth')
+        contourLineWidth = config.getfloat('transects', 'contourLineWidth')
         contourLineStyle = config.get('transects', 'contourLineStyle')
         comparisonContourLineStyle = config.get('transects',
                                                 'comparisonContourLineStyle')
@@ -533,17 +533,18 @@ class PlotTransectSubtask(AnalysisTask):
         if compareAsContours:
             contourLineColor = None
             comparisonContourLineColor = None
-            contourColormap, comparisonContourColormap = \
-                PlotTransectSubtask._get_contour_colormaps()
+            contourColormap = PlotTransectSubtask._get_contour_colormap()
             labelContours = config.getboolean(
                 'transects', 'labelContoursOnContourComparisonPlots')
+            comparisonContourLineWidth = \
+                config.getfloat('transects', 'comparisonContourLineWidth')
         else:
             contourLineColor = config.get('transects', 'contourLineColor')
             comparisonContourLineColor = None
             contourColormap = None
-            comparisonContourColormap = None
             labelContours = config.getboolean('transects',
                                               'labelContoursOnHeatmaps')
+            comparisonContourLineWidth = None
 
         contourLabelPrecision = config.getint('transects',
                                               'contourLabelPrecision')
@@ -596,9 +597,9 @@ class PlotTransectSubtask(AnalysisTask):
             lineStyle=contourLineStyle,
             lineColor=contourLineColor,
             contourColormap=contourColormap,
+            comparisonContourLineWidth=comparisonContourLineWidth,
             comparisonContourLineStyle=comparisonContourLineStyle,
             comparisonContourLineColor=comparisonContourLineColor,
-            comparisonContourColormap=comparisonContourColormap,
             labelContours=labelContours,
             contourLabelPrecision=contourLabelPrecision,
             plotTitleFontSize=titleFontSize,
@@ -854,18 +855,11 @@ class PlotTransectSubtask(AnalysisTask):
         return triangulation_args
 
     @staticmethod
-    def _get_contour_colormaps():
+    def _get_contour_colormap():
         # https://stackoverflow.com/a/18926541/7728169
 
-        cmap = cm.get_cmap('cmo.haline')
-        x = numpy.linspace(0., 1., 100)
-        # passes through 0 and 1, but slowly at 0 and fast at 1 to minimize
-        # the yellow, which is also in the "hot" colormap
-        main_cmap = colors.LinearSegmentedColormap.from_list(
-            f'trunc_{cmap.name}', cmap(x**1.2))
-
         cmap = cm.get_cmap('hot')
-        ref_cmap = colors.LinearSegmentedColormap.from_list(
+        cmap = colors.LinearSegmentedColormap.from_list(
             f'trunc_{cmap.name}', cmap(numpy.linspace(0.1, 0.85, 100)))
 
-        return main_cmap, ref_cmap
+        return cmap

--- a/mpas_analysis/ocean/sose_transects.py
+++ b/mpas_analysis/ocean/sose_transects.py
@@ -123,7 +123,13 @@ class SoseTransects(AnalysisTask):
               'units': r'm s$^{-1}$',
               'titleName': 'Velocity Magnitude',
               'obsFilePrefix': None,
-              'obsFieldName': 'velMag'}]
+              'obsFieldName': 'velMag'},
+             {'prefix': 'potentialDensityContour',
+              'mpas': 'timeMonthly_avg_potentialDensity',
+              'units': r'kg m$^{-3}$',
+              'titleName': 'Potential Density Contours',
+              'obsFilePrefix': 'pot_den',
+              'obsFieldName': 'potentialDensity'}]
 
         fieldList = config.getexpression(sectionName, 'fieldList')
         fields = [field for field in fields if field['prefix'] in fieldList]
@@ -323,7 +329,7 @@ class SoseTransectsObservations(TransectsObservations):
         for field in self.fields:
             prefix = field['obsFilePrefix']
             fieldName = field['obsFieldName']
-            if prefix is None:
+            if prefix is None or (dsObs is not None and fieldName in dsObs):
                 continue
             print('  {}'.format(field['prefix']))
 

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -148,6 +148,11 @@ verticalComparisonGridName = mpas
 # A range for the y axis (if any)
 verticalBounds = [-1500., 0.]
 
+# a list of fields top plot for each transect.
+fieldList = ['temperature', 'salinity', 'potentialDensity', 'zonalVelocity',
+             'meridionalVelocity', 'velocityMagnitude',
+             'potentialDensityContour']
+
 
 [soseTemperatureTransects]
 # options related to plotting SOSE transects of potential temperature

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -214,9 +214,12 @@ verticalComparisonGridName = mpas
 # Horizontal bounds of the plot (in km), or an empty list for automatic bounds
 # The bounds are a 2-element list of the minimum and maximum distance along the
 # transect
-horizontalBounds = {'WOCE_A21': [630., 830.],
-                    'WOCE_A23': [0., 200.],
-                    'WOCE_A12': [4620., 4820.]}
+horizontalBounds = {'WOCE_A21': [],
+                    'WOCE_A23': [],
+                    'WOCE_A12': [],
+                    'WOCE_A21_zoom': [630., 830.],
+                    'WOCE_A23_zoom': [0., 200.],
+                    'WOCE_A12_zoom': [4620., 4820.]}
 
 # A range for the y axis (if any)
 verticalBounds = [-4000., 0.]

--- a/mpas_analysis/shared/plot/colormap.py
+++ b/mpas_analysis/shared/plot/colormap.py
@@ -68,19 +68,24 @@ def setup_colormap(config, configSectionName, suffix=''):
 
     register_custom_colormaps()
 
-    colormapType = config.get(configSectionName,
-                              'colormapType{}'.format(suffix))
-    if colormapType == 'indexed':
-        (colormap, norm, levels, ticks) = _setup_indexed_colormap(
-            config, configSectionName, suffix=suffix)
-    elif colormapType == 'continuous':
-        (colormap, norm, ticks) = _setup_colormap_and_norm(
-            config, configSectionName, suffix=suffix)
-        levels = None
+    option = 'colormapType{}'.format(suffix)
+    if config.has_option(configSectionName, option):
+        colormapType = config.get(configSectionName, option)
+        if colormapType == 'indexed':
+            (colormap, norm, levels, ticks) = _setup_indexed_colormap(
+                config, configSectionName, suffix=suffix)
+        elif colormapType == 'continuous':
+            (colormap, norm, ticks) = _setup_colormap_and_norm(
+                config, configSectionName, suffix=suffix)
+            levels = None
+        else:
+            raise ValueError(f'config section {configSectionName} option '
+                             f'{option} is not "indexed" or "continuous"')
     else:
-        raise ValueError('config section {} option colormapType{} is not '
-                         '"indexed" or "continuous"'.format(
-                             configSectionName, suffix))
+        colormap = None
+        norm = None
+        levels = None
+        ticks = None
 
     option = 'contourLevels{}'.format(suffix)
     if config.has_option(configSectionName, option):

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -972,7 +972,10 @@ def plot_vertical_section(
         if len(contourLevels) == 0:
             # automatic calculation of contour levels
             contourLevels = None
-        cs1 = plt.tricontour(maskedTriangulation, field.values.ravel(),
+        mask = field.notnull()
+        fieldMasked = field.where(mask, 0.0).values.ravel()
+
+        cs1 = plt.tricontour(maskedTriangulation, fieldMasked,
                              levels=contourLevels,
                              colors=lineColor,
                              linestyles=lineStyle,
@@ -985,8 +988,10 @@ def plot_vertical_section(
         if plotAsContours and contourComparisonField is not None:
             if comparisonContourLineWidth is None:
                 comparisonContourLineWidth = lineWidth
+            mask = contourComparisonField.notnull()
+            fieldMasked = contourComparisonField.where(mask, 0.0).values.ravel()
             cs2 = plt.tricontour(maskedComparisonTriangulation,
-                                 contourComparisonField.values.ravel(),
+                                 fieldMasked,
                                  levels=contourLevels,
                                  colors=comparisonContourLineColor,
                                  linestyles=comparisonContourLineStyle,

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -980,7 +980,7 @@ def plot_vertical_section(
             comparisonFieldName = (comparisonFieldName + " (" +
                                    colorbarLabel + ")")
         ax.legend([h1[0], h2[0]], [originalFieldName, comparisonFieldName],
-                  loc='upper center', bbox_to_anchor=(0.5, -0.25), ncol=1)
+                  loc='upper center', bbox_to_anchor=(0.5, -0.15), ncol=1)
 
     if title is not None:
         if plotAsContours and labelContours \

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -858,6 +858,11 @@ def plot_vertical_section(
         mask = field.notnull()
         maskedTriangulation, unmaskedTriangulation = _get_triangulation(
             x, y, mask)
+        if contourComparisonField is not None:
+            mask = field.notnull()
+            maskedComparisonTriangulation, _ = _get_triangulation(x, y, mask)
+        else:
+            maskedComparisonTriangulation = None
     else:
         mask = field.notnull()
         triMask = np.logical_not(mask.values)
@@ -867,6 +872,15 @@ def plot_vertical_section(
         mask_args = dict(triangulation_args)
         mask_args['mask'] = triMask
         maskedTriangulation = Triangulation(**mask_args)
+        if contourComparisonField is not None:
+            mask = contourComparisonField.notnull()
+            triMask = np.logical_not(mask.values)
+            triMask = np.amax(triMask, axis=1)
+            mask_args = dict(triangulation_args)
+            mask_args['mask'] = triMask
+            maskedComparisonTriangulation = Triangulation(**mask_args)
+        else:
+            maskedComparisonTriangulation = None
 
     # set up figure
     if dpi is None:
@@ -949,7 +963,7 @@ def plot_vertical_section(
             fmt_string = "%%1.%df" % int(contourLabelPrecision)
             plt.clabel(cs1, fmt=fmt_string)
         if plotAsContours and contourComparisonField is not None:
-            cs2 = plt.tricontour(maskedTriangulation,
+            cs2 = plt.tricontour(maskedComparisonTriangulation,
                                  contourComparisonField.values.ravel(),
                                  levels=contourLevels,
                                  colors=comparisonContourLineColor,


### PR DESCRIPTION
A request was made by the cryosphere team for density contour plots that can be compared either with observations (or SOSE) or against other model runs.  The aim with these plots is to compare the slopes of isopicnals as we vary eddy parameterizations (GM and Redi).

This merge adds galleries of density contour plots on WOCE and SOSE transects.  Here are two WOCE examples:
![image](https://user-images.githubusercontent.com/4179064/170615261-c2f30962-2612-4f63-85c1-bf56cbbf8853.png)
![image](https://user-images.githubusercontent.com/4179064/170615301-97dece69-6eac-4d0c-b646-2773f7f69b45.png)

This merge also fixes several issues that emerged in contour comparison plots.  We have not tried them since moving to plotting transects with triangles on the native MPAS grid.  Some problems emerged, most notably that contours on triangles do not seem to allow value labels on the contours themselves.

As an alternative to contour labels, plots with color maps have been used instead.  The color maps were chosen to try to maximize the distinction both between contours with the same color map and between the 2 color maps.

It seems useful to plot both the full WOCE transects and the shorter "zooms" close to the Antarctic coast, so this merge makes that the default for polar regions:
![image](https://user-images.githubusercontent.com/4179064/170615375-210ce24d-043f-47ba-ac80-4f19329dff8f.png)
![image](https://user-images.githubusercontent.com/4179064/170615389-2dd668b5-6682-414a-b347-83caa414fdea.png)

