### PR TITLE
Add back legend for Antarctic melt flux time series

### DIFF
--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -661,10 +661,6 @@ class PlotMeltSubtask(AnalysisTask):
         else:
             defaultFontSize = None
 
-        if self.iceShelf != 'Antarctica' and self.iceShelf != 'Filchner':
-            # we only need the legend in those 2
-            legendText = None
-
         fig = timeseries_analysis_plot(config, fields, calendar=calendar,
                                        title=title, xlabel=xLabel,
                                        ylabel=yLabel,


### PR DESCRIPTION
This was erroneously removed in https://github.com/MPAS-Dev/MPAS-Analysis/pull/806, probably because it was useful for some one-off analysis for publication figures.