### PR TITLE
Switch to plotting sea-ice concentration and thickness on projection grids

### DIFF
--- a/docs/developers_guide/api.rst
+++ b/docs/developers_guide/api.rst
@@ -90,14 +90,6 @@ Ocean tasks
 
    ComputeAnomalySubtask
 
-.. currentmodule:: mpas_analysis.ocean.plot_climatology_map_subtask
-
-.. autosummary::
-   :toctree: generated/
-
-   PlotClimatologyMapSubtask
-   PlotClimatologyMapSubtask.set_plot_info
-
 .. currentmodule:: mpas_analysis.ocean.plot_depth_integrated_time_series_subtask
 
 .. autosummary::
@@ -266,6 +258,10 @@ Plotting
    colormap.setup_colormap
    ticks.plot_xtick_format
    add_inset
+
+   PlotClimatologyMapSubtask
+   PlotClimatologyMapSubtask.set_plot_info
+
 
 
 Projection

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -503,8 +503,9 @@ def run_analysis(config, analyses):
                                            'logsSubdirectory')
 
     mainRunName = config.get('runs', 'mainRunName')
+    maxTitleLength = config.getint('plot', 'maxTitleLength')
 
-    if len(mainRunName) > 55:
+    if len(mainRunName) > maxTitleLength:
         print('Warning: The main run name is quite long and will be '
               'truncated in some plots: \n{}\n\n'.format(mainRunName))
 

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -3612,12 +3612,8 @@ colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, -0.1, 0, 0.1, 0.2, 0.4,
 # observations are only available for these seasons)
 seasons =  ['JFM', 'JAS']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon']
-
-# reference lat/lon for sea ice plots in the northern hemisphere
-minimumLatitude = 50
-referenceLongitude = 0
+# comparison grid(s) (typically 'arctic') on which to plot analysis
+comparisonGrids = ['arctic']
 
 # a list of prefixes describing the sources of the observations to be used
 observationPrefixes = ['NASATeam', 'Bootstrap']
@@ -3659,12 +3655,8 @@ colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, -0.1, 0, 0.1, 0.2, 0.4,
 # observations are only available for these seasons)
 seasons =  ['DJF', 'JJA']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon']
-
-# reference lat/lon for sea ice plots in the northern hemisphere
-minimumLatitude = -50
-referenceLongitude = 180
+# comparison grid(s) (typically 'antarctic') on which to plot analysis
+comparisonGrids = ['antarctic']
 
 # a list of prefixes describing the sources of the observations to be used
 observationPrefixes = ['NASATeam', 'Bootstrap']

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -3698,12 +3698,8 @@ colorbarLevelsDifference = [-3., -2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5, 3.]
 # observations are only available for these seasons)
 seasons =  ['FM', 'ON']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon']
-
-# reference lat/lon for sea ice plots in the northern hemisphere
-minimumLatitude = 50
-referenceLongitude = 0
+# comparison grid(s) (typically 'arctic') on which to plot analysis
+comparisonGrids = ['arctic']
 
 # a list of prefixes describing the sources of the observations to be used
 observationPrefixes = ['']
@@ -3743,12 +3739,8 @@ colorbarLevelsDifference = [-3., -2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5, 3.]
 # observations are only available for these seasons)
 seasons =  ['FM', 'ON']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon']
-
-# reference lat/lon for sea ice plots in the northern hemisphere
-minimumLatitude = -50
-referenceLongitude = 180
+# comparison grid(s) (typically 'antarctic') on which to plot analysis
+comparisonGrids = ['antarctic']
 
 # a list of prefixes describing the sources of the observations to be used
 observationPrefixes = ['']

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -235,6 +235,17 @@ comparisonAntarcticStereoResolution = 10.
 comparisonArcticStereoWidth = 6000.
 comparisonArcticStereoResolution = 10.
 
+# The extended Antarctic polar stereographic comparison grid size and
+# resolution in km
+comparisonAntarcticExtendedWidth = 9000.
+comparisonAntarcticExtendedResolution = 15.
+
+# The extended Arctic polar stereographic comparison grid size and
+# resolution in km
+comparisonArcticExtendedWidth = 9000.
+comparisonArcticExtendedResolution = 15.
+
+
 # The comparison North Atlantic grid size and resolution in km
 comparisonNorthAtlanticWidth = 8500.
 comparisonNorthAtlanticHeight = 5500.
@@ -381,6 +392,36 @@ lonLines = np.arange(-180., 181., 30.)
 
 [plot_antarctic]
 ## options related to Antarctic projection plots
+
+# figure sizes for different numbers of panels and layouts
+onePanelFigSize = (8, 8.5)
+threePanelVertFigSize = (8, 22)
+threePanelHorizFigSize = (22, 7.5)
+
+# whether to use the cartopy coastline (as opposed to the model coastline)
+useCartopyCoastline = True
+
+# latitude and longitude grid lines
+latLines = np.arange(-80., 81., 10.)
+lonLines = np.arange(-180., 181., 30.)
+
+[plot_arctic_extended]
+## options related to extended Arctic projection plots
+
+# figure sizes for different numbers of panels and layouts
+onePanelFigSize = (8, 8.5)
+threePanelVertFigSize = (8, 22)
+threePanelHorizFigSize = (22, 7.5)
+
+# whether to use the cartopy coastline (as opposed to the model coastline)
+useCartopyCoastline = True
+
+# latitude and longitude grid lines
+latLines = np.arange(-80., 81., 10.)
+lonLines = np.arange(-180., 181., 30.)
+
+[plot_antarctic_extended]
+## options related to extended Antarctic projection plots
 
 # figure sizes for different numbers of panels and layouts
 onePanelFigSize = (8, 8.5)
@@ -1049,7 +1090,7 @@ colorbarLevelsDifference = [-5, -3, -2, -1, -0.1, 0, 0.1, 1, 2, 3, 5]
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 seasons =  ['JFM', 'JAS', 'ANN']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['latlon']
 
 # first and last year of SST observational climatology (preferably one of the
@@ -1088,7 +1129,7 @@ colorbarLevelsDifference = [-3, -2, -1, -0.5, -0.02, 0,  0.02, 0.5, 1, 2, 3]
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 seasons =  ['JFM', 'JAS', 'ANN']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['latlon']
 
 
@@ -1118,7 +1159,7 @@ colorbarLevelsDifference = [-150, -80, -30, -10, -1, 0, 1, 10, 30, 80, 150]
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 seasons =  ['JFM', 'JAS', 'ANN']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['latlon']
 
 
@@ -1131,7 +1172,7 @@ comparisonGrids = ['latlon']
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 seasons =  ['JFM', 'JAS', 'ANN']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['latlon']
 
 
@@ -1363,7 +1404,7 @@ colorbarLevelsDifference = [-100., -80., -60., -40., -20., -10., 0., 10., 20.,  
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 seasons =  ['JFM', 'JAS', 'ANN']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['latlon']
 
 
@@ -1397,7 +1438,7 @@ normArgsDifference = {'vmin': -300., 'vmax': 300.}
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 seasons =  ['ANN']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['latlon', 'subpolar_north_atlantic']
 
 
@@ -1423,7 +1464,6 @@ contourColorResult = black
 # Add arrows to contour lines
 # whether to include arrows on the contour lines showing the direction of flow
 arrowsOnContourResult = True
-#ticks = [np.arange(-100., 101.0, 10.), np.arange(-100., 101.0, 10.)]
 # colormap for differences
 colormapNameDifference = cmo.balance
 # whether the colormap is indexed or continuous
@@ -1473,7 +1513,7 @@ colorbarLevelsDifference = numpy.linspace(-2., 2., 10)
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 seasons =  ['ANN']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['latlon']
 
 # A list of pairs of minimum and maximum depths (positive up, in meters) to
@@ -2122,7 +2162,7 @@ normArgsDifference = {'vmin': -0.2, 'vmax': 0.2}
 ## fields at various levels, including the sea floor against control model
 ## results and WOA climatological data
 
-# comparison grid(s) ('latlon', 'antarctic', 'arctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['latlon']
 
 # Months or seasons to plot (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
@@ -3215,7 +3255,7 @@ variables = ['PO4', 'NO3', 'SiO3', 'CO2_gas_flux', 'pH_3D', 'DIC', 'ALK', 'O2',
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
 seasons = ['ANN', 'JFM', 'JAS']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['latlon', 'antarctic']
 
 # Whether to compare to preindustrial observations that are available.
@@ -3612,8 +3652,8 @@ colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, -0.1, 0, 0.1, 0.2, 0.4,
 # observations are only available for these seasons)
 seasons =  ['JFM', 'JAS']
 
-# comparison grid(s) (typically 'arctic') on which to plot analysis
-comparisonGrids = ['arctic']
+# comparison grid(s) (typically 'arctic_extended') on which to plot analysis
+comparisonGrids = ['arctic_extended']
 
 # a list of prefixes describing the sources of the observations to be used
 observationPrefixes = ['NASATeam', 'Bootstrap']
@@ -3655,8 +3695,8 @@ colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, -0.1, 0, 0.1, 0.2, 0.4,
 # observations are only available for these seasons)
 seasons =  ['DJF', 'JJA']
 
-# comparison grid(s) (typically 'antarctic') on which to plot analysis
-comparisonGrids = ['antarctic']
+# comparison grid(s) (typically 'antarctic_extended') on which to plot analysis
+comparisonGrids = ['antarctic_extended']
 
 # a list of prefixes describing the sources of the observations to be used
 observationPrefixes = ['NASATeam', 'Bootstrap']
@@ -3698,8 +3738,8 @@ colorbarLevelsDifference = [-3., -2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5, 3.]
 # observations are only available for these seasons)
 seasons =  ['FM', 'ON']
 
-# comparison grid(s) (typically 'arctic') on which to plot analysis
-comparisonGrids = ['arctic']
+# comparison grid(s) (typically 'arctic_extended') on which to plot analysis
+comparisonGrids = ['arctic_extended']
 
 # a list of prefixes describing the sources of the observations to be used
 observationPrefixes = ['']
@@ -3739,8 +3779,8 @@ colorbarLevelsDifference = [-3., -2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5, 3.]
 # observations are only available for these seasons)
 seasons =  ['FM', 'ON']
 
-# comparison grid(s) (typically 'antarctic') on which to plot analysis
-comparisonGrids = ['antarctic']
+# comparison grid(s) (typically 'antarctic_extended') on which to plot analysis
+comparisonGrids = ['antarctic_extended']
 
 # a list of prefixes describing the sources of the observations to be used
 observationPrefixes = ['']
@@ -3780,7 +3820,7 @@ normArgsDifference = {'linthresh': 1e-5, 'linscale': 1, 'vmin': -1e-2, 'vmax': 1
 # Times for comparison times
 seasons =  ['ANN', 'DJF', 'JJA']
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['latlon']
 
 # reference lat/lon for sea ice plots in the northern hemisphere

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -358,6 +358,7 @@ titleFontSize = 16
 titleFontColor = black
 titleFontWeight = normal
 axisFontSize = 12
+maxTitleLength = 45
 
 # font size for cartopy grid labels
 cartopyGridFontSize = 12

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -3662,6 +3662,9 @@ observationPrefixes = ['NASATeam', 'Bootstrap']
 # arrange subplots vertically?
 vertical = False
 
+# the minimum threshold below which concentration is masked out
+minConcentration = 0.15
+
 # observations files
 concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5_20180710.nc
 concentrationNASATeamNH_JAS = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jas.interp0.5x0.5_20180710.nc
@@ -3704,6 +3707,9 @@ observationPrefixes = ['NASATeam', 'Bootstrap']
 
 # arrange subplots vertically?
 vertical = False
+
+# the minimum threshold below which concentration is masked out
+minConcentration = 0.15
 
 # observations files
 concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5_20180710.nc

--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -27,8 +27,7 @@ from mpas_analysis.shared.projection import get_pyproj_projection
 from mpas_analysis.shared.climatology.climatology import \
     get_masked_mpas_climatology_file_name
 
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 from mpas_analysis.shared.constants import constants
 

--- a/mpas_analysis/ocean/climatology_map_argo.py
+++ b/mpas_analysis/ocean/climatology_map_argo.py
@@ -25,8 +25,7 @@ from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.ocean.remap_depth_slices_subtask import \
     RemapDepthSlicesSubtask
 
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 from mpas_analysis.shared.io.utility import build_obs_path
 

--- a/mpas_analysis/ocean/climatology_map_bgc.py
+++ b/mpas_analysis/ocean/climatology_map_bgc.py
@@ -16,8 +16,7 @@ from mpas_analysis.shared.io.utility import build_obs_path
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
 
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 from mpas_analysis.shared.interpolation.utility import add_periodic_lon
 

--- a/mpas_analysis/ocean/climatology_map_bsf.py
+++ b/mpas_analysis/ocean/climatology_map_bsf.py
@@ -15,8 +15,7 @@ import scipy.sparse.linalg
 
 from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 from mpas_analysis.ocean.utility import compute_zmid
 
 

--- a/mpas_analysis/ocean/climatology_map_eke.py
+++ b/mpas_analysis/ocean/climatology_map_eke.py
@@ -18,8 +18,7 @@ from mpas_analysis.shared.io.utility import build_obs_path
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
 
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 
 class ClimatologyMapEKE(AnalysisTask):

--- a/mpas_analysis/ocean/climatology_map_mld.py
+++ b/mpas_analysis/ocean/climatology_map_mld.py
@@ -19,8 +19,7 @@ from mpas_analysis.shared.io.utility import build_obs_path
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
 
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 
 class ClimatologyMapMLD(AnalysisTask):

--- a/mpas_analysis/ocean/climatology_map_mld_min_max.py
+++ b/mpas_analysis/ocean/climatology_map_mld_min_max.py
@@ -12,8 +12,7 @@ from mpas_analysis.shared import AnalysisTask
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask
 
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 
 class ClimatologyMapMLDMinMax(AnalysisTask):

--- a/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
+++ b/mpas_analysis/ocean/climatology_map_ohc_anomaly.py
@@ -13,8 +13,7 @@ import numpy as np
 
 from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 from mpas_analysis.ocean.utility import compute_zmid
 
 

--- a/mpas_analysis/ocean/climatology_map_schmidtko.py
+++ b/mpas_analysis/ocean/climatology_map_schmidtko.py
@@ -23,8 +23,7 @@ from mpas_analysis.shared import AnalysisTask
 
 from mpas_analysis.ocean.remap_depth_slices_subtask import \
     RemapDepthSlicesSubtask
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 from mpas_analysis.shared.io.utility import build_obs_path
 

--- a/mpas_analysis/ocean/climatology_map_sose.py
+++ b/mpas_analysis/ocean/climatology_map_sose.py
@@ -24,8 +24,7 @@ from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask
 
 from mpas_analysis.ocean.remap_depth_slices_subtask import \
     RemapDepthSlicesSubtask
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 from mpas_analysis.ocean.remap_sose_climatology import RemapSoseClimatology
 
 from mpas_analysis.shared.io.utility import build_obs_path

--- a/mpas_analysis/ocean/climatology_map_ssh.py
+++ b/mpas_analysis/ocean/climatology_map_ssh.py
@@ -18,8 +18,7 @@ from mpas_analysis.shared.io.utility import build_obs_path
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
 
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 from mpas_analysis.shared.constants import constants
 

--- a/mpas_analysis/ocean/climatology_map_sss.py
+++ b/mpas_analysis/ocean/climatology_map_sss.py
@@ -19,8 +19,7 @@ from mpas_analysis.shared.io.utility import build_obs_path
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
 
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 
 class ClimatologyMapSSS(AnalysisTask):

--- a/mpas_analysis/ocean/climatology_map_sst.py
+++ b/mpas_analysis/ocean/climatology_map_sst.py
@@ -20,8 +20,7 @@ from mpas_analysis.shared.io.utility import build_obs_path
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
 
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 
 class ClimatologyMapSST(AnalysisTask):

--- a/mpas_analysis/ocean/climatology_map_woa.py
+++ b/mpas_analysis/ocean/climatology_map_woa.py
@@ -24,8 +24,7 @@ from mpas_analysis.shared import AnalysisTask
 
 from mpas_analysis.ocean.remap_depth_slices_subtask import \
     RemapDepthSlicesSubtask
-from mpas_analysis.ocean.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 from mpas_analysis.shared.io.utility import build_obs_path
 

--- a/mpas_analysis/ocean/utility.py
+++ b/mpas_analysis/ocean/utility.py
@@ -62,12 +62,3 @@ def compute_zmid(bottomDepth, maxLevelCell, layerThickness):
     zMid = zLayerBot + 0.5 * layerThickness
 
     return zMid
-
-
-def nans_to_numpy_mask(field):
-    """
-    Convert a numpy array with NaNs to a masked numpy array
-    """
-    field = numpy.ma.masked_array(
-        field, numpy.isnan(field))
-    return field

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -19,7 +19,7 @@ generate = ['all']
 ## fields at various levels, including the sea floor against control model
 ## results and WOA climatological data
 
-# comparison grid(s) ('latlon', 'antarctic', 'arctic') on which to plot analysis
+# comparison grid(s) on which to plot analysis
 comparisonGrids = ['antarctic', 'arctic']
 
 # list of depths in meters (positive up) at which to analyze, 'top' for the
@@ -442,8 +442,9 @@ yLim = [-600., -5.]
 ## the barotropic streamfunction (BSF) against control model results
 ## (if available)
 
-# comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-comparisonGrids = ['latlon', 'arctic', 'antarctic', 'subpolar_north_atlantic']
+# comparison grid(s) on which to plot analysis
+comparisonGrids = ['latlon', 'arctic_extended', 'antarctic_extended',
+                   'subpolar_north_atlantic']
 
 [climatologyMapAntarcticMelt]
 ## options related to plotting horizontally regridded maps of Antarctic

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -112,8 +112,7 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
         else:
             self._add_ref_tasks(seasons, comparisonGridNames, hemisphere,
                                 hemisphereLong, remapClimatologySubtask,
-                                controlConfig, mpasFieldName,
-                                fieldName, iselValues)
+                                controlConfig, mpasFieldName)
 
     def _add_obs_tasks(self, seasons, comparisonGridNames, hemisphere,
                        hemisphereLong, remapClimatologySubtask,
@@ -121,6 +120,8 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
         config = self.config
         obsFieldName = 'seaIceConc'
         sectionName = self.taskName
+
+        minConcentration = config.getfloat(self.taskName, 'minConcentration')
 
         observationPrefixes = config.getexpression(sectionName,
                                                    'observationPrefixes')
@@ -181,15 +182,17 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                         groupSubtitle=None,
                         groupLink='{}_conc'.format(hemisphere.lower()),
                         galleryName='Observations: SSM/I {}'.format(
-                            prefix))
+                            prefix),
+                        maskMinThreshold=minConcentration)
 
                     self.add_subtask(subtask)
 
     def _add_ref_tasks(self, seasons, comparisonGridNames, hemisphere,
                        hemisphereLong, remapClimatologySubtask,
-                       controlConfig, mpasFieldName, fieldName,
-                       iselValues):
+                       controlConfig, mpasFieldName):
 
+        minConcentration = self.config.getfloat(self.taskName,
+                                                'minConcentration')
         controlRunName = controlConfig.get('runs', 'mainRunName')
         galleryName = None
         refTitleLabel = 'Control: {}'.format(controlRunName)
@@ -224,7 +227,8 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                     galleryGroup=galleryGroup,
                     groupSubtitle=None,
                     groupLink='{}_conc'.format(hemisphere.lower()),
-                    galleryName=galleryName)
+                    galleryName=galleryName,
+                    maskMinThreshold=minConcentration)
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -183,7 +183,8 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                         groupLink='{}_conc'.format(hemisphere.lower()),
                         galleryName='Observations: SSM/I {}'.format(
                             prefix),
-                        maskMinThreshold=minConcentration)
+                        maskMinThreshold=minConcentration,
+                        extend='neither')
 
                     self.add_subtask(subtask)
 
@@ -228,7 +229,8 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                     groupSubtitle=None,
                     groupLink='{}_conc'.format(hemisphere.lower()),
                     galleryName=galleryName,
-                    maskMinThreshold=minConcentration)
+                    maskMinThreshold=minConcentration,
+                    extend='neither')
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -17,8 +17,7 @@ from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
 
-from mpas_analysis.sea_ice.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 from mpas_analysis.shared.io.utility import build_obs_path
 
@@ -148,8 +147,8 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                 for comparisonGridName in comparisonGridNames:
 
                     imageDescription = \
-                        '{} Climatology Map of {}-Hemisphere Sea-Ice ' \
-                        'Concentration'.format(season, hemisphereLong)
+                        'Climatology Map of {}-Hemisphere Sea-Ice ' \
+                        'Concentration'.format(hemisphereLong)
                     imageCaption = \
                         '{}. <br> Observations: SSM/I {}'.format(
                             imageDescription, prefix)
@@ -158,11 +157,15 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                             hemisphereLong)
                     # make a new subtask for this season and comparison
                     # grid
+
+                    subtaskName = f'plot{season}_{comparisonGridName}_{prefix}'
+
                     subtask = PlotClimatologyMapSubtask(
-                        self, hemisphere, season, comparisonGridName,
-                        remapClimatologySubtask,
+                        parentTask=self, season=season,
+                        comparisonGridName=comparisonGridName,
+                        remapMpasClimatologySubtask=remapClimatologySubtask,
                         remapObsClimatologySubtask=remapObservationsSubtask,
-                        subtaskSuffix=prefix)
+                        subtaskName=subtaskName)
 
                     subtask.set_plot_info(
                         outFileLabel='iceconc{}{}'.format(prefix,
@@ -173,7 +176,6 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                         refTitleLabel=observationTitleLabel,
                         diffTitleLabel='Model - Observations',
                         unitsLabel=r'fraction',
-                        imageDescription=imageDescription,
                         imageCaption=imageCaption,
                         galleryGroup=galleryGroup,
                         groupSubtitle=None,
@@ -205,8 +207,10 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                 # make a new subtask for this season and comparison
                 # grid
                 subtask = PlotClimatologyMapSubtask(
-                    self, hemisphere, season, comparisonGridName,
-                    remapClimatologySubtask, controlConfig=controlConfig)
+                    parentTask=self, season=season,
+                    comparisonGridName=comparisonGridName,
+                    remapMpasClimatologySubtask=remapClimatologySubtask,
+                    controlConfig=controlConfig)
 
                 subtask.set_plot_info(
                     outFileLabel='iceconc{}'.format(hemisphere),
@@ -216,7 +220,6 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                     refTitleLabel=refTitleLabel,
                     diffTitleLabel='Main - Control',
                     unitsLabel=r'fraction',
-                    imageDescription=imageDescription,
                     imageCaption=imageCaption,
                     galleryGroup=galleryGroup,
                     groupSubtitle=None,

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -164,7 +164,8 @@ class ClimatologyMapSeaIceThick(AnalysisTask):
                     groupSubtitle=None,
                     groupLink=f'{hemisphere.lower()}_thick',
                     galleryName=galleryName,
-                    maskMinThreshold=0)
+                    maskMinThreshold=0,
+                    extend='neither')
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -164,7 +164,7 @@ class ClimatologyMapSeaIceThick(AnalysisTask):
                     groupSubtitle=None,
                     groupLink=f'{hemisphere.lower()}_thick',
                     galleryName=galleryName,
-                    maskValue=0)
+                    maskMinThreshold=0)
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -17,8 +17,7 @@ from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
 
-from mpas_analysis.sea_ice.plot_climatology_map_subtask import \
-    PlotClimatologyMapSubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
 
 from mpas_analysis.shared.io.utility import build_obs_path
 
@@ -48,14 +47,14 @@ class ClimatologyMapSeaIceThick(AnalysisTask):
         hemisphere : {'NH', 'SH'}
             The hemisphere to plot
 
-        controlconfig : mpas_tools.config.MpasConfigParser, optional
+        controlConfig : mpas_tools.config.MpasConfigParser, optional
             Configuration options for a control run (if any)
         """
         # Authors
         # -------
         # Xylar Asay-Davis
 
-        taskName = 'climatologyMapSeaIceThick{}'.format(hemisphere)
+        taskName = f'climatologyMapSeaIceThick{hemisphere}'
 
         fieldName = 'seaIceThick'
 
@@ -85,22 +84,22 @@ class ClimatologyMapSeaIceThick(AnalysisTask):
         seasons = config.getexpression(sectionName, 'seasons')
 
         if len(seasons) == 0:
-            raise ValueError('config section {} does not contain valid list '
-                             'of seasons'.format(sectionName))
+            raise ValueError(f'config section {sectionName} does not contain '
+                             f'a valid list of seasons')
 
         comparisonGridNames = config.getexpression(sectionName,
                                                    'comparisonGrids')
 
         if len(comparisonGridNames) == 0:
-            raise ValueError('config section {} does not contain valid list '
-                             'of comparison grids'.format(sectionName))
+            raise ValueError(f'config section {sectionName} does not contain '
+                             f'a valid list of comparison grids')
 
         # the variable self.mpasFieldName will be added to mpasClimatologyTask
         # along with the seasons.
         remapClimatologySubtask = RemapMpasClimatologySubtask(
             mpasClimatologyTask=mpasClimatologyTask,
             parentTask=self,
-            climatologyName='{}{}'.format(fieldName, hemisphere),
+            climatologyName=f'{fieldName}{hemisphere}',
             variableList=[mpasFieldName],
             comparisonGridNames=comparisonGridNames,
             seasons=seasons,
@@ -114,58 +113,56 @@ class ClimatologyMapSeaIceThick(AnalysisTask):
         else:
             controlRunName = controlConfig.get('runs', 'mainRunName')
             galleryName = None
-            refTitleLabel = 'Control: {}'.format(controlRunName)
+            refTitleLabel = f'Control: {controlRunName}'
             refFieldName = mpasFieldName
             diffTitleLabel = 'Main - Control'
-
-            remapObservationsSubtask = None
 
         for season in seasons:
             if controlConfig is None:
                 obsFileName = build_obs_path(
                     config, 'seaIce',
-                    relativePathOption='thickness{}_{}'.format(hemisphere,
-                                                               season),
+                    relativePathOption=f'thickness{hemisphere}_{season}',
                     relativePathSection=sectionName)
 
                 remapObservationsSubtask = RemapObservedThickClimatology(
                     parentTask=self, seasons=[season],
                     fileName=obsFileName,
-                    outFilePrefix='{}{}_{}'.format(refFieldName,
-                                                   hemisphere,
-                                                   season),
+                    outFilePrefix=f'{refFieldName}{hemisphere}_{season}',
                     comparisonGridNames=comparisonGridNames,
-                    subtaskName='remapObservations{}'.format(season))
+                    subtaskName=f'remapObservations{season}')
                 self.add_subtask(remapObservationsSubtask)
+            else:
+                remapObservationsSubtask = None
 
             for comparisonGridName in comparisonGridNames:
 
-                imageDescription = \
-                    '{} Climatology Map of {}-Hemisphere Sea-Ice ' \
-                    'Thickness.'.format(season, hemisphereLong)
-                imageCaption = imageDescription
+                imageCaption = \
+                    f'Climatology Map of {hemisphereLong}-Hemisphere ' \
+                    f'Sea-Ice Thickness.'
                 galleryGroup = \
-                    '{}-Hemisphere Sea-Ice Thickness'.format(
-                        hemisphereLong)
+                    f'{hemisphereLong}-Hemisphere Sea-Ice Thickness'
                 # make a new subtask for this season and comparison grid
+                subtaskName = f'plot{season}_{comparisonGridName}'
+
                 subtask = PlotClimatologyMapSubtask(
-                    self, hemisphere, season, comparisonGridName,
-                    remapClimatologySubtask, remapObservationsSubtask,
-                    controlConfig)
+                    parentTask=self, season=season,
+                    comparisonGridName=comparisonGridName,
+                    remapMpasClimatologySubtask=remapClimatologySubtask,
+                    remapObsClimatologySubtask=remapObservationsSubtask,
+                    subtaskName=subtaskName)
 
                 subtask.set_plot_info(
-                    outFileLabel='icethick{}'.format(hemisphere),
+                    outFileLabel=f'icethick{hemisphere}',
                     fieldNameInTitle='Sea ice thickness',
                     mpasFieldName=mpasFieldName,
                     refFieldName=refFieldName,
                     refTitleLabel=refTitleLabel,
                     diffTitleLabel=diffTitleLabel,
                     unitsLabel=r'm',
-                    imageDescription=imageDescription,
                     imageCaption=imageCaption,
                     galleryGroup=galleryGroup,
                     groupSubtitle=None,
-                    groupLink='{}_thick'.format(hemisphere.lower()),
+                    groupLink=f'{hemisphere.lower()}_thick',
                     galleryName=galleryName,
                     maskValue=0)
 

--- a/mpas_analysis/shared/climatology/comparison_descriptors.py
+++ b/mpas_analysis/shared/climatology/comparison_descriptors.py
@@ -121,12 +121,16 @@ def _get_projection_comparison_descriptor(config, comparison_grid_name):
 
     option_suffixes = {'antarctic': 'AntarcticStereo',
                        'arctic': 'ArcticStereo',
+                       'antarctic_extended': 'AntarcticExtended',
+                       'arctic_extended': 'ArcticExtended',
                        'north_atlantic': 'NorthAtlantic',
                        'north_pacific': 'NorthPacific',
                        'subpolar_north_atlantic': 'SubpolarNorthAtlantic'}
 
     grid_suffixes = {'antarctic': 'Antarctic_stereo',
                      'arctic': 'Arctic_stereo',
+                     'antarctic_extended': 'Antarctic_stereo',
+                     'arctic_extended': 'Arctic_stereo',
                      'north_atlantic': 'North_Atlantic',
                      'north_pacific': 'North_Pacific',
                      'subpolar_north_atlantic': 'Subpolar_North_Atlantic'}

--- a/mpas_analysis/shared/plot/__init__.py
+++ b/mpas_analysis/shared/plot/__init__.py
@@ -12,3 +12,6 @@ from mpas_analysis.shared.plot.oned import plot_1D
 from mpas_analysis.shared.plot.save import savefig
 
 from mpas_analysis.shared.plot.inset import add_inset
+
+from mpas_analysis.shared.plot.plot_climatology_map_subtask import \
+    PlotClimatologyMapSubtask

--- a/mpas_analysis/shared/plot/climatology_map.py
+++ b/mpas_analysis/shared/plot/climatology_map.py
@@ -55,7 +55,7 @@ def plot_polar_comparison(
         figsize=None,
         dpi=None,
         vertical=False,
-        maxTitleLength=60):
+        maxTitleLength=None):
     """
     Plots a data set around either the north or south pole.
 
@@ -116,9 +116,10 @@ def plot_polar_comparison(
         whether the subplots should be stacked vertically rather than
         horizontally
 
-    maxTitleLength : int, optional
+    maxTitleLength : int or None, optional
         the maximum number of characters in the title, beyond which it is
-        truncated with a trailing ellipsis
+        truncated with a trailing ellipsis.  The default is from the
+        ``maxTitleLength`` config option.
     """
     # Authors
     # -------
@@ -178,6 +179,9 @@ def plot_polar_comparison(
         if ticks is not None:
             cbar.set_ticks(ticks)
             cbar.set_ticklabels(['{}'.format(tick) for tick in ticks])
+
+    if maxTitleLength is None:
+        maxTitleLength = config.getint('plot', 'maxTitleLength')
 
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')
@@ -266,7 +270,7 @@ def plot_global_comparison(
         dpi=None,
         lineWidth=1,
         lineColor='black',
-        maxTitleLength=60):
+        maxTitleLength=None):
     """
     Plots a data set as a longitude/latitude map.
 
@@ -325,9 +329,10 @@ def plot_global_comparison(
     lineColor : str, optional
         the color of contour lines (if specified)
 
-    maxTitleLength : int, optional
+    maxTitleLength : int or None, optional
         the maximum number of characters in the title, beyond which it is
-        truncated with a trailing ellipsis
+        truncated with a trailing ellipsis.  The default is from the
+        ``maxTitleLength`` config option.
     """
     # Authors
     # -------
@@ -375,6 +380,10 @@ def plot_global_comparison(
         if ticks is not None:
             cbar.set_ticks(ticks)
             cbar.set_ticklabels(['{}'.format(tick) for tick in ticks])
+
+    if maxTitleLength is None:
+        maxTitleLength = config.getint('plot', 'maxTitleLength')
+
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')
     matplotlib.rc('font', size=defaultFontSize)
@@ -454,7 +463,7 @@ def plot_projection_comparison(
         cartopyGridFontSize=None,
         defaultFontSize=None,
         vertical=False,
-        maxTitleLength=55):
+        maxTitleLength=None):
     """
     Plots a data set as a projection map.
 
@@ -515,9 +524,10 @@ def plot_projection_comparison(
         available via
         :py:func:`mpas_analysis.shared.projection.get_cartopy_projection()`.
 
-    maxTitleLength : int, optional
+    maxTitleLength : int or None, optional
         the maximum number of characters in the title, beyond which it is
-        truncated with a trailing ellipsis
+        truncated with a trailing ellipsis.  The default is from the
+        ``maxTitleLength`` config option.
     """
     # Authors
     # -------
@@ -602,6 +612,9 @@ def plot_projection_comparison(
         if ticks is not None:
             cbar.set_ticks(ticks)
             cbar.set_ticklabels(['{}'.format(tick) for tick in ticks])
+
+    if maxTitleLength is None:
+        maxTitleLength = config.getint('plot', 'maxTitleLength')
 
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')

--- a/mpas_analysis/shared/plot/climatology_map.py
+++ b/mpas_analysis/shared/plot/climatology_map.py
@@ -270,7 +270,8 @@ def plot_global_comparison(
         dpi=None,
         lineWidth=1,
         lineColor='black',
-        maxTitleLength=None):
+        maxTitleLength=None,
+        extend='both'):
     """
     Plots a data set as a longitude/latitude map.
 
@@ -333,6 +334,10 @@ def plot_global_comparison(
         the maximum number of characters in the title, beyond which it is
         truncated with a trailing ellipsis.  The default is from the
         ``maxTitleLength`` config option.
+
+    extend : {'neither', 'both', 'min', 'max'}, optional
+        Determines the ``contourf``-coloring of values that are outside the
+        range of the levels provided if using an indexed colormap.
     """
     # Authors
     # -------
@@ -361,7 +366,7 @@ def plot_global_comparison(
                                        zorder=1, rasterized=True)
         else:
             plotHandle = ax.contourf(Lons, Lats, array, cmap=colormap,
-                                     norm=norm, levels=levels, extend='both',
+                                     norm=norm, levels=levels, extend=extend,
                                      transform=projection, zorder=1)
 
         _add_land_lakes_coastline(ax)
@@ -463,7 +468,8 @@ def plot_projection_comparison(
         cartopyGridFontSize=None,
         defaultFontSize=None,
         vertical=False,
-        maxTitleLength=None):
+        maxTitleLength=None,
+        extend='both'):
     """
     Plots a data set as a projection map.
 
@@ -528,6 +534,10 @@ def plot_projection_comparison(
         the maximum number of characters in the title, beyond which it is
         truncated with a trailing ellipsis.  The default is from the
         ``maxTitleLength`` config option.
+
+    extend : {'neither', 'both', 'min', 'max'}, optional
+        Determines the ``contourf``-coloring of values that are outside the
+        range of the levels provided if using an indexed colormap.
     """
     # Authors
     # -------
@@ -580,7 +590,7 @@ def plot_projection_comparison(
                                        rasterized=True)
         else:
             plotHandle = ax.contourf(xCenter, yCenter, array, cmap=colormap,
-                                     norm=norm, levels=levels, extend='both')
+                                     norm=norm, levels=levels, extend=extend)
 
         if useCartopyCoastline:
             _add_land_lakes_coastline(ax, ice_shelves=False)

--- a/mpas_analysis/shared/plot/oned.py
+++ b/mpas_analysis/shared/plot/oned.py
@@ -34,7 +34,7 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
             xLim=None,
             yLim=None,
             invertYAxis=False,
-            maxTitleLength=80,
+            maxTitleLength=None,
             titleFontSize=None,
             axisFontSize=None,
             defaultFontSize=None):
@@ -88,9 +88,10 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
     invertYAxis : logical, optional
         if True, invert Y axis
 
-    maxTitleLength : int, optional
-        the maximum number of characters in the title and legend, beyond which
-        they are truncated with a trailing ellipsis
+    maxTitleLength : int or None, optional
+        the maximum number of characters in the title, beyond which it is
+        truncated with a trailing ellipsis.  The default is from the
+        ``maxTitleLength`` config option.
 
     titleFontSize : int, optional
         size of the title font
@@ -104,6 +105,9 @@ def plot_1D(config, xArrays, fieldArrays, errArrays,
     # Authors
     # -------
     # Mark Petersen, Milena Veneziani, Xylar Asay-Davis
+
+    if maxTitleLength is None:
+        maxTitleLength = config.getint('plot', 'maxTitleLength')
 
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')

--- a/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
+++ b/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
@@ -200,6 +200,26 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         if secondRemapMpasClimatologySubtask is not None:
             self.run_after(secondRemapMpasClimatologySubtask)
 
+        self.outFileLabel = None
+        self.fieldNameInTitle = None
+        self.mpasFieldName = None
+        self.refFieldName = None
+        self.refTitleLabel = None
+        self.diffTitleLabel = None
+        self.unitsLabel = None
+        self.imageCaption = None
+        self.galleryGroup = None
+        self.groupSubtitle = None
+        self.groupLink = None
+        self.galleryName = None
+        self.configSectionName = None
+        self.thumbnailDescription = None
+        self.startYear = None
+        self.endYear = None
+        self.startDate = None
+        self.endDate = None
+        self.filePrefix = None
+
     def set_plot_info(self, outFileLabel, fieldNameInTitle, mpasFieldName,
                       refFieldName, refTitleLabel, unitsLabel,
                       imageCaption, galleryGroup, groupSubtitle, groupLink,

--- a/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
+++ b/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
@@ -102,6 +102,10 @@ class PlotClimatologyMapSubtask(AnalysisTask):
 
     maskMaxThreshold : float or None
         a value above which the field is mask out in plots
+
+    extend : {'neither', 'both', 'min', 'max'}
+        Determines the ``contourf``-coloring of values that are outside the
+        range of the levels provided if using an indexed colormap.
     """
 
     def __init__(self, parentTask, season, comparisonGridName,
@@ -214,13 +218,14 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         self.filePrefix = None
         self.maskMinThreshold = None
         self.maskMaxThreshold = None
+        self.extend = 'both'
 
     def set_plot_info(self, outFileLabel, fieldNameInTitle, mpasFieldName,
                       refFieldName, refTitleLabel, unitsLabel,
                       imageCaption, galleryGroup, groupSubtitle, groupLink,
                       galleryName, diffTitleLabel='Model - Observations',
                       configSectionName=None, maskMinThreshold=None,
-                      maskMaxThreshold=None):
+                      maskMaxThreshold=None, extend=None):
         """
         Store attributes related to plots, plot file names and HTML output.
 
@@ -274,6 +279,10 @@ class PlotClimatologyMapSubtask(AnalysisTask):
 
         maskMaxThreshold : float or None, optional
             a value above which the field is mask out in plots
+
+        extend : {'neither', 'both', 'min', 'max'}, optional
+            Determines the ``contourf``-coloring of values that are outside the
+            range of the levels provided if using an indexed colormap.
         """
 
         self.outFileLabel = outFileLabel
@@ -312,6 +321,9 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         else:
             self.fieldNameInTitle = f'{fieldNameInTitle} at z={depth} m'
             self.thumbnailDescription = f'{season} z={depth} m'
+
+        if extend is not None:
+            self.extend = extend
 
     def setup_and_check(self):
         """
@@ -529,7 +541,8 @@ class PlotClimatologyMapSubtask(AnalysisTask):
                                diffTitle=self.diffTitleLabel,
                                cbarlabel=self.unitsLabel,
                                titleFontSize=titleFontSize,
-                               defaultFontSize=defaultFontSize)
+                               defaultFontSize=defaultFontSize,
+                               extend=self.extend)
 
         caption = f'{season} {self.imageCaption}'
         write_image_xml(
@@ -631,7 +644,8 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             titleFontSize=titleFontSize,
             cartopyGridFontSize=cartopyGridFontSize,
             defaultFontSize=defaultFontSize,
-            vertical=vertical)
+            vertical=vertical,
+            extend=self.extend)
 
         upperGridName = capwords(comparisonGridName.replace('_', ' '))
         caption = f'{season} {self.imageCaption}'

--- a/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
+++ b/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
@@ -8,13 +8,6 @@
 # Additional copyright and license information can be found in the LICENSE file
 # distributed with this code, or at
 # https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/master/LICENSE
-"""
-An analysis subtasks for plotting comparison of 2D model fields against
-observations.
-"""
-# Authors
-# -------
-# Luke Van Roekel, Xylar Asay-Davis, Milena Veneziani
 
 import xarray as xr
 import numpy as np
@@ -46,15 +39,15 @@ class PlotClimatologyMapSubtask(AnalysisTask):
     comparisonGridName : str
         The name of the comparison grid to plot.
 
-    remapMpasClimatologySubtask : ``RemapMpasClimatologySubtask``
+    remapMpasClimatologySubtask : mpas_analysis.shared.climatology.RemapMpasClimatologySubtask
         The subtask for remapping the MPAS climatology that this subtask
         will plot
 
-    remapObsClimatologySubtask : ``RemapObservedClimatologySubtask``
+    remapObsClimatologySubtask : mpas_analysis.shared.climatology.RemapObservedClimatologySubtask
         The subtask for remapping the observational climatology that this
         subtask will plot
 
-    secondRemapMpasClimatologySubtask : ``RemapMpasClimatologySubtask``
+    secondRemapMpasClimatologySubtask : mpas_analysis.shared.climatology.RemapMpasClimatologySubtask
         A second subtask for remapping another MPAS climatology to plot
         in the second panel and compare with in the third panel
 
@@ -104,9 +97,6 @@ class PlotClimatologyMapSubtask(AnalysisTask):
     configSectionName : str
         the name of the section where the color map and range is defined
     """
-    # Authors
-    # -------
-    # Luke Van Roekel, Xylar Asay-Davis, Milena Veneziani
 
     def __init__(self, parentTask, season, comparisonGridName,
                  remapMpasClimatologySubtask, remapObsClimatologySubtask=None,
@@ -118,7 +108,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):
 
         Parameters
         ----------
-        parentTask :  ``AnalysisTask``
+        parentTask :  mpas_analysis.shared.AnalysisTask
             The parent (master) task for this subtask
 
         season : str
@@ -128,15 +118,15 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         comparisonGridName : str
             The name of the comparison grid to plot.
 
-        remapMpasClimatologySubtask : ``RemapMpasClimatologySubtask``
+        remapMpasClimatologySubtask : mpas_analysis.shared.climatology.RemapMpasClimatologySubtask
             The subtask for remapping the MPAS climatology that this subtask
             will plot
 
-        remapObsClimatologySubtask : ``RemapObservedClimatologySubtask``, optional
+        remapObsClimatologySubtask : mpas_analysis.shared.climatology.RemapObservedClimatologySubtask, optional
             The subtask for remapping the observational climatology that this
             subtask will plot
 
-        secondRemapMpasClimatologySubtask : ``RemapMpasClimatologySubtask``, optional
+        secondRemapMpasClimatologySubtask : mpas_analysis.shared.climatology.RemapMpasClimatologySubtask, optional
             A second subtask for remapping another MPAS climatology to plot
             in the second panel and compare with in the third panel
 
@@ -159,9 +149,6 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             ``plot<season>_<comparisonGridName>`` with a suffix indicating the
             depth being sliced (if any)
         """
-        # Authors
-        # -------
-        # Xylar Asay-Davis
 
         self.season = season
         self.depth = depth
@@ -273,9 +260,6 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             the name of the section where the color map and range is defined,
             default is the name of the task
         """
-        # Authors
-        # -------
-        # Xylar Asay-Davis
 
         self.outFileLabel = outFileLabel
         self.fieldNameInTitle = fieldNameInTitle
@@ -316,9 +300,6 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         """
         Perform steps to set up the analysis and check for errors in the setup.
         """
-        # Authors
-        # -------
-        # Xylar Asay-Davis
 
         # first, call setup_and_check from the base class (AnalysisTask),
         # which will perform some common setup, including storing:
@@ -356,9 +337,6 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         Plots a comparison of E3SM/MPAS output to SST/TEMP, SSS/SALT or MLD
         observations or a control run
         """
-        # Authors
-        # -------
-        # Luke Van Roekel, Xylar Asay-Davis, Milena Veneziani
 
         season = self.season
         depth = self.depth

--- a/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
+++ b/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
@@ -176,12 +176,12 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         if depth is None:
             self.depthSuffix = ''
         else:
-            self.depthSuffix = 'depth_{}'.format(depth)
+            self.depthSuffix = f'depth_{depth}'
 
         if subtaskName is None:
-            subtaskName = 'plot{}_{}'.format(season, comparisonGridName)
+            subtaskName = f'plot{season}_{comparisonGridName}'
             if depth is not None:
-                subtaskName = '{}_{}'.format(subtaskName, self.depthSuffix)
+                subtaskName = f'{subtaskName}_{self.depthSuffix}'
 
         config = parentTask.config
         taskName = parentTask.taskName
@@ -303,15 +303,14 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             self.fieldNameInTitle = fieldNameInTitle
             self.thumbnailDescription = season
         elif depth == 'top':
-            self.fieldNameInTitle = 'Sea Surface {}'.format(fieldNameInTitle)
-            self.thumbnailDescription = '{} surface'.format(season)
+            self.fieldNameInTitle = f'Sea Surface {fieldNameInTitle}'
+            self.thumbnailDescription = f'{season} surface'
         elif depth == 'bot':
-            self.fieldNameInTitle = 'Sea Floor {}'.format(fieldNameInTitle)
-            self.thumbnailDescription = '{} floor'.format(season)
+            self.fieldNameInTitle = f'Sea Floor {fieldNameInTitle}'
+            self.thumbnailDescription = f'{season} floor'
         else:
-            self.fieldNameInTitle = '{} at z={} m'.format(fieldNameInTitle,
-                                                          depth)
-            self.thumbnailDescription = '{} z={} m'.format(season, depth)
+            self.fieldNameInTitle = f'{fieldNameInTitle} at z={depth} m'
+            self.thumbnailDescription = f'{season} z={depth} m'
 
     def setup_and_check(self):
         """
@@ -344,13 +343,13 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         prefixPieces.append(mainRunName)
         if self.depth is not None:
             prefixPieces.append(self.depthSuffix)
-        years = 'years{:04d}-{:04d}'.format(self.startYear, self.endYear)
+        years = f'years{self.startYear:04d}-{self.endYear:04d}'
         prefixPieces.extend([self.season, years])
 
         self.filePrefix = '_'.join(prefixPieces)
 
-        self.xmlFileNames.append('{}/{}.xml'.format(self.plotsDirectory,
-                                                    self.filePrefix))
+        self.xmlFileNames.append(
+            f'{self.plotsDirectory}/{self.filePrefix}.xml')
 
     def run_task(self):
         """
@@ -364,9 +363,9 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         season = self.season
         depth = self.depth
         comparisonGridName = self.comparisonGridName
-        self.logger.info("\nPlotting 2-d maps of {} climatologies for {} on "
-                         "the {} grid...".format(self.fieldNameInTitle,
-                                                 season, comparisonGridName))
+        self.logger.info(
+            f"\nPlotting 2-d maps of {self.fieldNameInTitle} climatologies "
+            f"for {season} on the {comparisonGridName} grid...")
 
         # first read the model climatology
         remappedFileName = \
@@ -377,10 +376,10 @@ class PlotClimatologyMapSubtask(AnalysisTask):
 
         if depth is not None:
             if str(depth) not in remappedModelClimatology.depthSlice.values:
-                raise KeyError('The climatology you are attempting to perform '
-                               'depth slices of was originally created '
-                               'without depth {}. You will need to delete and '
-                               'regenerate the climatology'.format(depth))
+                raise KeyError(f'The climatology you are attempting to '
+                               f'perform depth slices of was originally '
+                               f'created without depth {depth}. You will need '
+                               f'to delete and regenerate the climatology')
 
             remappedModelClimatology = remappedModelClimatology.sel(
                 depthSlice=str(depth), drop=True)
@@ -413,8 +412,9 @@ class PlotClimatologyMapSubtask(AnalysisTask):
                                                        'endYear')
             if controlStartYear != self.startYear or \
                     controlEndYear != self.endYear:
-                self.refTitleLabel = '{}\n(years {:04d}-{:04d})'.format(
-                    self.refTitleLabel, controlStartYear, controlEndYear)
+                self.refTitleLabel = \
+                    f'{self.refTitleLabel}\n' \
+                    f'(years {controlStartYear:04d}-{controlEndYear:04d})'
 
         else:
             remappedRefClimatology = None
@@ -430,10 +430,10 @@ class PlotClimatologyMapSubtask(AnalysisTask):
                 if depthSlice == str(depth):
                     depthIndex = index
             if depthIndex == -1:
-                raise KeyError('The climatology you are attempting to perform '
-                               'depth slices of was originally created '
-                               'without depth {}. You will need to delete and '
-                               'regenerate the climatology'.format(depth))
+                raise KeyError(f'The climatology you are attempting to '
+                               f'perform depth slices of was originally '
+                               f'created without depth {depth}. You will need '
+                               f'to delete and regenerate the climatology')
 
             remappedRefClimatology = remappedRefClimatology.isel(
                 depthSlice=depthIndex, drop=True)
@@ -500,10 +500,9 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             defaultFontSize = None
 
         filePrefix = self.filePrefix
-        outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
-        title = '{} ({}, years {:04d}-{:04d})'.format(
-                self.fieldNameInTitle, season, self.startYear,
-                self.endYear)
+        outFileName = f'{self.plotsDirectory}/{filePrefix}.png'
+        title = f'{self.fieldNameInTitle} ({season}, years ' \
+                f'{self.startYear:04d}-{self.endYear:04d})'
         plot_global_comparison(config,
                                lonTarg,
                                latTarg,
@@ -513,22 +512,22 @@ class PlotClimatologyMapSubtask(AnalysisTask):
                                configSectionName,
                                fileout=outFileName,
                                title=title,
-                               modelTitle='{}'.format(mainRunName),
+                               modelTitle=mainRunName,
                                refTitle=self.refTitleLabel,
                                diffTitle=self.diffTitleLabel,
                                cbarlabel=self.unitsLabel,
                                titleFontSize=titleFontSize,
                                defaultFontSize=defaultFontSize)
 
-        caption = '{} {}'.format(season, self.imageCaption)
+        caption = f'{season} {self.imageCaption}'
         write_image_xml(
             config,
             filePrefix,
             componentName='Ocean',
             componentSubdirectory='ocean',
-            galleryGroup='Global {}'.format(self.galleryGroup),
+            galleryGroup=f'Global {self.galleryGroup}',
             groupSubtitle=self.groupSubtitle,
-            groupLink='global_{}'.format(self.groupLink),
+            groupLink=f'global_{self.groupLink}',
             gallery=self.galleryName,
             thumbnailDescription=self.thumbnailDescription,
             imageDescription=caption,
@@ -574,10 +573,9 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         vertical = aspectRatio > 1.2
 
         filePrefix = self.filePrefix
-        outFileName = '{}/{}.png'.format(self.plotsDirectory, filePrefix)
-        title = '{} ({}, years {:04d}-{:04d})'.format(
-                self.fieldNameInTitle, season, self.startYear,
-                self.endYear)
+        outFileName = f'{self.plotsDirectory}/{filePrefix}.png'
+        title = f'{self.fieldNameInTitle} ({season}, years ' \
+                f'{self.startYear:04d}-{self.endYear:04d})'
 
         if config.has_option(configSectionName, 'titleFontSize'):
             titleFontSize = config.getint(configSectionName, 'titleFontSize')
@@ -608,7 +606,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             colorMapSectionName=configSectionName,
             projectionName=comparisonGridName,
             title=title,
-            modelTitle='{}'.format(mainRunName),
+            modelTitle=mainRunName,
             refTitle=self.refTitleLabel,
             diffTitle=self.diffTitleLabel,
             cbarlabel=self.unitsLabel,
@@ -624,10 +622,9 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             filePrefix,
             componentName='Ocean',
             componentSubdirectory='ocean',
-            galleryGroup='{} {}'.format(upperGridName,
-                                        self.galleryGroup),
+            galleryGroup=f'{upperGridName} {self.galleryGroup}',
             groupSubtitle=self.groupSubtitle,
-            groupLink='{}_{}'.format(comparisonGridName, self.groupLink),
+            groupLink=f'{comparisonGridName}_{self.groupLink}',
             gallery=self.galleryName,
             thumbnailDescription=self.thumbnailDescription,
             imageDescription=caption,

--- a/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
+++ b/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
@@ -18,7 +18,8 @@ observations.
 
 import xarray as xr
 import numpy as np
-import string
+from string import capwords
+
 from mpas_analysis.shared import AnalysisTask
 
 from mpas_analysis.shared.plot import plot_global_comparison, \
@@ -30,8 +31,6 @@ from mpas_analysis.shared.climatology import \
     get_remapped_mpas_climatology_file_name
 from mpas_analysis.shared.climatology.comparison_descriptors import \
     get_comparison_descriptor
-
-from mpas_analysis.ocean.utility import nans_to_numpy_mask
 
 
 class PlotClimatologyMapSubtask(AnalysisTask):
@@ -141,7 +140,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             A second subtask for remapping another MPAS climatology to plot
             in the second panel and compare with in the third panel
 
-        controlconfig : mpas_tools.config.MpasConfigParser, optional
+        controlConfig : mpas_tools.config.MpasConfigParser, optional
             Configuration options for a control run (if any)
 
         depth : {float, 'top', 'bot'}, optional
@@ -452,7 +451,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):
 
         mainRunName = config.get('runs', 'mainRunName')
 
-        modelOutput = nans_to_numpy_mask(
+        modelOutput = _nans_to_numpy_mask(
             remappedModelClimatology[self.mpasFieldName].values)
 
         lon = remappedModelClimatology['lon'].values
@@ -464,7 +463,7 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             refOutput = None
             bias = None
         else:
-            refOutput = nans_to_numpy_mask(
+            refOutput = _nans_to_numpy_mask(
                 remappedRefClimatology[self.refFieldName].values)
 
             bias = modelOutput - refOutput
@@ -531,14 +530,14 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             np.ones(oceanMask.shape),
             mask=np.logical_not(np.isnan(oceanMask)))
 
-        modelOutput = nans_to_numpy_mask(
+        modelOutput = _nans_to_numpy_mask(
             remappedModelClimatology[self.mpasFieldName].values)
 
         if remappedRefClimatology is None:
             refOutput = None
             bias = None
         else:
-            refOutput = nans_to_numpy_mask(
+            refOutput = _nans_to_numpy_mask(
                 remappedRefClimatology[self.refFieldName].values)
 
             bias = modelOutput - refOutput
@@ -598,8 +597,8 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             defaultFontSize=defaultFontSize,
             vertical=vertical)
 
-        upperGridName = string.capwords(comparisonGridName.replace('_', ' '))
-        caption = '{} {}'.format(season, self.imageCaption)
+        upperGridName = capwords(comparisonGridName.replace('_', ' '))
+        caption = f'{season} {self.imageCaption}'
         write_image_xml(
             config,
             filePrefix,
@@ -613,3 +612,12 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             thumbnailDescription=self.thumbnailDescription,
             imageDescription=caption,
             imageCaption=caption)
+
+
+def _nans_to_numpy_mask(field):
+    """
+    Convert a numpy array with NaNs to a masked numpy array
+    """
+    field = np.ma.masked_array(
+        field, np.isnan(field))
+    return field

--- a/mpas_analysis/shared/plot/time_series.py
+++ b/mpas_analysis/shared/plot/time_series.py
@@ -38,7 +38,7 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
                              firstYearXTicks=None, yearStrideXTicks=None,
                              maxXTicks=20, obsMean=None, obsUncertainty=None,
                              obsLegend=None, legendLocation='lower left',
-                             maxTitleLength=90):
+                             maxTitleLength=None):
     """
     Plots the list of time series data sets.
 
@@ -113,9 +113,10 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
     legendLocation : str, optional
         The location of the legend (see ``pyplot.legend()`` for details)
 
-    maxTitleLength : int, optional
-        the maximum number of characters in the title and legend, beyond which
-        they are truncated with a trailing ellipsis
+    maxTitleLength : int or None, optional
+        the maximum number of characters in the title, beyond which it is
+        truncated with a trailing ellipsis.  The default is from the
+        ``maxTitleLength`` config option.
 
     Returns
     -------
@@ -125,6 +126,9 @@ def timeseries_analysis_plot(config, dsvalues, calendar, title, xlabel, ylabel,
     # Authors
     # -------
     # Xylar Asay-Davis, Milena Veneziani, Stephen Price
+
+    if maxTitleLength is None:
+        maxTitleLength = config.getint('plot', 'maxTitleLength')
 
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')
@@ -260,7 +264,7 @@ def timeseries_analysis_plot_polar(config, dsvalues, title,
                                    lineWidths=None, legendText=None,
                                    titleFontSize=None, defaultFontSize=None,
                                    figsize=(15, 6), dpi=None,
-                                   maxTitleLength=90):
+                                   maxTitleLength=None):
     """
     Plots the list of time series data sets on a polar plot.
 
@@ -299,9 +303,10 @@ def timeseries_analysis_plot_polar(config, dsvalues, title,
         the number of dots per inch of the figure, taken from section ``plot``
         option ``dpi`` in the config file by default
 
-    maxTitleLength : int, optional
-        the maximum number of characters in the title and legend, beyond which
-        they are truncated with a trailing ellipsis
+    maxTitleLength : int or None, optional
+        the maximum number of characters in the title, beyond which it is
+        truncated with a trailing ellipsis.  The default is from the
+        ``maxTitleLength`` config option.
 
     Returns
     -------
@@ -311,6 +316,9 @@ def timeseries_analysis_plot_polar(config, dsvalues, title,
     # Authors
     # -------
     # Adrian K. Turner, Xylar Asay-Davis
+
+    if maxTitleLength is None:
+        maxTitleLength = config.getint('plot', 'maxTitleLength')
 
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -84,7 +84,7 @@ def plot_vertical_section_comparison(
         contourLabelPrecision=1,
         resultSuffix='Result',
         diffSuffix='Difference',
-        maxTitleLength=70):
+        maxTitleLength=None):
     """
     Plots vertical section plots in a three-panel format, comparing model data
     (in modelArray) to some reference dataset (in refArray), which can be
@@ -300,9 +300,10 @@ def plot_vertical_section_comparison(
         a suffix added to the config options related to colormap information
         for the difference field
 
-    maxTitleLength : int, optional
+    maxTitleLength : int or None, optional
         the maximum number of characters in the title, beyond which it is
-        truncated with a trailing ellipsis
+        truncated with a trailing ellipsis.  The default is from the
+        ``maxTitleLength`` config option.
 
     Returns
     -------
@@ -318,6 +319,9 @@ def plot_vertical_section_comparison(
     # Authors
     # -------
     # Greg Streletz, Xylar Asay-Davis, Milena Veneziani
+
+    if maxTitleLength is None:
+        maxTitleLength = config.getint('plot', 'maxTitleLength')
 
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')
@@ -594,7 +598,7 @@ def plot_vertical_section(
         comparisonContourLineColor=None,
         labelContours=False,
         contourLabelPrecision=1,
-        maxTitleLength=70):
+        maxTitleLength=None):
     """
     Plots a data set as a x distance (latitude, longitude,
     or spherical distance) vs depth map (vertical section).
@@ -812,9 +816,10 @@ def plot_vertical_section(
         the precision (in terms of number of figures to the right of the
         decimal point) of contour labels
 
-    maxTitleLength : int, optional
+    maxTitleLength : int or None, optional
         the maximum number of characters in the title, beyond which it is
-        truncated with a trailing ellipsis
+        truncated with a trailing ellipsis.  The default is from the
+        ``maxTitleLength`` config option.
 
     Returns
     -------
@@ -827,6 +832,9 @@ def plot_vertical_section(
     # Authors
     # -------
     # Milena Veneziani, Mark Petersen, Xylar Asay-Davis, Greg Streletz
+
+    if maxTitleLength is None:
+        maxTitleLength = config.getint('plot', 'maxTitleLength')
 
     if defaultFontSize is None:
         defaultFontSize = config.getint('plot', 'defaultFontSize')

--- a/mpas_analysis/shared/projection/__init__.py
+++ b/mpas_analysis/shared/projection/__init__.py
@@ -13,7 +13,8 @@ import pyproj
 import cartopy
 
 
-known_comparison_grids = ['latlon', 'antarctic', 'arctic', 'north_atlantic',
+known_comparison_grids = ['latlon', 'antarctic', 'antarctic_extended',
+                          'arctic', 'arctic_extended', 'north_atlantic',
                           'north_pacific', 'subpolar_north_atlantic']
 
 
@@ -23,7 +24,8 @@ def get_pyproj_projection(comparison_grid_name):
 
     Parameters
     ----------
-    comparison_grid_name : {'antarctic', 'arctic', 'north_atlantic',
+    comparison_grid_name : {'antarctic', 'arctic', 'antarctic_extended',
+                            'arctic_extended', 'north_atlantic',
                             'north_pacific', 'subpolar_north_atlantic'}
         The name of the projection comparison grid to use for remapping
 
@@ -49,11 +51,11 @@ def get_pyproj_projection(comparison_grid_name):
 
     if comparison_grid_name == 'latlon':
         raise ValueError('latlon is not a projection grid.')
-    elif comparison_grid_name == 'antarctic':
+    elif comparison_grid_name in ['antarctic', 'antarctic_extended']:
         projection = pyproj.Proj(
             '+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0  +k_0=1.0 '
             '+x_0=0.0 +y_0=0.0 +ellps=WGS84')
-    elif comparison_grid_name == 'arctic':
+    elif comparison_grid_name in ['arctic', 'arctic_extended']:
         projection = pyproj.Proj(
             '+proj=stere +lat_ts=75.0 +lat_0=90 +lon_0=0.0  +k_0=1.0 '
             '+x_0=0.0 +y_0=0.0 +ellps=WGS84')
@@ -79,7 +81,8 @@ def get_cartopy_projection(comparison_grid_name):
 
     Parameters
     ----------
-    comparison_grid_name : {'antarctic', 'arctic', 'north_atlantic',
+    comparison_grid_name : {'antarctic', 'arctic', 'antarctic_extended',
+                            'arctic_extended', 'north_atlantic',
                             'north_pacific', 'subpolar_north_atlantic'}
         The name of the projection comparison grid to use for remapping
 
@@ -106,11 +109,11 @@ def get_cartopy_projection(comparison_grid_name):
     if comparison_grid_name == 'latlon':
         raise ValueError('latlon is not a projection grid.')
 
-    elif comparison_grid_name == 'antarctic':
+    elif comparison_grid_name in ['antarctic', 'antarctic_extended']:
         projection = cartopy.crs.Stereographic(
             central_latitude=-90., central_longitude=0.0,
             true_scale_latitude=-71.0)
-    elif comparison_grid_name == 'arctic':
+    elif comparison_grid_name in ['arctic', 'arctic_extended']:
         projection = cartopy.crs.Stereographic(
             central_latitude=90., central_longitude=0.0,
             true_scale_latitude=75.0)


### PR DESCRIPTION
This merge moves the class `PlotClimatologyMapSubtask` to the shared infrastructure and generalizes it to handle both ocean and sea-ice climatology plots.

Then, it changes all existing ocean and sea-ice climatology-map tasks to use this shared task.  The version of `PlotClimatologyMapSubtask` in `sea_ice` is retained because sea-ice tasks in development still need to use it.