### PR TITLE
Fix generate command-line flag

### DIFF
--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -432,7 +432,7 @@ def update_generate(config, generate):
     generateString = ', '.join(["'{}'".format(element)
                                 for element in generateList])
     generateString = '[{}]'.format(generateString)
-    config.set('output', 'generate', generateString)
+    config.set('output', 'generate', generateString, user=True)
 
 
 def run_analysis(config, analyses):


### PR DESCRIPTION
It needs to take precidence over the config option but wasn't doing so because the "user" config option was taking priority.