### PR TITLE
Add a check for duplicate analysis tasks and subtasks

### DIFF
--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -76,8 +76,8 @@ class AnalysisTask(Process):
     runAfterTasks : list of ``AnalysisTasks``
         tasks that must be complete before this task can run
 
-    subtasks : ``OrderedDict`` of ``AnalysisTasks``
-        Subtasks of this task, with subtask names as keys
+    subtasks :  list of mpas_analysis.shared.AnalysisTask
+        Subtasks of this task
 
     xmlFileNames : list of strings
         The XML file associated with each plot produced by this analysis, empty


### PR DESCRIPTION
This happens frequently by mistake and produces a very obscure error message.  With this merge, the error message will be more straightforward, e.g.:
```
ValueError: Analysis tasks failed these checks:
  A task named climatologyMapSeaIceSpeedSH has been added more than once
```