### PR TITLE
Fix depth slicing with non-ocean cells

### DIFF
--- a/mpas_analysis/ocean/remap_depth_slices_subtask.py
+++ b/mpas_analysis/ocean/remap_depth_slices_subtask.py
@@ -116,6 +116,7 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):
 
         zMid = compute_zmid(ds.bottomDepth, ds.maxLevelCell-1,
                             ds.layerThickness)
+        ocean_mask = (ds.maxLevelCell > 0)
 
         nVertLevels = zMid.shape[1]
         zMid.coords['verticalIndex'] = \
@@ -144,10 +145,12 @@ class RemapDepthSlicesSubtask(RemapMpasClimatologySubtask):
                 verticalIndices[depthIndex, :] = self.maxLevelCell.values
                 mask[depthIndex, :] = self.maxLevelCell.values >= 0
             else:
+                
+                diff = np.abs(zMid - depth).where(ocean_mask, drop=True)
+                verticalIndex = diff.argmin(dim='nVertLevels')
 
-                verticalIndex = np.abs(zMid - depth).argmin(dim='nVertLevels')
-
-                verticalIndices[depthIndex, :] = verticalIndex.values
+                verticalIndices[depthIndex, ocean_mask.values] = \
+                    verticalIndex.values
                 mask[depthIndex, :] = np.logical_and(depth <= zTop,
                                                      depth >= zBot).values
 

--- a/mpas_analysis/shared/plot/vertical_section.py
+++ b/mpas_analysis/shared/plot/vertical_section.py
@@ -875,11 +875,11 @@ def plot_vertical_section(
         if movingAveragePoints is not None and movingAveragePoints != 1:
             dim = field.dims[0]
             field = field.rolling(dim={dim: movingAveragePoints},
-                                  center=True).mean().dropna(dim)
+                                  center=True).mean().dropna(dim, how='all')
             x = x.rolling(dim={dim: movingAveragePoints},
-                          center=True).mean().dropna(dim)
+                          center=True).mean().dropna(dim, how='all')
             y = y.rolling(dim={dim: movingAveragePoints},
-                          center=True).mean().dropna(dim)
+                          center=True).mean().dropna(dim, how='all')
 
         mask = field.notnull()
         maskedTriangulation, unmaskedTriangulation = _get_triangulation(

--- a/mpas_analysis/shared/time_series/moving_average.py
+++ b/mpas_analysis/shared/time_series/moving_average.py
@@ -35,7 +35,7 @@ def compute_moving_avg(ds, movingAveragePoints=12):
     # Xylar Asay-Davis
 
     ds = ds.rolling(Time=movingAveragePoints,
-                    center=True).mean().dropna('Time')
+                    center=True).mean().dropna(dim='Time', how='all')
 
     return ds
 


### PR DESCRIPTION
Previously, when there were cells with `maxLevelCell = 0`, this caused a failure because there was no valid depth coordinate for that cell and therefore no closest depth index could be found.

This fix simply skips cells that are not in the ocean and masks them out.

This merge also fixes an issue with rolling averages that was discovered in the same run.  Rolling averages should drop `NaN` values only if all values at a given time point are `NaN`, not if *any* are (the default behavior).  This was presumably not noticed previously because we performed rolling averages on fields without any `NaN` values.