### PR TITLE
Fix config options for reference-year climatologies 

### DIFF
--- a/mpas_analysis/shared/climatology/ref_year_mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/ref_year_mpas_climatology_task.py
@@ -100,10 +100,12 @@ class RefYearMpasClimatologyTask(MpasClimatologyTask):
         startDate = '{:04d}-01-01_00:00:00'.format(startYear)
         endDate = '{:04d}-12-31_23:59:59'.format(endYear)
 
-        config.set('climatology', 'startYear', str(startYear))
-        config.set('climatology', 'startDate', startDate)
-        config.set('climatology', 'endYear', str(endYear))
-        config.set('climatology', 'endDate', endDate)
+        # using "user=True" so these changes take priority over user config
+        # options
+        config.set('climatology', 'startYear', str(startYear), user=True)
+        config.set('climatology', 'startDate', startDate, user=True)
+        config.set('climatology', 'endYear', str(endYear), user=True)
+        config.set('climatology', 'endDate', endDate, user=True)
 
         return startYear, endYear
 


### PR DESCRIPTION
The start and end year for reference climatologies were getting overridden by the user's specified start and end year for normal climatologies.

(This maybe suggests that we should consider a different strategy for setting the start and end years and dates for reference climatologies that doesn't rely on overriding the user config options.)

This fixes issues where the OHC anomaly plots were exactly zero.

closes #883 