### PR TITLE
Make sure both CI and develoment environments don't include conda MPI

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - cartopy_offlinedata
     - cmocean
     - dask
+    - esmf=*=nompi_*
     - f90nml
     - geometric_features >=0.5.0
     - gsw

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -8,6 +8,7 @@ cartopy >=0.18.0
 cartopy_offlinedata
 cmocean
 dask
+esmf=*=nompi_*
 f90nml
 geometric_features>=0.5.0
 gsw

--- a/suite/job_script.bash
+++ b/suite/job_script.bash
@@ -23,11 +23,11 @@ echo env: {{ conda_env }}
 echo configs: {{ flags }} {{ config }}
 
 
-{{ parallel_exec }} mpas_analysis --list
-{{ parallel_exec }} mpas_analysis --plot_colormaps
-{{ parallel_exec }} mpas_analysis --setup_only {{ flags }} {{ config }}
-{{ parallel_exec }} mpas_analysis --purge {{ flags }} {{ config }} --verbose
-{{ parallel_exec }} mpas_analysis --html_only {{ flags }} {{ config }}
+mpas_analysis --list
+mpas_analysis --plot_colormaps
+mpas_analysis --setup_only {{ flags }} {{ config }}
+mpas_analysis --purge {{ flags }} {{ config }} --verbose
+mpas_analysis --html_only {{ flags }} {{ config }}
 
 chmod ugo+rx {{ html_base }}/{{ out_common_dir }}
 chmod -R ugo+rX {{ html_base }}/{{ out_subdir }}

--- a/suite/setup.py
+++ b/suite/setup.py
@@ -169,11 +169,6 @@ def main():
         else:
             flags = ''
 
-        if machine == 'cori-haswell':
-            parallel_exec = ''
-        else:
-            parallel_exec = 'srun -N 1 -n 1'
-
         with open(os.path.join('suite', 'job_script.bash')) as template_file:
             template_data = template_file.read()
         template = Template(template_data)
@@ -182,8 +177,8 @@ def main():
             use_e3sm_unified=use_e3sm_unified,
             e3sm_unified_script=e3sm_unified_script, conda_env=conda_env,
             machine=machine, flags=flags, config=config_from_job,
-            parallel_exec=parallel_exec, html_base=html_base,
-            out_subdir=out_subdir, out_common_dir=out_common_dir)
+            html_base=html_base, out_subdir=out_subdir,
+            out_common_dir=out_common_dir)
         with open(job, 'w') as job_file:
             job_file.write(job_text)
 


### PR DESCRIPTION
We build the package on HPC using the CI recipe, so it is better if it doesn't use conda's MPI.  In addition, we don't want development environments to include MPI because the conda MPI package typically don't work on HPC, where we do a lot of our development and testing.

Finally, this merge also removes some unnecessary `srun` calls to `mpas_analysis` in the test suite.  On many systems, nesting calls to `srun` within a parallel job doesn't work, and given that we may want to call `ESMF_RegridWeightGen` or `ncclimo` with `srun` within MPAS-Analysis, it would be better if we don't also call `mpas_analysis` unnecessarily with `srun`.