### PR TITLE
Fix complete config file name in log dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # User defined config files
 /config.*
-!/config.default
+/*.cfg
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ for more details.
 
 ## Running the analysis
 
-  1. Create and empty config file (say `config.myrun`), copy `config.example`,
+  1. Create and empty config file (say `myrun.cfg`), copy `example.cfg`,
      or copy one of the example files in the `configs` directory (if using a
      git repo) or download one from the
      [example configs directory](https://github.com/MPAS-Dev/MPAS-Analysis/tree/develop/configs).
@@ -125,9 +125,9 @@ for more details.
      from GitHub:
      [default.cfg](https://github.com/MPAS-Dev/MPAS-Analysis/tree/develop/mpas_analysis/default.cfg).
   3. If you installed the `mpas-analysis` package, run:
-     `mpas_analysis config.myrun`.  This will read the configuration
+     `mpas_analysis myrun.cfg`.  This will read the configuration
      first from `mpas_analysis/default.cfg` and then replace that
-     configuraiton with any changes from from `config.myrun`
+     configuraiton with any changes from from `myrun.cfg`
   4. If you want to run a subset of the analysis, you can either set the
      `generate` option under `[output]` in your config file or use the
      `--generate` flag on the command line.  See the comments in

--- a/docs/users_guide/config/output.rst
+++ b/docs/users_guide/config/output.rst
@@ -151,10 +151,10 @@ Finally, we note that the ``generate`` option in the configuration file can
 be overridden by specifying the ``--generate`` option on the command line::
 
   mpas_analysis --generate=all_publicObs,no_index,no_climatologyMapSST \
-      config.my_run
+      my_run.cfg
 
 This example would override whatever ``generate`` option was specified in
-``config.my_run`` with a directive to generate only tasks that support the
+``my_run.cfg`` with a directive to generate only tasks that support the
 publicly available observations, skipping those using climate indices (e.g.
 El Ni |n~| o 3.4) and also skipping ``climatologyMapSST``.
 

--- a/docs/users_guide/config/runs.rst
+++ b/docs/users_guide/config/runs.rst
@@ -71,7 +71,7 @@ Once the analysis has been run on the control run, a comparison is made by
 uncommenting ``controlRunConfigFile`` and specifying the path to the
 configuration file use in this analysis, e.g.::
 
-  controlRunConfigFile = config.control_run
+  controlRunConfigFile = control_run.cfg
 
 If analysis has already been run on the "main" run in a "main vs ref"
 comparison, some time can be saved in performing the comparison
@@ -101,6 +101,6 @@ Specify the path to the configuration file use in "main" analysis by
 uncommenting the option and providing a relative or absolute path to the
 config file::
 
-  mainRunConfigFile = config.main_run
+  mainRunConfigFile = main_run.cfg
 
 

--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -525,7 +525,7 @@ def run_analysis(config, analyses):
         print('Warning: The main run name is quite long and will be '
               'truncated in some plots: \n{}\n\n'.format(mainRunName))
 
-    configFileName = '{}/config.{}'.format(logsDirectory, mainRunName)
+    configFileName = '{}/complete.{}.cfg'.format(logsDirectory, mainRunName)
 
     configFile = open(configFileName, 'w')
     config.write(configFile)


### PR DESCRIPTION
This merge also fixes some cases in which example config files are referred to in the old way (`config.*`) instead of the new way (`*.cfg`).