### PR TITLE
Add Horizontal Streamfunction plots + Subpolar North Atlantic projection 

### DIFF
--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -146,7 +146,7 @@ def build_analysis_list(config, controlConfig):
                                             oceanClimatologyTasks['avg'],
                                             controlConfig))
     analyses.append(ocean.ClimatologyMapBSF(config,
-                                            oceanClimatolgyTasks['avg'],
+                                            oceanClimatologyTasks['avg'],
                                             controlConfig))
     analyses.append(ocean.ClimatologyMapOHCAnomaly(
         config, oceanClimatologyTasks['avg'], oceanRefYearClimatologyTask,

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -145,6 +145,9 @@ def build_analysis_list(config, controlConfig):
     analyses.append(ocean.ClimatologyMapEKE(config,
                                             oceanClimatologyTasks['avg'],
                                             controlConfig))
+    analyses.append(ocean.ClimatologyMapBSF(config,
+                                            oceanClimatolgyTasks['avg'],
+                                            controlConfig))
     analyses.append(ocean.ClimatologyMapOHCAnomaly(
         config, oceanClimatologyTasks['avg'], oceanRefYearClimatologyTask,
         controlConfig))

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -245,6 +245,11 @@ comparisonNorthPacificWidth = 15000.
 comparisonNorthPacificHeight = 5000.
 comparisonNorthPacificResolution = 20.
 
+# The comparison North Atlantic grid size and resolution in km
+comparisonSubpolarNorthAtlanticWidth = 7000.
+comparisonSubpolarNorthAtlanticHeight = 4000.
+comparisonSubpolarNorthAtlanticResolution = 20.
+
 # interpolation order for model and observation results. Likely values are
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
 mpasInterpolationMethod = bilinear
@@ -419,6 +424,20 @@ useCartopyCoastline = True
 latLines = np.arange(-80., 81., 10.)
 lonLines = np.arange(-180., 181., 30.)
 
+[plot_subpolar_north_atlantic]
+## options related to Subpolar North Atlantic projection plots
+
+# figure sizes for different numbers of panels and layouts
+onePanelFigSize = (8, 7.5)
+threePanelVertFigSize = (8, 10)
+threePanelHorizFigSize = (22, 7.5)
+
+# whether to use the cartopy coastline (as opposed to the model coastline)
+useCartopyCoastline = True
+
+# latitude and longitude grid lines
+latLines = np.arange(-80., 81., 10.)
+lonLines = np.arange(-180., 181., 30.)
 
 [html]
 ## options related to generating a webpage to display the analysis
@@ -1395,8 +1414,8 @@ colormapTypeResult = continuous
 # the type of norm used in the colormap
 normTypeResult = symLog
 # A dictionary with keywords for the norm
-normArgsResult = {'linthresh': 0.1, 'linscale': 0.5, 'vmin': -10., 'vmax': 10.}
-colorbarTicksResult = [-10., -3., -1., -0.3, -0.1, 0., 0.1, 0.3, 1., 3., 10.]
+normArgsResult = {'linthresh': 0.1, 'linscale': 0.5, 'vmin': -100., 'vmax': 100.}
+colorbarTicksResult = [-100.,-30.,-10., -3., -1., -0.3, -0.1, 0., 0.1, 0.3, 1., 3., 10.,30.,100.]
 
 # colormap for differences
 colormapNameDifference = cmo.balance
@@ -1412,11 +1431,11 @@ colorbarTicksDifference = [-10., -3., -1., -0.3, -0.1, 0., 0.1, 0.3, 1., 3.,
 
 # Months or seasons to plot (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['ANN']
+seasons =  ['ANN','JFM','AMJ','JAS','OND']
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon']
-
+comparisonGrids = ['latlon','subpolar_north_atlantic']
+depthRanges = [(0.0, -10000.0), (0.0, -2000.0)]
 
 [climatologyMapOHCAnomaly]
 ## options related to plotting horizontally remapped climatologies of

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -1382,6 +1382,42 @@ seasons =  ['ANN']
 comparisonGrids = ['latlon']
 
 
+[climatologyMapBSF]
+## options related to plotting horizontally remapped climatologies of
+## the barotropic streamfunction (BSF) against control model results
+## (if available)
+
+# colormap for model/observations
+colormapNameResult = cmo.curl
+# whether the colormap is indexed or continuous
+colormapTypeResult = continuous
+# color indices into colormapName for filled contours
+# the type of norm used in the colormap
+normTypeResult = symLog
+# A dictionary with keywords for the norm
+normArgsResult = {'linthresh': 0.1, 'linscale': 0.5, 'vmin': -10., 'vmax': 10.}
+colorbarTicksResult = [-10., -3., -1., -0.3, -0.1, 0., 0.1, 0.3, 1., 3., 10.]
+
+# colormap for differences
+colormapNameDifference = cmo.balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = continuous
+# the type of norm used in the colormap
+normTypeDifference = symLog
+# A dictionary with keywords for the norm
+normArgsDifference = {'linthresh': 0.1, 'linscale': 0.5, 'vmin': -10.,
+                      'vmax': 10.}
+colorbarTicksDifference = [-10., -3., -1., -0.3, -0.1, 0., 0.1, 0.3, 1., 3.,
+                           10.]
+
+# Months or seasons to plot (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['ANN']
+
+# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+comparisonGrids = ['latlon']
+
+
 [climatologyMapOHCAnomaly]
 ## options related to plotting horizontally remapped climatologies of
 ## ocean heat content (OHC) against control model results (if available)
@@ -1389,7 +1425,7 @@ comparisonGrids = ['latlon']
 # colormap for model/observations
 colormapNameResult = BuOr
 # whether the colormap is indexed or continuous
-colormapTypeResult = indexed
+colormapTypeResult = continuous
 # color indices into colormapName for filled contours
 colormapIndicesResult = numpy.array(numpy.linspace(0, 255, 38), int)
 # colormap levels/values for contour boundaries

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -368,9 +368,9 @@ pdf = False
 ## options related to Arctic projection plots
 
 # figure sizes for different numbers of panels and layouts
-onePanelFigSize = (8, 7.5)
+onePanelFigSize = (7, 7.5)
 threePanelVertFigSize = (8, 22)
-threePanelHorizFigSize = (22, 7.5)
+threePanelHorizFigSize = (20, 7.5)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
 useCartopyCoastline = True
@@ -1420,6 +1420,8 @@ colorbarTicksResult = [-100.,-40.,-20.,-10., 0., 10., 20., 40.,100.]
 contourLevelsResult = np.arange(-100., 101.0, 10.)
 contourThicknessResult = 0.5
 contourColorResult = black
+# Add arrows to contour lines
+# whether to include arrows on the contour lines showing the direction of flow
 arrowsOnContourResult = True
 #ticks = [np.arange(-100., 101.0, 10.), np.arange(-100., 101.0, 10.)]
 # colormap for differences
@@ -1439,7 +1441,8 @@ colorbarTicksDifference = [-10., -3., -1., -0.3, -0.1, 0., 0.1, 0.3, 1., 3.,
 seasons =  ['ANN']
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon','subpolar_north_atlantic', 'antarctic', 'north_pacific']
+comparisonGrids = ['latlon','subpolar_north_atlantic']
+# list of tuples(pairs) of depths (min, max) to integrate horizontal transport over 
 depthRanges = [(0.0, -10000.0), (0.0, -2000.0)]
 
 [climatologyMapOHCAnomaly]
@@ -1449,21 +1452,13 @@ depthRanges = [(0.0, -10000.0), (0.0, -2000.0)]
 # colormap for model/observations
 colormapNameResult = BuOr
 # whether the colormap is indexed or continuous
-colormapTypeResult = continuous
-# the type of norm used in the colormap
-normTypeResult = linear
-# A dictionary with keywords for the norm
-normArgsResult = {'vmin': -12., 'vmax': 12.}
+colormapTypeResult = indexed
 # color indices into colormapName for filled contours
 colormapIndicesResult = numpy.array(numpy.linspace(0, 255, 38), int)
 # colormap levels/values for contour boundaries
 colorbarLevelsResult = numpy.linspace(-12., 12., 37)
 # colormap levels/values for ticks (defaults to same as levels)
 colorbarTicksResult = numpy.linspace(-12., 12., 9)
-# Adding contour lines to the figure
-contourLevelsResult = np.arange(-12., 12., 1.)
-contourThicknessResult = 0.5
-contourColorResult = black
 # colormap for differences
 colormapNameDifference = balance
 # whether the colormap is indexed or continuous
@@ -1478,7 +1473,7 @@ colorbarLevelsDifference = numpy.linspace(-2., 2., 10)
 seasons =  ['ANN']
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon','subpolar_north_atlantic']
+comparisonGrids = ['latlon']
 
 # A list of pairs of minimum and maximum depths (positive up, in meters) to
 # include in the vertical sums.  The default values are the equivalents of the

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -369,8 +369,8 @@ pdf = False
 
 # figure sizes for different numbers of panels and layouts
 onePanelFigSize = (7, 7.5)
-threePanelVertFigSize = (8, 22)
-threePanelHorizFigSize = (20, 7.5)
+threePanelVertFigSize = (7.5, 20)
+threePanelHorizFigSize = (18, 6)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
 useCartopyCoastline = True
@@ -384,8 +384,8 @@ lonLines = np.arange(-180., 181., 30.)
 
 # figure sizes for different numbers of panels and layouts
 onePanelFigSize = (7, 7.5)
-threePanelVertFigSize = (8, 22)
-threePanelHorizFigSize = (20, 7.5)
+threePanelVertFigSize = (7.5, 20)
+threePanelHorizFigSize = (18, 6)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
 useCartopyCoastline = True
@@ -399,8 +399,8 @@ lonLines = np.arange(-180., 181., 30.)
 
 # figure sizes for different numbers of panels and layouts
 onePanelFigSize = (10, 7.5)
-threePanelVertFigSize = (8, 16)
-threePanelHorizFigSize = (24, 7.5)
+threePanelVertFigSize = (10, 18)
+threePanelHorizFigSize = (24, 7)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
 useCartopyCoastline = True
@@ -414,7 +414,7 @@ lonLines = np.arange(-180., 181., 30.)
 
 # figure sizes for different numbers of panels and layouts
 onePanelFigSize = (10, 4)
-threePanelVertFigSize = (8, 10)
+threePanelVertFigSize = (10, 9)
 threePanelHorizFigSize = (26, 4)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
@@ -429,7 +429,7 @@ lonLines = np.arange(-180., 181., 30.)
 
 # figure sizes for different numbers of panels and layouts
 onePanelFigSize = (8, 5)
-threePanelVertFigSize = (8, 10)
+threePanelVertFigSize = (8.5, 11)
 threePanelHorizFigSize = (21, 5)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
@@ -1441,7 +1441,7 @@ colorbarTicksDifference = [-10., -3., -1., -0.3, -0.1, 0., 0.1, 0.3, 1., 3.,
 seasons =  ['ANN']
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon','subpolar_north_atlantic']
+comparisonGrids = ['latlon','subpolar_north_atlantic', north_atlantic', 'north_pacific','antarctic', 'arctic']
 # list of tuples(pairs) of depths (min, max) to integrate horizontal transport over 
 depthRanges = [(0.0, -10000.0), (0.0, -2000.0)]
 

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -383,9 +383,9 @@ lonLines = np.arange(-180., 181., 30.)
 ## options related to Antarctic projection plots
 
 # figure sizes for different numbers of panels and layouts
-onePanelFigSize = (8, 7.5)
+onePanelFigSize = (7, 7.5)
 threePanelVertFigSize = (8, 22)
-threePanelHorizFigSize = (22, 7.5)
+threePanelHorizFigSize = (20, 7.5)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
 useCartopyCoastline = True
@@ -398,9 +398,9 @@ lonLines = np.arange(-180., 181., 30.)
 ## options related to North Atlantic projection plots
 
 # figure sizes for different numbers of panels and layouts
-onePanelFigSize = (8, 7.5)
+onePanelFigSize = (10, 7.5)
 threePanelVertFigSize = (8, 16)
-threePanelHorizFigSize = (22, 7.5)
+threePanelHorizFigSize = (24, 7.5)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
 useCartopyCoastline = True
@@ -413,9 +413,9 @@ lonLines = np.arange(-180., 181., 30.)
 ## options related to North Pacific projection plots
 
 # figure sizes for different numbers of panels and layouts
-onePanelFigSize = (8, 7.5)
+onePanelFigSize = (10, 4)
 threePanelVertFigSize = (8, 10)
-threePanelHorizFigSize = (22, 7.5)
+threePanelHorizFigSize = (26, 4)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
 useCartopyCoastline = True
@@ -428,9 +428,9 @@ lonLines = np.arange(-180., 181., 30.)
 ## options related to Subpolar North Atlantic projection plots
 
 # figure sizes for different numbers of panels and layouts
-onePanelFigSize = (8, 7.5)
+onePanelFigSize = (8, 5)
 threePanelVertFigSize = (8, 10)
-threePanelHorizFigSize = (22, 7.5)
+threePanelHorizFigSize = (21, 5)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
 useCartopyCoastline = True
@@ -1398,7 +1398,7 @@ normArgsDifference = {'vmin': -300., 'vmax': 300.}
 seasons =  ['ANN']
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon']
+comparisonGrids = ['latlon', 'subpolar_north_atlantic']
 
 
 [climatologyMapBSF]
@@ -1414,9 +1414,14 @@ colormapTypeResult = continuous
 # the type of norm used in the colormap
 normTypeResult = symLog
 # A dictionary with keywords for the norm
-normArgsResult = {'linthresh': 0.1, 'linscale': 0.5, 'vmin': -100., 'vmax': 100.}
-colorbarTicksResult = [-100.,-30.,-10., -3., -1., -0.3, -0.1, 0., 0.1, 0.3, 1., 3., 10.,30.,100.]
-
+normArgsResult = {'linthresh': 30., 'linscale': 0.5, 'vmin': -100., 'vmax': 100.}
+colorbarTicksResult = [-100.,-40.,-20.,-10., 0., 10., 20., 40.,100.]
+# Adding contour lines to the figure
+contourLevelsResult = np.arange(-100., 101.0, 10.)
+contourThicknessResult = 0.5
+contourColorResult = black
+arrowsOnContourResult = True
+#ticks = [np.arange(-100., 101.0, 10.), np.arange(-100., 101.0, 10.)]
 # colormap for differences
 colormapNameDifference = cmo.balance
 # whether the colormap is indexed or continuous
@@ -1431,10 +1436,10 @@ colorbarTicksDifference = [-10., -3., -1., -0.3, -0.1, 0., 0.1, 0.3, 1., 3.,
 
 # Months or seasons to plot (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
-seasons =  ['ANN','JFM','AMJ','JAS','OND']
+seasons =  ['ANN']
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon','subpolar_north_atlantic']
+comparisonGrids = ['latlon','subpolar_north_atlantic', 'antarctic', 'north_pacific']
 depthRanges = [(0.0, -10000.0), (0.0, -2000.0)]
 
 [climatologyMapOHCAnomaly]
@@ -1445,13 +1450,20 @@ depthRanges = [(0.0, -10000.0), (0.0, -2000.0)]
 colormapNameResult = BuOr
 # whether the colormap is indexed or continuous
 colormapTypeResult = continuous
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': -12., 'vmax': 12.}
 # color indices into colormapName for filled contours
 colormapIndicesResult = numpy.array(numpy.linspace(0, 255, 38), int)
 # colormap levels/values for contour boundaries
 colorbarLevelsResult = numpy.linspace(-12., 12., 37)
 # colormap levels/values for ticks (defaults to same as levels)
 colorbarTicksResult = numpy.linspace(-12., 12., 9)
-
+# Adding contour lines to the figure
+contourLevelsResult = np.arange(-12., 12., 1.)
+contourThicknessResult = 0.5
+contourColorResult = black
 # colormap for differences
 colormapNameDifference = balance
 # whether the colormap is indexed or continuous
@@ -1466,7 +1478,7 @@ colorbarLevelsDifference = numpy.linspace(-2., 2., 10)
 seasons =  ['ANN']
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon']
+comparisonGrids = ['latlon','subpolar_north_atlantic']
 
 # A list of pairs of minimum and maximum depths (positive up, in meters) to
 # include in the vertical sums.  The default values are the equivalents of the

--- a/mpas_analysis/ocean/__init__.py
+++ b/mpas_analysis/ocean/__init__.py
@@ -5,6 +5,8 @@ from mpas_analysis.ocean.climatology_map_mld_min_max import \
 from mpas_analysis.ocean.climatology_map_sss import ClimatologyMapSSS
 from mpas_analysis.ocean.climatology_map_ssh import ClimatologyMapSSH
 from mpas_analysis.ocean.climatology_map_eke import ClimatologyMapEKE
+from mpas_analysis.ocean.climatology_map_bsf import \
+    ClimatologyMapBSF
 from mpas_analysis.ocean.climatology_map_ohc_anomaly import \
     ClimatologyMapOHCAnomaly
 from mpas_analysis.ocean.climatology_map_bgc import ClimatologyMapBGC

--- a/mpas_analysis/ocean/climatology_map_bsf.py
+++ b/mpas_analysis/ocean/climatology_map_bsf.py
@@ -81,7 +81,7 @@ class ClimatologyMapBSF(AnalysisTask):
             depth_range_string = \
                 f'{np.abs(min_depth):g}-{np.abs(max_depth):g}m'
             if np.abs(max_depth) < 5000. :
-                fname_title=f'Depth Integrated Transport Streamfunction {depth_range_string}'
+                fname_title=f'Streamfunction over {depth_range_string}'
                 fname_clim=f'{field_name}_{depth_range_string}'
             else:
                 fname_title=f'Barotropic Streamfunction'
@@ -129,7 +129,7 @@ class ClimatologyMapBSF(AnalysisTask):
                         diffTitleLabel=diff_title_label,
                         unitsLabel='Sv',
                         imageCaption=fname_title,
-                        galleryGroup='Barotropic Streamfunction',
+                        galleryGroup='Horizontal Streamfunction',
                         groupSubtitle=None,
                         groupLink='bsf',
                         galleryName=None)

--- a/mpas_analysis/ocean/climatology_map_bsf.py
+++ b/mpas_analysis/ocean/climatology_map_bsf.py
@@ -1,0 +1,302 @@
+# This software is open source software available under the BSD-3 license.
+#
+# Copyright (c) 2022 Triad National Security, LLC. All rights reserved.
+# Copyright (c) 2022 Lawrence Livermore National Security, LLC. All rights
+# reserved.
+# Copyright (c) 2022 UT-Battelle, LLC. All rights reserved.
+#
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at
+# https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
+import xarray as xr
+import numpy as np
+import scipy.sparse
+import scipy.sparse.linalg
+
+from mpas_analysis.shared import AnalysisTask
+from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask
+from mpas_analysis.ocean.plot_climatology_map_subtask import \
+    PlotClimatologyMapSubtask
+
+
+class ClimatologyMapBSF(AnalysisTask):
+    """
+    An analysis task for computing and plotting maps of the barotropic
+    streamfunction (BSF)
+
+    Attributes
+    ----------
+    mpas_climatology_task : mpas_analysis.shared.climatology.MpasClimatologyTask
+        The task that produced the climatology to be remapped and plotted
+    """
+
+    def __init__(self, config, mpas_climatology_task, control_config=None):
+        """
+        Construct the analysis task.
+
+        Parameters
+        ----------
+        config : mpas_tools.config.MpasConfigParser
+            Configuration options
+
+        mpas_climatology_task : mpas_analysis.shared.climatology.MpasClimatologyTask
+            The task that produced the climatology to be remapped and plotted
+
+        control_config : mpas_tools.config.MpasConfigParser, optional
+            Configuration options for a control run (if any)
+        """
+
+        field_name = 'barotropicStreamfunction'
+        # call the constructor from the base class (AnalysisTask)
+        super().__init__(config=config, taskName='climatologyMapBSF',
+                         componentName='ocean',
+                         tags=['climatology', 'horizontalMap', field_name,
+                               'publicObs', 'streamfunction'])
+
+        self.mpas_climatology_task = mpas_climatology_task
+
+        section_name = self.taskName
+
+        # read in what seasons we want to plot
+        seasons = config.getexpression(section_name, 'seasons')
+
+        if len(seasons) == 0:
+            raise ValueError(f'config section {section_name} does not contain '
+                             f'valid list of seasons')
+
+        comparison_grid_names = config.getexpression(section_name,
+                                                     'comparisonGrids')
+
+        if len(comparison_grid_names) == 0:
+            raise ValueError(f'config section {section_name} does not contain '
+                             f'valid list of comparison grids')
+
+        mpas_field_name = field_name
+
+        variable_list = ['timeMonthly_avg_normalVelocity',
+                         'timeMonthly_avg_layerThickness']
+
+        remap_climatology_subtask = RemapMpasBSFClimatology(
+            mpasClimatologyTask=mpas_climatology_task,
+            parentTask=self,
+            climatologyName=field_name,
+            variableList=variable_list,
+            comparisonGridNames=comparison_grid_names,
+            seasons=seasons)
+
+        self.add_subtask(remap_climatology_subtask)
+
+        out_file_label = field_name
+        remap_observations_subtask = None
+        if control_config is None:
+            ref_title_label = None
+            ref_field_name = None
+            diff_title_label = 'Model - Observations'
+
+        else:
+            control_run_name = control_config.get('runs', 'mainRunName')
+            ref_title_label = f'Control: {control_run_name}'
+            ref_field_name = mpas_field_name
+            diff_title_label = 'Main - Control'
+
+        for comparison_grid_name in comparison_grid_names:
+            for season in seasons:
+                # make a new subtask for this season and comparison grid
+                subtask_name = f'plot{season}_{comparison_grid_name}'
+
+                subtask = PlotClimatologyMapSubtask(
+                    self, season, comparison_grid_name,
+                    remap_climatology_subtask, remap_observations_subtask,
+                    controlConfig=control_config, subtaskName=subtask_name)
+
+                subtask.set_plot_info(
+                    outFileLabel=out_file_label,
+                    fieldNameInTitle=f'Barotropic Streamfunction',
+                    mpasFieldName=mpas_field_name,
+                    refFieldName=ref_field_name,
+                    refTitleLabel=ref_title_label,
+                    diffTitleLabel=diff_title_label,
+                    unitsLabel='Sv',
+                    imageCaption='Barotropic Streamfunction',
+                    galleryGroup='Barotropic Streamfunction',
+                    groupSubtitle=None,
+                    groupLink='bsf',
+                    galleryName=None)
+
+                self.add_subtask(subtask)
+
+
+class RemapMpasBSFClimatology(RemapMpasClimatologySubtask):
+    """
+    A subtask for computing climatologies of the barotropic streamfunction
+    from climatologies of normal velocity and layer thickness
+    """
+
+    def customize_masked_climatology(self, climatology, season):
+        """
+        Compute the ocean heat content (OHC) anomaly from the temperature
+        and layer thickness fields.
+
+        Parameters
+        ----------
+        climatology : xarray.Dataset
+            the climatology data set
+
+        season : str
+            The name of the season to be masked
+
+        Returns
+        -------
+        climatology : xarray.Dataset
+            the modified climatology data set
+        """
+        logger = self.logger
+
+        ds_mesh = xr.open_dataset(self.restartFileName)
+        ds_mesh = ds_mesh[['cellsOnEdge', 'cellsOnVertex', 'nEdgesOnCell',
+                           'edgesOnCell', 'verticesOnCell', 'verticesOnEdge',
+                           'dcEdge', 'dvEdge']]
+        ds_mesh.load()
+
+        bsf_vertex = self._compute_barotropic_streamfunction_vertex(
+            ds_mesh, climatology)
+        logger.info('bsf on vertices computed.')
+        bsf_cell = self._compute_barotropic_streamfunction_cell(
+            ds_mesh, bsf_vertex)
+        logger.info('bsf on cells computed.')
+
+        climatology['barotropicStreamfunction'] = \
+            bsf_cell.transpose('Time', 'nCells', 'nVertices')
+        climatology.barotropicStreamfunction.attrs['units'] = 'Sv'
+        climatology.barotropicStreamfunction.attrs['description'] = \
+            'barotropic streamfunction at cell centers'
+
+        climatology = climatology.drop_vars(self.variableList)
+
+        return climatology
+
+    def _compute_transport(self, ds_mesh, ds):
+
+        cells_on_edge = ds_mesh.cellsOnEdge - 1
+        inner_edges = np.logical_and(cells_on_edge.isel(TWO=0) >= 0,
+                                     cells_on_edge.isel(TWO=1) >= 0)
+
+        # convert from boolean mask to indices
+        inner_edges = np.flatnonzero(inner_edges.values)
+
+        cell0 = cells_on_edge.isel(nEdges=inner_edges, TWO=0)
+        cell1 = cells_on_edge.isel(nEdges=inner_edges, TWO=1)
+
+        layer_thickness = ds.timeMonthly_avg_layerThickness
+        normal_velocity = \
+            ds.timeMonthly_avg_normalVelocity.isel(nEdges=inner_edges)
+
+        layer_thickness_edge = 0.5*(layer_thickness.isel(nCells=cell0) +
+                                    layer_thickness.isel(nCells=cell1))
+        transport = ds_mesh.dvEdge[inner_edges] * \
+            (layer_thickness_edge * normal_velocity).sum(dim='nVertLevels')
+
+        return inner_edges, transport
+
+    def _compute_barotropic_streamfunction_vertex(self, ds_mesh, ds):
+        inner_edges, transport = self._compute_transport(ds_mesh, ds)
+        print('transport computed.')
+
+        nvertices = ds_mesh.sizes['nVertices']
+        ntime = ds.sizes['Time']
+
+        cells_on_vertex = ds_mesh.cellsOnVertex - 1
+        vertices_on_edge = ds_mesh.verticesOnEdge - 1
+        is_boundary_cov = cells_on_vertex == -1
+        boundary_vertices = np.logical_or(is_boundary_cov.isel(vertexDegree=0),
+                                          is_boundary_cov.isel(vertexDegree=1))
+        boundary_vertices = np.logical_or(boundary_vertices,
+                                          is_boundary_cov.isel(vertexDegree=2))
+
+        # convert from boolean mask to indices
+        boundary_vertices = np.flatnonzero(boundary_vertices.values)
+
+        n_boundary_vertices = len(boundary_vertices)
+        n_inner_edges = len(inner_edges)
+
+        indices = np.zeros((2, 2*n_inner_edges+n_boundary_vertices), dtype=int)
+        data = np.zeros(2*n_inner_edges+n_boundary_vertices, dtype=float)
+
+        # The difference between the streamfunction at vertices on an inner
+        # edge should be equal to the transport
+        v0 = vertices_on_edge.isel(nEdges=inner_edges, TWO=0).values
+        v1 = vertices_on_edge.isel(nEdges=inner_edges, TWO=1).values
+
+        ind = np.arange(n_inner_edges)
+        indices[0, 2*ind] = ind
+        indices[1, 2*ind] = v1
+        data[2*ind] = 1.
+
+        indices[0, 2*ind+1] = ind
+        indices[1, 2*ind+1] = v0
+        data[2*ind+1] = -1.
+
+        # the streamfunction should be zero at all boundary vertices
+        ind = np.arange(n_boundary_vertices)
+        indices[0, 2*n_inner_edges + ind] = n_inner_edges + ind
+        indices[1, 2*n_inner_edges + ind] = boundary_vertices
+        data[2*n_inner_edges + ind] = 1.
+
+        bsf_vertex = xr.DataArray(np.zeros((ntime, nvertices)),
+                                  dims=('Time', 'nVertices'))
+
+        for tindex in range(ntime):
+            rhs = np.zeros(n_inner_edges+n_boundary_vertices, dtype=float)
+
+            # convert to Sv
+            ind = np.arange(n_inner_edges)
+            rhs[ind] = 1e-6*transport.isel(Time=tindex)
+
+            ind = np.arange(n_boundary_vertices)
+            rhs[n_inner_edges + ind] = 0.
+
+            matrix = scipy.sparse.csr_matrix(
+                (data, indices),
+                shape=(n_inner_edges+n_boundary_vertices, nvertices))
+
+            solution = scipy.sparse.linalg.lsqr(matrix, rhs)
+
+            bsf_vertex[tindex, :] = -solution[0]
+
+        return bsf_vertex
+
+    def _compute_barotropic_streamfunction_cell(self, ds_mesh, bsf_vertex):
+        """
+        Interpolate the barotropic streamfunction from vertices to cells
+        """
+        n_edges_on_cell = ds_mesh.nEdgesOnCell
+        edges_on_cell = ds_mesh.edgesOnCell - 1
+        vertices_on_cell = ds_mesh.verticesOnCell - 1
+        area_edge = 0.25*ds_mesh.dcEdge*ds_mesh.dvEdge
+
+        ncells = ds_mesh.sizes['nCells']
+        max_edges = ds_mesh.sizes['maxEdges']
+
+        area_vert = xr.DataArray(np.zeros((ncells, max_edges)),
+                                 dims=('nCells', 'maxEdges'))
+
+        for ivert in range(max_edges):
+            edge_indices = edges_on_cell.isel(maxEdges=ivert)
+            mask = ivert < n_edges_on_cell
+            area_vert[:, ivert] += 0.5*mask*area_edge.isel(nEdges=edge_indices)
+
+        for ivert in range(max_edges-1):
+            edge_indices = edges_on_cell.isel(maxEdges=ivert+1)
+            mask = ivert+1 < n_edges_on_cell
+            area_vert[:, ivert] += 0.5*mask*area_edge.isel(nEdges=edge_indices)
+
+        edge_indices = edges_on_cell.isel(maxEdges=0)
+        mask = n_edges_on_cell == max_edges
+        area_vert[:, max_edges-1] += \
+            0.5*mask*area_edge.isel(nEdges=edge_indices)
+
+        bsf_cell = \
+            ((area_vert * bsf_vertex[:, vertices_on_cell]).sum(dim='maxEdges') /
+             area_vert.sum(dim='maxEdges'))
+
+        return bsf_cell

--- a/mpas_analysis/ocean/climatology_map_bsf.py
+++ b/mpas_analysis/ocean/climatology_map_bsf.py
@@ -80,7 +80,7 @@ class ClimatologyMapBSF(AnalysisTask):
         for min_depth, max_depth in depth_ranges:
             depth_range_string = \
                 f'{np.abs(min_depth):g}-{np.abs(max_depth):g}m'
-            if np.abs(max_depth) < 5000. :
+            if np.abs(max_depth) < 6000. :
                 fname_title=f'Streamfunction over {depth_range_string}'
                 fname_clim=f'{field_name}_{depth_range_string}'
             else:

--- a/mpas_analysis/ocean/plot_climatology_map_subtask.py
+++ b/mpas_analysis/ocean/plot_climatology_map_subtask.py
@@ -18,7 +18,7 @@ observations.
 
 import xarray as xr
 import numpy as np
-
+import string
 from mpas_analysis.shared import AnalysisTask
 
 from mpas_analysis.shared.plot import plot_global_comparison, \
@@ -598,7 +598,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             defaultFontSize=defaultFontSize,
             vertical=vertical)
 
-        upperGridName = comparisonGridName.replace('_', ' ').capitalize()
+        upperGridName = string.capwords(comparisonGridName.replace('_', ' '))
         caption = '{} {}'.format(season, self.imageCaption)
         write_image_xml(
             config,

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -410,7 +410,7 @@ yLim = [-600., -5.]
 ## (if available)
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon', 'arctic', 'antarctic']
+comparisonGrids = ['latlon', 'arctic', 'antarctic', 'subpolar_north_atlantic']
 
 [climatologyMapAntarcticMelt]
 ## options related to plotting horizontally regridded maps of Antarctic

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -404,6 +404,14 @@ movingAveragePoints = 12
 yLim = [-600., -5.]
 
 
+[climatologyMapBSF]
+## options related to plotting horizontally remapped climatologies of
+## the barotropic streamfunction (BSF) against control model results
+## (if available)
+
+# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+comparisonGrids = ['latlon', 'arctic', 'antarctic']
+
 [climatologyMapAntarcticMelt]
 ## options related to plotting horizontally regridded maps of Antarctic
 ## sub-ice-shelf melt rates against control model results and observations

--- a/mpas_analysis/shared/climatology/comparison_descriptors.py
+++ b/mpas_analysis/shared/climatology/comparison_descriptors.py
@@ -34,7 +34,7 @@ def get_comparison_descriptor(config, comparison_grid_name):
         Contains configuration options
 
     comparison_grid_name : {'latlon', 'antarctic', 'arctic', 'north_atlantic',
-                            'north_pacific'}
+                            'north_pacific', 'subpolar_north_atlantic'}
         The name of the comparison grid to use for remapping.
 
     Raises
@@ -121,12 +121,14 @@ def _get_projection_comparison_descriptor(config, comparison_grid_name):
     option_suffixes = {'antarctic': 'AntarcticStereo',
                        'arctic': 'ArcticStereo',
                        'north_atlantic': 'NorthAtlantic',
-                       'north_pacific': 'NorthPacific'}
+                       'north_pacific': 'NorthPacific',
+                       'subpolar_north_atlantic': 'SubpolarNorthAtlantic'}
 
     grid_suffixes = {'antarctic': 'Antarctic_stereo',
                      'arctic': 'Arctic_stereo',
                      'north_atlantic': 'North_Atlantic',
-                     'north_pacific': 'North_Pacific'}
+                     'north_pacific': 'North_Pacific',
+                     'subpolar_north_atlantic': 'SubpolarNorthAtlantic'}
 
     if comparison_grid_name not in option_suffixes:
         raise ValueError(f'{comparison_grid_name} is not one of the supported '

--- a/mpas_analysis/shared/climatology/comparison_descriptors.py
+++ b/mpas_analysis/shared/climatology/comparison_descriptors.py
@@ -110,7 +110,8 @@ def _get_projection_comparison_descriptor(config, comparison_grid_name):
     Returns
     -------
     descriptor : pyremap.ProjectionGridDescriptor
-        A descriptor of the Arctic comparison grid
+        A descriptor of the comparison grid
+        (eg. - Arctic, North Atlantic)
     """
     # Authors
     # -------
@@ -128,7 +129,7 @@ def _get_projection_comparison_descriptor(config, comparison_grid_name):
                      'arctic': 'Arctic_stereo',
                      'north_atlantic': 'North_Atlantic',
                      'north_pacific': 'North_Pacific',
-                     'subpolar_north_atlantic': 'SubpolarNorthAtlantic'}
+                     'subpolar_north_atlantic': 'Subpolar_North_Atlantic'}
 
     if comparison_grid_name not in option_suffixes:
         raise ValueError(f'{comparison_grid_name} is not one of the supported '

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -268,7 +268,8 @@ class RemapMpasClimatologySubtask(AnalysisTask):
                                        comparisonDescriptor):
         """
         Add a custom grid descriptor (something other than 'latlon',
-        'antarctic', 'arctic', 'north_atlantic', or 'north_pacific').
+        'antarctic', 'arctic', 'north_atlantic', or 'north_pacific',
+         or 'subpolar_north_atlantic').
 
         Parameters
         ----------

--- a/mpas_analysis/shared/plot/climatology_map.py
+++ b/mpas_analysis/shared/plot/climatology_map.py
@@ -554,10 +554,10 @@ def plot_projection_comparison(
         return arrows
 
     def plot_panel(ax, title, array, colormap, norm, levels, ticks, contours,
-                   lineWidth, lineColor,arrows):
+                   lineWidth, lineColor, arrows):
 
         title = limit_title(title, maxTitleLength)
-        ax.set_title(title,**plottitle_font)
+        ax.set_title(title, **plottitle_font)
 
         ax.set_extent(extent, crs=projection)
 
@@ -634,7 +634,6 @@ def plot_projection_comparison(
     else:
         figsize = config.getexpression(section, 'threePanelHorizFigSize')
         subplots = [131, 132, 133]
-    aspectratio = figsize[0]/figsize[1]
     latLines = config.getexpression(section, 'latLines', use_numpyfunc=True)
     lonLines = config.getexpression(section, 'lonLines', use_numpyfunc=True)
 

--- a/mpas_analysis/shared/plot/climatology_map.py
+++ b/mpas_analysis/shared/plot/climatology_map.py
@@ -20,6 +20,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import matplotlib.colors as cols
 import matplotlib.ticker as mticker
+import matplotlib.patches as mpatches
 import numpy as np
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
@@ -124,7 +125,7 @@ def plot_polar_comparison(
     # Xylar Asay-Davis, Milena Veneziani
 
     def do_subplot(ax, field, title, colormap, norm, levels, ticks, contours,
-                   lineWidth, lineColor):
+                   lineWidth, lineColor, arrows):
         """
         Make a subplot within the figure.
         """
@@ -333,7 +334,7 @@ def plot_global_comparison(
     # Xylar Asay-Davis, Milena Veneziani
 
     def plot_panel(ax, title, array, colormap, norm, levels, ticks, contours,
-                   lineWidth, lineColor):
+                   lineWidth, lineColor, arrows):
 
         ax.set_extent(extent, crs=projection)
 
@@ -369,9 +370,11 @@ def plot_global_comparison(
                          bbox_to_anchor=(0.08, 0., 1, 1),
                          bbox_transform=ax.transAxes, borderpad=0)
 
-        cbar = plt.colorbar(plotHandle, cax=cax, ticks=ticks, boundaries=ticks)
+        cbar = plt.colorbar(plotHandle, cax=cax)
         cbar.set_label(cbarlabel)
-
+        if ticks is not None:
+            cbar.set_ticks(ticks)
+            cbar.set_ticklabels(['{}'.format(tick) for tick in ticks])
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')
     matplotlib.rc('font', size=defaultFontSize)
@@ -519,12 +522,42 @@ def plot_projection_comparison(
     # Authors
     # -------
     # Xylar Asay-Davis
+    def add_arrow_to_line2D(ax, path, arrow_spacing=8e5,arrow_width=1.5e4):
+        """
+        https://stackoverflow.com/a/27637925/7728169
+        Add arrows to a matplotlib.lines.Line2D at selected locations.
+        Parameters:
+	-----------
+	axes:
+	line: list of 1 Line2D object as returned by plot command
+	arrow_spacing: distance in m between arrows
+
+	Returns:
+	--------
+	arrows: list of arrows
+	"""
+        v = path.vertices
+        x = v[:, 0]
+        y = v[:, 1]
+        arrows = []
+        s = np.cumsum(np.sqrt(np.diff(x) ** 2 + np.diff(y) ** 2))
+        indices = np.searchsorted(s, arrow_spacing*np.arange(1,
+            int(s[-1]/arrow_spacing)))
+        for n in indices:
+            dx = np.mean(x[n-2:n]) - x[n]
+            dy = np.mean(y[n-2:n]) - y[n]
+            p = mpatches.FancyArrow(
+                x[n], y[n], dx, dy, length_includes_head=False, 
+                width=arrow_width, facecolor='k')
+            ax.add_patch(p)
+            arrows.append(p)
+        return arrows
 
     def plot_panel(ax, title, array, colormap, norm, levels, ticks, contours,
-                   lineWidth, lineColor):
+                   lineWidth, lineColor,arrows):
 
         title = limit_title(title, maxTitleLength)
-        ax.set_title(title, y=1.06, **plottitle_font)
+        ax.set_title(title,**plottitle_font)
 
         ax.set_extent(extent, crs=projection)
 
@@ -560,9 +593,13 @@ def plot_projection_comparison(
             matplotlib.rcParams['contour.negative_linestyle'] = 'solid'
             x_center = 0.5*(x[0:-1] + x[1:])
             y_center = 0.5*(y[0:-1] + y[1:])
-            ax.contour(x_center, y_center, array, levels=contours,
-                       colors=lineColor, linewidths=lineWidth)
-
+            cs = ax.contour(x_center, y_center, array, levels=contours,
+                            colors=lineColor, linewidths=lineWidth)
+            # add arrows to streamlines
+            if arrows is not None:
+                for collection in cs.collections:
+                    for path in collection.get_paths():
+                        add_arrow_to_line2D(ax, path)
         # create an axes on the right side of ax. The width of cax will be 5%
         # of ax and the padding between cax and ax will be fixed at 0.05 inch.
         divider = make_axes_locatable(ax)
@@ -597,7 +634,7 @@ def plot_projection_comparison(
     else:
         figsize = config.getexpression(section, 'threePanelHorizFigSize')
         subplots = [131, 132, 133]
-
+    aspectratio = figsize[0]/figsize[1]
     latLines = config.getexpression(section, 'latLines', use_numpyfunc=True)
     lonLines = config.getexpression(section, 'lonLines', use_numpyfunc=True)
 

--- a/mpas_analysis/shared/plot/colormap.py
+++ b/mpas_analysis/shared/plot/colormap.py
@@ -108,12 +108,15 @@ def setup_colormap(config, configSectionName, suffix=''):
         lineColor = config.get(configSectionName, option)
     else:
         lineColor = None
-
+    option = 'arrowsOnContour{}'.format(suffix)
+    if config.has_option(configSectionName, option):
+        arrows = config.getboolean(configSectionName, option)
+    else:
+        arrows = None
     return {'colormap': colormap, 'norm': norm, 'levels': levels,
             'ticks': ticks, 'contours': contours, 'lineWidth': lineWidth,
-            'lineColor': lineColor}
-
-
+            'lineColor': lineColor, 'arrows': arrows}
+    
 def register_custom_colormaps():
     name = 'ferret'
     backgroundColor = (0.9, 0.9, 0.9)

--- a/mpas_analysis/shared/projection/__init__.py
+++ b/mpas_analysis/shared/projection/__init__.py
@@ -120,7 +120,7 @@ def get_cartopy_projection(comparison_grid_name):
             standard_parallels=(39., 51.))
     elif comparison_grid_name == 'north_pacific':
         projection = cartopy.crs.LambertConformal(
-            central_latitude=54., central_longitude=-40.,
+            central_latitude=40., central_longitude=180.,
             standard_parallels=(34., 46.))
     elif comparison_grid_name == 'subpolar_north_atlantic':
         projection = cartopy.crs.LambertConformal(

--- a/mpas_analysis/shared/projection/__init__.py
+++ b/mpas_analysis/shared/projection/__init__.py
@@ -125,7 +125,7 @@ def get_cartopy_projection(comparison_grid_name):
     elif comparison_grid_name == 'subpolar_north_atlantic':
         projection = cartopy.crs.LambertConformal(
             central_latitude=54., central_longitude=-40.,
-            standard_parallels=(40,68))
+            standard_parallels=(40., 68.))
     else:
         raise ValueError(f'We missed one of the known comparison grids: '
                          f'{comparison_grid_name}')

--- a/mpas_analysis/shared/projection/__init__.py
+++ b/mpas_analysis/shared/projection/__init__.py
@@ -14,7 +14,7 @@ import cartopy
 
 
 known_comparison_grids = ['latlon', 'antarctic', 'arctic', 'north_atlantic',
-                          'north_pacific']
+                          'north_pacific', 'subpolar_north_atlantic']
 
 
 def get_pyproj_projection(comparison_grid_name):
@@ -24,7 +24,7 @@ def get_pyproj_projection(comparison_grid_name):
     Parameters
     ----------
     comparison_grid_name : {'antarctic', 'arctic', 'north_atlantic',
-                            'north_pacific'}
+                            'north_pacific', 'subpolar_north_atlantic'}
         The name of the projection comparison grid to use for remapping
 
     Returns
@@ -63,6 +63,9 @@ def get_pyproj_projection(comparison_grid_name):
     elif comparison_grid_name == 'north_pacific':
         projection = pyproj.Proj('+proj=lcc +lon_0=180 +lat_0=40 +lat_1=34 '
                                  '+lat_2=46 +x_0=0.0 +y_0=0.0 +ellps=WGS84')
+    elif comparison_grid_name == 'subpolar_north_atlantic':
+        projection = pyproj.Proj('+proj=lcc +lon_0=-40 +lat_0=54 +lat_1=40 '
+                                 '+lat_2=68 +x_0=0.0 +y_0=0.0 +ellps=WGS84')
     else:
         raise ValueError(f'We missed one of the known comparison grids: '
                          f'{comparison_grid_name}')
@@ -77,7 +80,7 @@ def get_cartopy_projection(comparison_grid_name):
     Parameters
     ----------
     comparison_grid_name : {'antarctic', 'arctic', 'north_atlantic',
-                            'north_pacific'}
+                            'north_pacific', 'subpolar_north_atlantic'}
         The name of the projection comparison grid to use for remapping
 
     Returns
@@ -117,8 +120,12 @@ def get_cartopy_projection(comparison_grid_name):
             standard_parallels=(39., 51.))
     elif comparison_grid_name == 'north_pacific':
         projection = cartopy.crs.LambertConformal(
-            central_latitude=40., central_longitude=180.,
+            central_latitude=54., central_longitude=-40.,
             standard_parallels=(34., 46.))
+    elif comparison_grid_name == 'subpolar_north_atlantic':
+        projection = cartopy.crs.LambertConformal(
+            central_latitude=54., central_longitude=-40.,
+            standard_parallels=(40,68))
     else:
         raise ValueError(f'We missed one of the known comparison grids: '
                          f'{comparison_grid_name}')


### PR DESCRIPTION
Summary : 
Config option (`climatologyMapBSF`)  for plotting climatological depth integrated transport streamfunction 
- either full depth (Barotropic) or up to a specified depth (task file = `ocean/climatology_map_bsf.py`)
- option to add arrows to contourlines: config option `arrowsOnContour<suffix>`  in `default.cfg`, files updated `shared/plot/climatology_map.py`, `shared/plot/colormap.py`
Subpolar North Atlantic projection to visualize sub polar gyre.
- subpolar North Atlantic projection added to `shared/projection/__init__.py`, `shared/climatology/comparison_descriptors.py` and `shared/climatology/remap_mpas_climatology_subtask.py` 
- doctoring updated in `shared/climatology/comparison_descriptors.py`
