### PR TITLE
Fix hovmoller plot comparison

### DIFF
--- a/mpas_analysis/ocean/plot_hovmoller_subtask.py
+++ b/mpas_analysis/ocean/plot_hovmoller_subtask.py
@@ -350,7 +350,14 @@ class PlotHovmollerSubtask(AnalysisTask):
             assert(np.all(refMask.values == mask.values))
             refField = refField.where(mask, drop=True)
             assert(field.shape == refField.shape)
+            # make sure the start and end time sare the same
+            assert(int(field.Time.values[0]) == int(refField.Time.values[0]))
+            assert(int(field.Time.values[-1]) == int(refField.Time.values[-1]))
+            # we're seeing issues with slightly different times between runs
+            # so let's copy them
+            refField['Time'] = field.Time
             diff = field - refField
+            assert(field.shape == diff.shape)
             refTitle = self.controlConfig.get('runs', 'mainRunName')
             diffTitle = 'Main - Control'
 


### PR DESCRIPTION
Sometimes, runs have slightly different Time values in timeSeriesStatsMonthly (seemingly related to restarts). When this happens, the hovmoller differences are only at times that match exactly, leading to a diff field with the wrong size.

This merge fixes the issue by first checking to make sure the two runs start and end at (approximately) the same time, then using the time from the "main" run for the "reference" run, too.