### PR TITLE
Update suite to python 3.11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -74,7 +74,7 @@ jobs:
       conda activate
       mamba create --yes --quiet --name docs -c ${CONDA_PREFIX}/conda-bld/ \
           python=$PYTHON_VERSION mpas-analysis sphinx mock sphinx_rtd_theme \
-          tabulate m2r2 "mistune<2"
+          tabulate "m2r2>=0.3.3" "mistune<2"
     condition: eq(variables['python.version'], '3.10')
     displayName: Create Anaconda docs environment
 

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -40,7 +40,7 @@ pytest
 
 # Documentation
 mock
-m2r2
+m2r2>=0.3.3
 mistune<2
 sphinx
 sphinx_rtd_theme

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -557,7 +557,7 @@ class PlotMeltSubtask(AnalysisTask):
             obsFileName = '{}/{}'.format(observationsDirectory,
                                          obsFileNameDict[obsName])
             obsDict[obsName] = {}
-            obsFile = csv.reader(open(obsFileName, 'rU'))
+            obsFile = csv.reader(open(obsFileName, 'r'))
             next(obsFile, None)  # skip the header line
             for line in obsFile:  # some later useful values commented out
                 shelfName = line[0]

--- a/suite/main_vs_ctrl.cfg
+++ b/suite/main_vs_ctrl.cfg
@@ -12,5 +12,5 @@ controlRunConfigFile = ../ctrl.cfg
 # remapped to the comparison grid and time series have been extracted.
 # Leave this option commented out if the analysis for the main run should be
 # performed.
-mainRunConfigFile = ../main_py3.9.cfg
+mainRunConfigFile = ../main_py3.10.cfg
 

--- a/suite/run_suite.bash
+++ b/suite/run_suite.bash
@@ -5,8 +5,8 @@ set -e
 conda_base=$(dirname $(dirname $CONDA_EXE))
 source $conda_base/etc/profile.d/conda.sh
 
-main_py=3.10
-alt_py=3.9
+main_py=3.11
+alt_py=3.10
 
 export HDF5_USE_FILE_LOCKING=FALSE
 

--- a/suite/run_suite.bash
+++ b/suite/run_suite.bash
@@ -20,8 +20,8 @@ for py in ${main_py} ${alt_py}
 do
     env=test_mpas_analysis_py${py}
     mamba create -y -n ${env} --use-local python=${py} mpas-analysis sphinx \
-        mock sphinx_rtd_theme "tabulate>=0.8.2" m2r2 "mistune<2" pytest \
-	      "esmf=*=nompi_*" jinja2
+        mock sphinx_rtd_theme "tabulate>=0.8.2" "m2r2>=0.3.3" "mistune<2" \
+        pytest "mache>=1.11.0" "esmf=*=nompi_*" jinja2
     conda activate ${env}
     pytest
     conda deactivate


### PR DESCRIPTION
This merge also updates `m2r2 >=0.3.3`, which is necessary for python 3.11 to work.