### PR TITLE
Fix region masking in observations

### DIFF
--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -77,7 +77,7 @@ class RegionalTSDiagrams(AnalysisTask):
         regionMasksTask : ``ComputeRegionMasks``
             A task for computing region masks
 
-        controlconfig : mpas_tools.config.MpasConfigParser, optional
+        controlConfig : mpas_tools.config.MpasConfigParser, optional
             Configuration options for a control run (if any)
         """
         # Authors
@@ -715,7 +715,7 @@ class ComputeRegionTSSubtask(AnalysisTask):
                 xarray.open_dataset(regionMaskFileName).chunk(chunk).stack(
                         nCells=(obsDict['latVar'], obsDict['lonVar']))
             dsRegionMask = dsRegionMask.reset_index('nCells').drop_vars(
-                [obsDict['latVar'], obsDict['lonVar']])
+                [obsDict['latVar'], obsDict['lonVar'], 'nCells'])
 
             maskRegionNames = decode_strings(dsRegionMask.regionNames)
             regionIndex = maskRegionNames.index(self.regionName)
@@ -745,7 +745,7 @@ class ComputeRegionTSSubtask(AnalysisTask):
             ds = xarray.open_dataset(obsFileName, chunks=chunk)
             ds = ds.stack(nCells=(obsDict['latVar'], obsDict['lonVar']))
             ds = ds.reset_index('nCells').drop_vars(
-                [obsDict['latVar'], obsDict['lonVar']])
+                [obsDict['latVar'], obsDict['lonVar'], 'nCells'])
 
             ds = ds.where(cellMask, drop=True)
 

--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -658,12 +658,9 @@ class ComputeRegionTSSubtask(AnalysisTask):
 
             ds = ds.where(cellMask, drop=True)
 
-            self.logger.info("Don't worry about the following dask "
-                             "warnings.")
             depthMask = numpy.logical_and(ds.zMid >= zmin,
                                           ds.zMid <= zmax)
             depthMask.compute()
-            self.logger.info("Dask warnings should be done.")
             ds['depthMask'] = depthMask
 
             for var in variableList:

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -871,7 +871,7 @@ class ComputeObsRegionalTimeSeriesSubtask(AnalysisTask):
             xarray.open_dataset(regionMaskFileName).stack(
                     nCells=(obsDict['latVar'], obsDict['lonVar']))
         dsRegionMask = dsRegionMask.reset_index('nCells').drop_vars(
-            [obsDict['latVar'], obsDict['lonVar']])
+            [obsDict['latVar'], obsDict['lonVar'], 'nCells'])
 
         maskRegionNames = decode_strings(dsRegionMask.regionNames)
         regionIndex = maskRegionNames.index(self.regionName)
@@ -956,7 +956,7 @@ class ComputeObsRegionalTimeSeriesSubtask(AnalysisTask):
             dsMonth = dsMonth.stack(nCells=(obsDict['latVar'],
                                             obsDict['lonVar']))
             dsMonth = dsMonth.reset_index('nCells').drop_vars(
-                [obsDict['latVar'], obsDict['lonVar']])
+                [obsDict['latVar'], obsDict['lonVar'], 'nCells'])
 
             dsMonth = dsMonth.where(cellMask, drop=True)
 


### PR DESCRIPTION
It appears a recent change in xarray or dask has broken the way MPAS-Analysis currently handles region masking on lon/lat grids (i.e. for observations).  A seemingly inconsistent multi-index called `nCells` is generated when going from the 2D lon/lat space to a 1D "unraveled" coordinate.  The easiest way to handle this seems to just be to drop the `nCells` multi-index from both the mask and the data set to be masked.