### PR TITLE
Switch to `noleap` instead of `gregorian_noleap`

### DIFF
--- a/mpas_analysis/ocean/index_nino34.py
+++ b/mpas_analysis/ocean/index_nino34.py
@@ -328,7 +328,7 @@ class IndexNino34(AnalysisTask):
         regionSST : xarray.DataArray object
            values of SST in the nino region
 
-        calendar: {'gregorian', 'gregorian_noleap'}
+        calendar: {'gregorian', 'noleap'}
             The name of the calendars used in the MPAS run
 
         Returns

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -525,7 +525,7 @@ class TimeSeriesSeaIce(AnalysisTask):
             length of dsToReplicate plus the time between the first two time
             values (typically one year total).
 
-        calendar : {'gregorian', 'gregorian_noleap'}
+        calendar : {'gregorian', 'noleap'}
             The name of one of the calendars supported by MPAS cores
 
         Returns:

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -147,7 +147,7 @@ def compute_monthly_climatology(ds, calendar=None, maskVaries=True):
         A data set with a ``Time`` coordinate expressed as days since
         0001-01-01 or ``month`` coordinate
 
-    calendar : {'gregorian', 'gregorian_noleap'}, optional
+    calendar : {'gregorian', 'noleap'}, optional
         The name of one of the calendars supported by MPAS cores, used to
         determine ``month`` from ``Time`` coordinate, so must be supplied if
         ``ds`` does not already have a ``month`` coordinate or data array
@@ -201,7 +201,7 @@ def compute_climatology(ds, monthValues, calendar=None,
     monthValues : int or array-like of ints
         A single month or an array of months to be averaged together
 
-    calendar : {'gregorian', 'gregorian_noleap'}, optional
+    calendar : {'gregorian', 'noleap'}, optional
         The name of one of the calendars supported by MPAS cores, used to
         determine ``month`` from ``Time`` coordinate, so must be supplied if
         ``ds`` does not already have a ``month`` coordinate or data array
@@ -242,7 +242,7 @@ def add_years_months_days_in_month(ds, calendar=None):
     """
     Add ``year``, ``month`` and ``daysInMonth`` as data arrays in ``ds``.
     The number of days in each month of ``ds`` is computed either using the
-    ``startTime`` and ``endTime`` if available or assuming ``gregorian_noleap``
+    ``startTime`` and ``endTime`` if available or assuming ``noleap``
     calendar and ignoring leap years.  ``year`` and ``month`` are computed
     accounting correctly for the the calendar.
 
@@ -252,7 +252,7 @@ def add_years_months_days_in_month(ds, calendar=None):
         A data set with a ``Time`` coordinate expressed as days since
         0001-01-01
 
-    calendar : {'gregorian', 'gregorian_noleap'}, optional
+    calendar : {'gregorian', 'noleap'}, optional
         The name of one of the calendars supported by MPAS cores, used to
         determine ``year`` and ``month`` from ``Time`` coordinate
 

--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -47,7 +47,7 @@ def open_multifile_dataset(fileNames, calendar, config,
     fileNames : list of strings
         A lsit of file paths to read
 
-    calendar : {``'gregorian'``, ``'gregorian_noleap'``}, optional
+    calendar : {``'gregorian'``, ``'noleap'``}, optional
         The name of one of the calendars supported by MPAS cores
 
     config : mpas_tools.config.MpasConfigParser
@@ -186,7 +186,7 @@ def _preprocess(ds, calendar, simulationStartTime, timeVariableName,
         an xarray time coordinate and with variable names to be
         substituted.
 
-    calendar : {'gregorian', 'gregorian_noleap'}
+    calendar : {'gregorian', 'noleap'}
         The name of one of the calendars supported by MPAS cores
 
         The name of the time variable (typically 'Time' if using a variableMap

--- a/mpas_analysis/shared/io/mpas_reader.py
+++ b/mpas_analysis/shared/io/mpas_reader.py
@@ -35,7 +35,7 @@ def open_mpas_dataset(fileName, calendar,
     fileName : str
         File path to read
 
-    calendar : {``'gregorian'``, ``'gregorian_noleap'``}, optional
+    calendar : {``'gregorian'``, ``'noleap'``}, optional
         The name of one of the calendars supported by MPAS cores
 
     timeVariableNames : str or list of 2 str, optional
@@ -120,7 +120,7 @@ def _parse_dataset_time(ds, inTimeVariableName, calendar,
         inTimeVariableName is typically
         ``['xtime_startMonthly', 'xtime_endMonthly']``.
 
-    calendar : {'gregorian', 'gregorian_noleap'}
+    calendar : {'gregorian', 'noleap'}
         The name of one of the calendars supported by MPAS cores
 
     outTimeVariableName : str

--- a/mpas_analysis/shared/io/namelist_streams_interface.py
+++ b/mpas_analysis/shared/io/namelist_streams_interface.py
@@ -390,7 +390,7 @@ class StreamsFile:
             and added to endDate because the file date might be the first
             or last date contained in the file (or anything in between).
 
-        calendar : {'gregorian', 'gregorian_noleap'}, optional
+        calendar : {'gregorian', 'noleap'}, optional
             The name of one of the calendars supported by MPAS cores, and is
             required if startDate and/or endDate are supplied
 

--- a/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
+++ b/mpas_analysis/shared/mpas_xarray/mpas_xarray.py
@@ -44,7 +44,7 @@ def open_multifile_dataset(fileNames, calendar,
     fileNames : list of strings
         A lsit of file paths to read
 
-    calendar : {``'gregorian'``, ``'gregorian_noleap'``}, optional
+    calendar : {'gregorian', 'noleap'}, optional
         The name of one of the calendars supported by MPAS cores
 
     simulationStartTime : string, optional
@@ -181,7 +181,7 @@ def preprocess(ds, calendar, simulationStartTime, timeVariableName,
         The data set containing an MPAS time variable to be used to build
         an xarray time coordinate.
 
-    calendar : {``'gregorian'``, ``'gregorian_noleap'``}
+    calendar : {'gregorian', 'noleap'}
         The name of one of the calendars supported by MPAS cores
 
     simulationStartTime : string, optinal
@@ -376,7 +376,7 @@ def _parse_dataset_time(ds, inTimeVariableName, calendar,
         determine the value of the time coordinate.  In such cases,
         inTimeVariableName is typically {['xtime_start', 'xtime_end']}.
 
-    calendar : {'gregorian', 'gregorian_noleap'}
+    calendar : {'gregorian', 'noleap'}
         The name of one of the calendars supported by MPAS cores
 
 

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -135,7 +135,7 @@ def cache_time_series(timesInDataSet, timeSeriesCalcFunction, cacheFileName,
         The absolute path to the cache file where the times series will be
         stored
 
-    calendar : {'gregorian', 'gregorian_noleap'}
+    calendar : {'gregorian', 'noleap'}
         The name of one of the calendars supported by MPAS cores, used to
         determine ``year`` and ``month`` from ``Time`` coordinate
 

--- a/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
+++ b/mpas_analysis/shared/timekeeping/MpasRelativeDelta.py
@@ -31,7 +31,7 @@ class MpasRelativeDelta(relativedelta):
 
     def __init__(self, dt1=None, dt2=None, years=0, months=0, days=0,
                  hours=0, minutes=0, seconds=0, calendar='gregorian'):
-        if calendar not in ['gregorian', 'gregorian_noleap']:
+        if calendar not in ['gregorian', 'noleap', 'gregorian_noleap']:
             raise ValueError('Unsupported MPAs calendar {}'.format(calendar))
         self.calendar = calendar
         super(MpasRelativeDelta, self).__init__(dt1=dt1, dt2=dt2, years=years,
@@ -79,7 +79,7 @@ class MpasRelativeDelta(relativedelta):
 
         if self.calendar == 'gregorian':
             daysInMonth = monthrange(year, month)[1]
-        elif self.calendar == 'gregorian_noleap':
+        elif self.calendar in ['noleap', 'gregorian_noleap']:
             # use year 0001, which is not a leapyear
             daysInMonth = monthrange(1, month)[1]
 
@@ -87,7 +87,7 @@ class MpasRelativeDelta(relativedelta):
         repl = {"year": year, "month": month, "day": day}
 
         days = self.days
-        if self.calendar == 'gregorian_noleap' and isleap(year):
+        if self.calendar in ['noleap', 'gregorian_noleap'] and isleap(year):
             if month == 2 and day + days >= 29:
                 # skip forward over the leap day
                 days += 1

--- a/mpas_analysis/shared/timekeeping/utility.py
+++ b/mpas_analysis/shared/timekeeping/utility.py
@@ -137,7 +137,7 @@ def string_to_relative_delta(dateString, calendar='gregorian'):
         Note: either underscores or spaces can be used to separate the date
         from the time portion of the string.
 
-    calendar: {'gregorian', 'gregorian_noleap'}, optional
+    calendar: {'gregorian', 'noleap'}, optional
         The name of one of the calendars supported by MPAS cores
 
     Returns
@@ -189,7 +189,7 @@ def string_to_days_since_date(dateString, calendar='gregorian',
         Note: either underscores or spaces can be used to separate the date
         from the time portion of the string.
 
-    calendar: {'gregorian', 'gregorian_noleap'}, optional
+    calendar: {'gregorian', 'noleap'}, optional
         The name of one of the calendars supported by MPAS cores
 
     referenceDate : str, optional
@@ -232,14 +232,14 @@ def string_to_days_since_date(dateString, calendar='gregorian',
 def days_to_datetime(days, calendar='gregorian', referenceDate='0001-01-01'):
     """
     Covert days to ``datetime.datetime`` objects given a reference date and an
-    MPAS calendar (either 'gregorian' or 'gregorian_noleap').
+    MPAS calendar (either 'gregorian' or 'noleap').
 
     Parameters
     ----------
     days : float or array-like of floats
         The number of days since the reference date.
 
-    calendar : {'gregorian', 'gregorian_noleap'}, optional
+    calendar : {'gregorian', 'noleap'}, optional
         A calendar to be used to convert days to a ``datetime.datetime``
         object.
 
@@ -293,7 +293,7 @@ def datetime_to_days(dates, calendar='gregorian', referenceDate='0001-01-01'):
         The date(s) to be converted to days since ``referenceDate`` on the
         given ``calendar``.
 
-    calendar : {'gregorian', 'gregorian_noleap'}, optional
+    calendar : {'gregorian', 'noleap'}, optional
         A calendar to be used to convert days to a ``datetime.datetime`` object.
 
     referenceDate : str, optional
@@ -342,7 +342,7 @@ def date_to_days(year=1, month=1, day=1, hour=0, minute=0, second=0,
         The date to be converted to days since ``referenceDate`` on the
         given ``calendar``.
 
-    calendar : {'gregorian', 'gregorian_noleap'}, optional
+    calendar : {'gregorian', 'noleap'}, optional
         A calendar to be used to convert days to a ``datetime.datetime``
         object.
 
@@ -469,7 +469,7 @@ def _mpas_to_netcdf_calendar(calendar):
 
     if calendar == 'gregorian_noleap':
         calendar = 'noleap'
-    elif calendar != 'gregorian':
+    if calendar not in ['gregorian', 'noleap']:
         raise ValueError('Unsupported calendar {}'.format(calendar))
     return calendar
 

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -197,7 +197,7 @@ class TestClimatology(TestCase):
 
     def test_compute_climatology(self):
         config = self.setup_config()
-        calendar = 'gregorian_noleap'
+        calendar = 'noleap'
         ds = self.open_test_ds(config, calendar)
 
         assert('month' not in ds.coords.keys())
@@ -237,7 +237,7 @@ class TestClimatology(TestCase):
 
     def test_compute_monthly_climatology(self):
         config = self.setup_config()
-        calendar = 'gregorian_noleap'
+        calendar = 'noleap'
         ds = self.open_test_ds(config, calendar)
 
         monthlyClimatology = compute_monthly_climatology(ds, calendar)

--- a/mpas_analysis/test/test_generalized_reader.py
+++ b/mpas_analysis/test/test_generalized_reader.py
@@ -56,7 +56,7 @@ class TestGeneralizedReader(TestCase):
                         'refBottomDepth', 'daysSinceStartOfSim']
 
         config = self.setup_config()
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
             # preprocess_mpas will use variableMap to map the variable names
             # from their values in the file to the desired values in
             # variableList
@@ -80,7 +80,7 @@ class TestGeneralizedReader(TestCase):
             ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
 
         config = self.setup_config()
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
             ds = open_multifile_dataset(
                 fileNames=fileName,
                 calendar=calendar,
@@ -97,7 +97,7 @@ class TestGeneralizedReader(TestCase):
             ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
 
         config = self.setup_config()
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
             # all dates
             ds = open_multifile_dataset(
                 fileNames=fileName,

--- a/mpas_analysis/test/test_mpas_climatology_task/mpas-o_in
+++ b/mpas_analysis/test/test_mpas_climatology_task/mpas-o_in
@@ -2,7 +2,7 @@
  config_ocean_run_mode = 'forward'
 /
 &time_management
- config_calendar_type = 'gregorian_noleap'
+ config_calendar_type = 'noleap'
  config_do_restart = .true.
  config_restart_timestamp_name = 'rpointer.ocn'
  config_start_time = 'file'

--- a/mpas_analysis/test/test_mpas_xarray.py
+++ b/mpas_analysis/test/test_mpas_xarray.py
@@ -29,7 +29,7 @@ class TestMpasXarray(TestCase):
 
     def test_subset_variables(self):
         fileName = str(self.datadir.join('example_jan.nc'))
-        calendar = 'gregorian_noleap'
+        calendar = 'noleap'
         timestr = ['xtime_start', 'xtime_end']
         variableList = \
             ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
@@ -63,7 +63,7 @@ class TestMpasXarray(TestCase):
 
     def test_iselvals(self):
         fileName = str(self.datadir.join('example_jan.nc'))
-        calendar = 'gregorian_noleap'
+        calendar = 'noleap'
         simulationStartTime = '0001-01-01'
         timestr = 'time_avg_daysSinceStartOfSim'
         variableList = \
@@ -93,7 +93,7 @@ class TestMpasXarray(TestCase):
 
     def test_no_units(self):
         fileName = str(self.datadir.join('example_no_units_jan.nc'))
-        calendar = 'gregorian_noleap'
+        calendar = 'noleap'
         simulationStartTime = '0001-01-01'
         timestr = 'time_avg_daysSinceStartOfSim'
         variableList = \
@@ -117,7 +117,7 @@ class TestMpasXarray(TestCase):
 
     def test_bad_selvals(self):
         fileName = str(self.datadir.join('example_jan.nc'))
-        calendar = 'gregorian_noleap'
+        calendar = 'noleap'
         simulationStartTime = '0001-01-01'
         timestr = 'time_avg_daysSinceStartOfSim'
         variableList = \
@@ -138,7 +138,7 @@ class TestMpasXarray(TestCase):
 
     def test_selvals(self):
         fileName = str(self.datadir.join('example_jan.nc'))
-        calendar = 'gregorian_noleap'
+        calendar = 'noleap'
         simulationStartTime = '0001-01-01'
         timestr = 'time_avg_daysSinceStartOfSim'
         variableList = \
@@ -172,7 +172,7 @@ class TestMpasXarray(TestCase):
 
     def test_remove_repeated_time_index(self):
         fileName = str(self.datadir.join('example_jan*.nc'))
-        calendar = 'gregorian_noleap'
+        calendar = 'noleap'
         timestr = ['xtime_start', 'xtime_end']
         variableList = \
             ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']

--- a/mpas_analysis/test/test_namelist_streams_interface.py
+++ b/mpas_analysis/test/test_namelist_streams_interface.py
@@ -69,7 +69,7 @@ class TestNamelist(TestCase):
         files = self.sf.readpath('output',
                                  startDate='0001-01-02',
                                  endDate='0001-12-30',
-                                 calendar='gregorian_noleap')
+                                 calendar='noleap')
         expectedFiles = []
         for date in ['0001-01-02', '0001-02-01']:
             expectedFiles.append('{}/output/output.{}_00.00.00.nc'
@@ -78,7 +78,7 @@ class TestNamelist(TestCase):
 
         files = self.sf.readpath('output',
                                  startDate='0001-01-02',
-                                 calendar='gregorian_noleap')
+                                 calendar='noleap')
         expectedFiles = []
         for date in ['0001-01-02', '0001-02-01', '0002-01-01']:
             expectedFiles.append('{}/output/output.{}_00.00.00.nc'
@@ -87,7 +87,7 @@ class TestNamelist(TestCase):
 
         files = self.sf.readpath('output',
                                  endDate='0001-12-30',
-                                 calendar='gregorian_noleap')
+                                 calendar='noleap')
         expectedFiles = []
         for date in ['0001-01-01', '0001-01-02', '0001-02-01']:
             expectedFiles.append('{}/output/output.{}_00.00.00.nc'
@@ -97,7 +97,7 @@ class TestNamelist(TestCase):
         files = self.sf.readpath('restart',
                                  startDate='0001-01-01',
                                  endDate='0001-12-31',
-                                 calendar='gregorian_noleap')
+                                 calendar='noleap')
         expectedFiles = []
         for seconds in ['00010', '00020']:
             expectedFiles.append('{}/restarts/restart.0001-01-01_{}.nc'
@@ -111,6 +111,6 @@ class TestNamelist(TestCase):
         files = self.sf.readpath('mesh',
                                  startDate='0001-01-01',
                                  endDate='0001-12-31',
-                                 calendar='gregorian_noleap')
+                                 calendar='noleap')
         expectedFiles = ['{}/mesh.nc'.format(self.sf.streamsdir)]
         self.assertEqual(files, expectedFiles)

--- a/mpas_analysis/test/test_namelist_streams_interface/namelist.ocean
+++ b/mpas_analysis/test/test_namelist_streams_interface/namelist.ocean
@@ -8,7 +8,7 @@
     config_start_time = '0000-01-01_00:00:00'
     config_stop_time = 'none'
     config_run_duration = '1000_00:00:00'
-    config_calendar_type = 'gregorian_noleap'
+    config_calendar_type = 'noleap'
 /
 &time_integration
     config_dt = '00:10:00'

--- a/mpas_analysis/test/test_open_mpas_dataset.py
+++ b/mpas_analysis/test/test_open_mpas_dataset.py
@@ -29,7 +29,7 @@ class TestOpenMpasDataset(TestCase):
         variableList = \
             ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
 
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
             ds = open_mpas_dataset(
                 fileName=fileName,
                 calendar=calendar,
@@ -43,7 +43,7 @@ class TestOpenMpasDataset(TestCase):
         variableList = \
             ['time_avg_avgValueWithinOceanRegion_avgSurfaceTemperature']
 
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
             # all dates
             ds = open_mpas_dataset(
                 fileName=fileName,
@@ -76,7 +76,7 @@ class TestOpenMpasDataset(TestCase):
 
     def test_open_process_climatology(self):
         fileName = str(self.datadir.join('timeSeries.nc'))
-        calendar = 'gregorian_noleap'
+        calendar = 'noleap'
         open_mpas_dataset(
             fileName=fileName,
             calendar=calendar,

--- a/mpas_analysis/test/test_remap_obs_clim_subtask/mpas-o_in
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask/mpas-o_in
@@ -2,7 +2,7 @@
  config_ocean_run_mode = 'forward'
 /
 &time_management
- config_calendar_type = 'gregorian_noleap'
+ config_calendar_type = 'noleap'
  config_do_restart = .true.
  config_restart_timestamp_name = 'rpointer.ocn'
  config_start_time = 'file'

--- a/mpas_analysis/test/test_timekeeping.py
+++ b/mpas_analysis/test/test_timekeeping.py
@@ -40,7 +40,7 @@ class TestTimekeeping(TestCase):
         # YYYY-MM-DD
         # SSSSS
 
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
             # test datetime.datetime
             # YYYY-MM-DD_hh:mm:ss
             date1 = string_to_datetime('0001-01-01_00:00:00')
@@ -136,7 +136,7 @@ class TestTimekeeping(TestCase):
         # also, test addition and subtraction of the form
         # datetime.datetime +/- MpasRelativeDelta above
         # both calendars with adding one day
-        for calendar, expected in zip(['gregorian', 'gregorian_noleap'],
+        for calendar, expected in zip(['gregorian', 'noleap'],
                                       ['2016-02-29', '2016-03-01']):
             self.assertEqual(string_to_datetime('2016-02-28') +
                              string_to_relative_delta('0000-00-01',
@@ -144,7 +144,7 @@ class TestTimekeeping(TestCase):
                              string_to_datetime(expected))
 
         # both calendars with subtracting one day
-        for calendar, expected in zip(['gregorian', 'gregorian_noleap'],
+        for calendar, expected in zip(['gregorian', 'noleap'],
                                       ['2016-02-29', '2016-02-28']):
             self.assertEqual(string_to_datetime('2016-03-01') -
                              string_to_relative_delta('0000-00-01',
@@ -152,7 +152,7 @@ class TestTimekeeping(TestCase):
                              string_to_datetime(expected))
 
         # both calendars with adding one month
-        for calendar, expected in zip(['gregorian', 'gregorian_noleap'],
+        for calendar, expected in zip(['gregorian', 'noleap'],
                                       ['2016-02-29', '2016-02-28']):
             self.assertEqual(string_to_datetime('2016-01-31') +
                              string_to_relative_delta('0000-01-00',
@@ -160,14 +160,14 @@ class TestTimekeeping(TestCase):
                              string_to_datetime(expected))
 
         # both calendars with subtracting one month
-        for calendar, expected in zip(['gregorian', 'gregorian_noleap'],
+        for calendar, expected in zip(['gregorian', 'noleap'],
                                       ['2016-02-29', '2016-02-28']):
             self.assertEqual(string_to_datetime('2016-03-31') -
                              string_to_relative_delta('0000-01-00',
                                                       calendar=calendar),
                              string_to_datetime(expected))
 
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
 
             delta1 = string_to_relative_delta('0000-01-00', calendar=calendar)
             delta2 = string_to_relative_delta('0000-00-01', calendar=calendar)
@@ -207,12 +207,12 @@ class TestTimekeeping(TestCase):
             delta1 = string_to_relative_delta('0000-01-00',
                                               calendar='gregorian')
             delta2 = string_to_relative_delta('0000-00-01',
-                                              calendar='gregorian_noleap')
+                                              calendar='noleap')
             deltaSum = delta1 + delta2
 
     def test_string_to_days_since_date(self):
         referenceDate = '0001-01-01'
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
             for dateString, expected_days in [('0001-01-01', 0.),
                                               ('0001-01-02', 1.),
                                               ('0001-02-01', 31.),
@@ -224,7 +224,7 @@ class TestTimekeeping(TestCase):
 
         referenceDate = '2016-01-01'
         for calendar, expected_days in [('gregorian', 366.),
-                                        ('gregorian_noleap', 365.)]:
+                                        ('noleap', 365.)]:
             days = string_to_days_since_date(dateString='2017-01-01',
                                              calendar=calendar,
                                              referenceDate=referenceDate)
@@ -232,7 +232,7 @@ class TestTimekeeping(TestCase):
 
     def test_days_to_datetime(self):
         referenceDate = '0001-01-01'
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
             for dateString, days in [('0001-01-01', 0.),
                                      ('0001-01-02', 1.),
                                      ('0001-02-01', 31.),
@@ -244,7 +244,7 @@ class TestTimekeeping(TestCase):
 
         referenceDate = '2016-01-01'
         for calendar, days in [('gregorian', 366.),
-                               ('gregorian_noleap', 365.)]:
+                               ('noleap', 365.)]:
             datetime = days_to_datetime(days=days,
                                         calendar=calendar,
                                         referenceDate=referenceDate)
@@ -252,7 +252,7 @@ class TestTimekeeping(TestCase):
 
     def test_datetime_to_days(self):
         referenceDate = '0001-01-01'
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
             for dateString, expected_days in [('0001-01-01', 0.),
                                               ('0001-01-02', 1.),
                                               ('0001-02-01', 31.),
@@ -264,7 +264,7 @@ class TestTimekeeping(TestCase):
 
         referenceDate = '2016-01-01'
         for calendar, expected_days in [('gregorian', 366.),
-                                        ('gregorian_noleap', 365.)]:
+                                        ('noleap', 365.)]:
             days = datetime_to_days(dates=string_to_datetime('2017-01-01'),
                                     calendar=calendar,
                                     referenceDate=referenceDate)
@@ -272,7 +272,7 @@ class TestTimekeeping(TestCase):
 
     def test_date_to_days(self):
         referenceDate = '0001-01-01'
-        for calendar in ['gregorian', 'gregorian_noleap']:
+        for calendar in ['gregorian', 'noleap']:
             days = date_to_days(year=1, month=1, day=1, calendar=calendar,
                                 referenceDate=referenceDate)
             self.assertApproxEqual(days, 0.)
@@ -288,7 +288,7 @@ class TestTimekeeping(TestCase):
 
         referenceDate = '2016-01-01'
         for calendar, expected_days in [('gregorian', 366.),
-                                        ('gregorian_noleap', 365.)]:
+                                        ('noleap', 365.)]:
             days = date_to_days(year=2017, month=1, day=1,
                                 calendar=calendar,
                                 referenceDate=referenceDate)


### PR DESCRIPTION
For backwards compatibility, namelists withh a `gregorian_noleap` calendar are still supported but `noleap` is used for testing and listed in docstrings.

closes #888 