### PR TITLE
Don't decode time as part of transect remapping

### DIFF
--- a/mpas_analysis/ocean/compute_transects_subtask.py
+++ b/mpas_analysis/ocean/compute_transects_subtask.py
@@ -262,7 +262,7 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):
                 remappedFileName = self.get_remapped_file_name(
                     season, comparisonGridName=self.transectCollectionName)
 
-                ds = xr.open_dataset(remappedFileName)
+                ds = xr.open_dataset(remappedFileName, decode_times=False)
                 transectNames = list(obsDatasets.keys())
                 for transectIndex, transectName in enumerate(transectNames):
                     self.logger.info('  {}'.format(transectName))


### PR DESCRIPTION
xarray seems to have trouble with masking a dataset with a `cftime._cftime.DatetimeNoLeap` time coordinated.  To avoid this, we'll just not decode time since we don't need to.