### PR TITLE
Add OSNAP Arctic Transects transport time series

### DIFF
--- a/docs/users_guide/tasks/timeSeriesTransport.rst
+++ b/docs/users_guide/tasks/timeSeriesTransport.rst
@@ -23,8 +23,7 @@ The following configuration options are available for this task::
     # available transects.
     transectsToPlot = ['Drake Passage', 'Tasmania-Ant', 'Africa-Ant', 'Antilles Inflow',
                        'Mona Passage', 'Windward Passage', 'Florida-Cuba', 'Florida-Bahamas',
-                       'Indonesian Throughflow', 'Agulhas', 'Mozambique Channel', 'Bering Strait',
-                       'Lancaster Sound', 'Fram Strait', 'Nares Strait']
+                       'Indonesian Throughflow', 'Agulhas', 'Mozambique Channel']
 
     # Number of months over which to compute moving average
     movingAverageMonths = 1
@@ -54,8 +53,9 @@ defined in the ``transportTransects`` transect group.  These are::
    "Japan blockage", "Lancaster Sound", "Mona Passage", "Mozambique Channel",
    "Nares Strait", "Nares Strait Deepen", "Persian Gulf Deepen",
    "Red Sea Deepen", "Sakhalin blockage", "Strait of Gibralter Deepen 1",
-    "Strait of Gibralter Deepen 2", "Tasmania-Ant", "White Sea",
-    "Windward Passage"]
+   "Hudson Bay-Labrador Sea", "OSNAP section East", "OSNAP section West",
+   "Strait of Gibralter Deepen 2", "Tasmania-Ant", "White Sea",
+   "Windward Passage"]
 
 Many of these are likely not of interest in most simulations, so a subset of
 the most relevant transects has been chosen in the default configuration.

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -1763,15 +1763,15 @@ obs = ['SOSE', 'WOA18']
 
 [timeSeriesTransport]
 ## options related to plotting time series of transport through transects
+transportGroups = ['Transport Transects']
 
+[timeSeriesTransportTransects]
 # list of ocean transects from geometric_features to plot or ['all'] for all
 # available transects.
 transectsToPlot = ['Drake Passage', 'Tasmania-Ant', 'Africa-Ant',
                    'Antilles Inflow', 'Mona Passage', 'Windward Passage',
                    'Florida-Cuba', 'Florida-Bahamas', 'Indonesian Throughflow',
-                   'Agulhas', 'Mozambique Channel', 'Bering Strait',
-                   'Lancaster Sound', 'Fram Strait', 'Nares Strait',
-                   'Denmark Strait', 'Iceland-Faroe-Scotland']
+                   'Agulhas', 'Mozambique Channel']
 
 # Number of months over which to compute moving average
 movingAveragePoints = 1
@@ -1789,6 +1789,27 @@ movingAveragePoints = 1
 # The number of parallel tasks occupied by each timeSeriesTransport task.
 # Analysis may run faster for large meshes when this value is set to 2 or 3
 subprocessCount = 1
+
+[timeSeriesArcticTransportTransects]
+
+transectsToPlot = ['all']
+# Number of months over which to compute moving average
+movingAveragePoints = 1
+
+# An optional first year for the tick marks on the x axis. Leave commented out
+# to start at the beginning of the time series.
+
+# firstYearXTicks = 1
+
+# An optional number of years between tick marks on the x axis.  Leave
+# commented out to determine the distance between ticks automatically.
+
+# yearStrideXTicks = 1
+
+# The number of parallel tasks occupied by each timeSeriesTransport task.
+# Analysis may run faster for large meshes when this value is set to 2 or 3
+subprocessCount = 1
+
 
 
 [regionalTSDiagrams]

--- a/mpas_analysis/ocean/time_series_transport.py
+++ b/mpas_analysis/ocean/time_series_transport.py
@@ -577,6 +577,8 @@ class PlotTransportSubtask(AnalysisTask):
                    'Davis Strait': [-1.6, -3.6],
                    'Barents Sea Opening': [1.4, 2.6],
                    'Nares Strait': [-1.8, 0.2],
+                   'OSNAP section East': [15.6 - 0.8, 15.6 + 0.8],
+                   'OSNAP section West': [2.1 - 0.3, 2.1 + 0.3],
                    'Denmark Strait': None,
                    'Iceland-Faroe-Scotland': None}
 

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -549,6 +549,9 @@ makeTables = True
 # ['all'] for all 106 ice shelves and regions.
 iceShelvesInTable = ['all']
 
+[timeSeriesTransport]
+## options related to plotting time series of transport through transects
+transportGroups = ['Transport Transects', 'Arctic Transport Transects']
 
 [timeSeriesConservation]
 ## options related to producing time series plots from the conservation


### PR DESCRIPTION
Add Arctic Transects from branch https://github.com/milenaveneziani/geometric_features/tree/flipOSNAP_renameArcticTransectsTag of geometric features.
Separate all arctic transects from standard transects using transectGroup flag in config option `timeSeriesTransport`.
When running `mpas_analysis` without the flag `--polar_regions` only standard transects are plotted. All Arctic transects including the three new ones "Hudson Bay-Labrador Sea", "OSNAP section East" and "OSNAP section West"
are only plotted when `--polar_regions` is specified.
timeSeriesTransport split into transportGroups "Transport Transects" and "Arctic Transport Transects". By default all Arctic transects are removed from standard transects. 

User can specify the list of standard transects to plot with transectsToPlot under config option (default.cfg) `timeSeriesTransportTransects` and leave it as `all` under `timeSeriesArcticTransportTransects`. List can not include an Arctic Transect.
Similarly user can also specify the list of arctic transects to plot with transectsToPlot under config option `timeSeriesArcticTransportTransects` but to plot these `mpas_analysis` needs to be run with the `--polar_regions` flag.

Files changed: `default.cfg`, `polar_regions.cfg` and `ocean/time_series_transport.py`
@xylar @milenaveneziani @alicebarthel