### PR TITLE
Update postprocessed MOC to match analysis member

### DIFF
--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -324,7 +324,7 @@ class ComputeMOCClimatologySubtask(AnalysisTask):
             if self.includeSubmesoscale:
                 variableList.extend(
                     ['timeMonthly_avg_normalMLEvelocity',
-                     'timeMonthly_avg_vertMLEVelocityTop'])
+                     'timeMonthly_avg_vertMLEBolusVelocityTop'])
 
 
         self.mpasClimatologyTask.add_variables(variableList=variableList,
@@ -547,7 +547,7 @@ class ComputeMOCClimatologySubtask(AnalysisTask):
 
             annualClimatology['avgVertVelocityTop'] = \
                 annualClimatology['avgVertVelocityTop'] + \
-                annualClimatology['timeMonthly_avg_vertMLEVelocityTop']
+                annualClimatology['timeMonthly_avg_vertMLEBolusVelocityTop']
 
         # Convert to numpy arrays
         # (can result in a memory error for large array size)
@@ -940,7 +940,7 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):
             if self.includeSubmesoscale:
                 self.variableList.extend(
                     ['timeMonthly_avg_normalMLEvelocity',
-                     'timeMonthly_avg_vertMLEVelocityTop'])
+                     'timeMonthly_avg_vertMLEBolusVelocityTop'])
 
     def run_task(self):
         """
@@ -1274,7 +1274,7 @@ class ComputeMOCTimeSeriesSubtask(AnalysisTask):
 
                 dsLocal['avgVertVelocityTop'] = \
                     dsLocal['avgVertVelocityTop'] + \
-                    dsLocal['timeMonthly_avg_vertMLEVelocityTop']
+                    dsLocal['timeMonthly_avg_vertMLEBolusVelocityTop']
 
             horizontalVel = dsLocal.avgNormalVelocity.values
             verticalVel = dsLocal.avgVertVelocityTop.values

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -1538,7 +1538,8 @@ def _compute_moc(latBins, nz, latCell, regionCellMask, transportZ,
     """compute meridionally integrated MOC streamfunction"""
 
     mocTop = np.zeros([np.size(latBins), nz + 1])
-    mocTop[0, range(1, nz + 1)] = transportZ.cumsum()
+    mocSouthBottomUp = - transportZ[::-1].cumsum()
+    mocTop[0, 0:nz] = mocSouthBottomUp[::-1]
     for iLat in range(1, np.size(latBins)):
         indlat = np.logical_and(np.logical_and(
             regionCellMask == 1, latCell >= latBins[iLat - 1]),


### PR DESCRIPTION
To match changes made in E3SM in https://github.com/E3SM-Project/E3SM/pull/5170, this merge changes the transport computation into the southern boundary of an MOC region to work from the bottom up rather than the top down.

This merge also adds the submesoscale velocity to the postprocessed MOC computation.

Finally, we also add the full AMOC to the time-series output for debugging and follow-up analysis.  No plots are made of these fields.