### PR TITLE
Improve error message on incorrect machine

### DIFF
--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -30,6 +30,7 @@ import progressbar
 import logging
 import xarray
 import time
+from importlib.resources import contents
 
 from mache import discover_machine, MachineInfo
 
@@ -794,7 +795,21 @@ def main():
 
     if machine is not None:
         print(f'Detected E3SM supported machine: {machine}')
-        config.add_from_package('mache.machines', f'{machine}.cfg')
+        try:
+            config.add_from_package('mache.machines', f'{machine}.cfg')
+        except FileNotFoundError:
+
+            possible_machines = []
+            machine_configs = contents('mache.machines')
+            for config in machine_configs:
+                if config.endswith('.cfg'):
+                    possible_machines.append(os.path.splitext(config)[0])
+
+            possible_machines = '\n  '.join(sorted(possible_machines))
+            raise ValueError(
+                f'We could not find the machine: {machine}.\n'
+                f'Possible machines are:\n  {possible_machines}')
+
         try:
             config.add_from_package('mpas_analysis.configuration',
                                     f'{machine}.cfg')


### PR DESCRIPTION
Now, when you give an incorrect machine, e.g.:
```
mpas_analysis -m blah example_e3sm.cfg
```
you get an error message like:
```
Traceback (most recent call last):
  File "/home/xylar/code/MPAS-Analysis/improve_error_on_wrong_machine/mpas_analysis/__main__.py", line 799, in main
    config.add_from_package('mache.machines', f'{machine}.cfg')
  File "/home/xylar/mambaforge/envs/mpas_dev/lib/python3.10/site-packages/mpas_tools/config.py", line 87, in add_from_package
    self._add(path, user=False)
  File "/home/xylar/mambaforge/envs/mpas_dev/lib/python3.10/site-packages/mpas_tools/config.py", line 426, in _add
    raise FileNotFoundError(f'Config file does not exist: {filename}')
FileNotFoundError: Config file does not exist: /home/xylar/mambaforge/envs/mpas_dev/lib/python3.10/site-packages/mache/machines/blah.cfg

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/xylar/mambaforge/envs/mpas_dev/bin/mpas_analysis", line 33, in <module>
    sys.exit(load_entry_point('mpas-analysis', 'console_scripts', 'mpas_analysis')())
  File "/home/xylar/code/MPAS-Analysis/improve_error_on_wrong_machine/mpas_analysis/__main__.py", line 809, in main
    raise ValueError(
ValueError: We could not find the machine: blah.
Possible machines are:
  acme1
  andes
  anvil
  badger
  chrysalis
  compy
  cooley
  cori-haswell
  cori-knl
  default
  grizzly
```

closes #891 