### PR TITLE
Skip making MOC basin masks if they exist

### DIFF
--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -183,13 +183,13 @@ class ComputeMOCMasksSubtask(ComputeRegionMasksSubtask):
         # -------
         # Xylar Asay-Davis
 
+        if os.path.exists(self.maskAndTransectFileName):
+            return
+
         # call ComputeRegionMasksSubtask.run_task() first
         super().run_task()
 
         config = self.config
-
-        if os.path.exists(self.maskAndTransectFileName):
-            return
 
         dsMesh = xr.open_dataset(self.obsFileName)
         dsMask = xr.open_dataset(self.maskFileName)


### PR DESCRIPTION
Before this merge, we were needlessly computing the MOC basin masks when we use the post-processed MOC calculation, even if the basin masks and transects were already computed.  This change makes sure the mask creation gets skipped when it should.