### PR TITLE
Disable latest conda in CI (for now)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,7 @@ jobs:
       eval "$(conda shell.bash hook)"
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-      conda install --yes conda conda-build mamba boa
-      conda update --all --yes
+      conda install --yes "conda<22.11.0" conda-build mamba boa
     displayName: Update conda base environment
 
   - bash: |
@@ -159,8 +158,7 @@ jobs:
       eval "$(conda shell.bash hook)"
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-      conda install --yes python=$PYTHON_VERSION conda conda-build mamba boa
-      conda update --all --yes
+      conda install --yes python=$PYTHON_VERSION "conda<22.11.0" conda-build mamba boa
     displayName: Update conda base environment
 
   - bash: |
@@ -215,8 +213,7 @@ jobs:
       eval "$(conda shell.bash hook)"
       conda config --add channels conda-forge
       conda config --set channel_priority strict
-      conda install --yes conda conda-build mamba boa
-      conda update --all --yes
+      conda install --yes "conda<22.11.0" conda-build mamba boa
     displayName: Update conda base environment
 
   - bash: |


### PR DESCRIPTION
We're seeing weird errors in python 3.11 with it:
```
Encountered problems while solving:
  - nothing provides __win needed by pysocks-1.7.1-pyh0701188_6

```