### PR TITLE
Fix comparison of sea-ice thickness vs. control

### DIFF
--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -149,7 +149,8 @@ class ClimatologyMapSeaIceThick(AnalysisTask):
                     comparisonGridName=comparisonGridName,
                     remapMpasClimatologySubtask=remapClimatologySubtask,
                     remapObsClimatologySubtask=remapObservationsSubtask,
-                    subtaskName=subtaskName)
+                    subtaskName=subtaskName,
+                    controlConfig=controlConfig)
 
                 subtask.set_plot_info(
                     outFileLabel=f'icethick{hemisphere}',


### PR DESCRIPTION
This merge adds back the `controlConfig` argument to the subtask for plotting sea-ice thickness climatologies so the comparison with a control run gets plotted.