### PR TITLE
Various fixes to get the `no_ncclimo` test working again

### DIFF
--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -19,7 +19,7 @@ from mpas_analysis.shared import AnalysisTask
 
 from mpas_analysis.shared.io.utility import build_obs_path, decode_strings, \
     build_config_full_path
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
     RemapObservedClimatologySubtask
@@ -463,7 +463,7 @@ class AntarcticMeltTableSubtask(AnalysisTask):
 
                 ds['regionNames'] = dsRegionMask.regionNames
 
-                write_netcdf(ds, meltRateFileName)
+                write_netcdf_with_fill(ds, meltRateFileName)
         else:
             ds = xr.open_dataset(meltRateFileName)
 

--- a/mpas_analysis/ocean/compute_anomaly_subtask.py
+++ b/mpas_analysis/ocean/compute_anomaly_subtask.py
@@ -15,7 +15,7 @@ import os
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 from mpas_analysis.shared.timekeeping.utility import \
     get_simulation_start_time, string_to_datetime
@@ -192,4 +192,4 @@ class ComputeAnomalySubtask(AnalysisTask):
             outFileName = '{}/{}'.format(baseDirectory,
                                          outFileName)
 
-        write_netcdf(ds, outFileName)
+        write_netcdf_with_fill(ds, outFileName)

--- a/mpas_analysis/ocean/compute_transects_subtask.py
+++ b/mpas_analysis/ocean/compute_transects_subtask.py
@@ -29,7 +29,7 @@ from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask, \
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 from mpas_analysis.ocean.utility import compute_zmid
 
@@ -419,10 +419,10 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):
             dsObs = interp_1d(dsObs, inInterpDim='nz', inInterpCoord='z',
                               outInterpDim='nzOut', outInterpCoord='zOut')
             dsObs = dsObs.rename({'nzOut': 'nz'})
-            write_netcdf(dsObs, outObsFileName)
+            write_netcdf_with_fill(dsObs, outObsFileName)
 
         ds = ds.drop_vars(['validMask', 'transectNumber'])
-        write_netcdf(ds, outFileName)
+        write_netcdf_with_fill(ds, outFileName)
 
     def get_mpas_transect_file_name(self, transectName):
         """Get the file name for a masked MPAS transect info"""
@@ -511,9 +511,9 @@ class ComputeTransectsSubtask(RemapMpasClimatologySubtask):
                         dim='nHorizWeights')
                     dsMpasTransect['landIceFraction'] = landIceFraction
 
-                # use to_netcdf rather than write_netcdf because integer indices
-                # are getting converted to floats when xarray reads them back
-                # because of _FillValue
+                # use to_netcdf rather than write_netcdf_with_fill because
+                # integer indices are getting converted to floats when xarray
+                # reads them back because of _FillValue
                 dsMpasTransect.to_netcdf(transectInfoFileName)
 
                 dsTransectOnMpas = xr.Dataset(dsMpasTransect)
@@ -666,7 +666,7 @@ class TransectsObservations(object):
                     dsObs.coords[coord] = dsObs[coord]
 
                 dsObs = self._add_distance(dsObs)
-                write_netcdf(dsObs, outFileName)
+                write_netcdf_with_fill(dsObs, outFileName)
             obsDatasets[name] = dsObs
 
         return obsDatasets

--- a/mpas_analysis/ocean/histogram.py
+++ b/mpas_analysis/ocean/histogram.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 
 from mpas_analysis.shared import AnalysisTask
 
-from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
+from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf_with_fill
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     build_obs_path, make_directories, decode_strings
 from mpas_analysis.shared.climatology import compute_climatology, \
@@ -256,7 +256,7 @@ class ComputeHistogramWeightsSubtask(AnalysisTask):
         # referenced by future analysis (i.e., as a control run)
         new_region_mask_filename = \
             f'{base_directory}/{self.filePrefix}_{self.regionName}_mask.nc'
-        write_netcdf(ds_mask, new_region_mask_filename)
+        write_netcdf_with_fill(ds_mask, new_region_mask_filename)
 
         if self.weightList is not None:
             ds_weights = xarray.Dataset()
@@ -273,7 +273,7 @@ class ComputeHistogramWeightsSubtask(AnalysisTask):
 
         weights_filename = \
             f'{base_directory}/{self.filePrefix}_{self.regionName}_weights.nc'
-        write_netcdf(ds_weights, weights_filename)
+        write_netcdf_with_fill(ds_weights, weights_filename)
 
 
 class PlotRegionHistogramSubtask(AnalysisTask):

--- a/mpas_analysis/ocean/hovmoller_ocean_regions.py
+++ b/mpas_analysis/ocean/hovmoller_ocean_regions.py
@@ -17,7 +17,7 @@ import xarray
 from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.ocean.plot_hovmoller_subtask import PlotHovmollerSubtask
 
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 from mpas_analysis.shared.timekeeping.utility import \
     get_simulation_start_time, string_to_datetime
@@ -308,4 +308,4 @@ class ComputeHovmollerAnomalySubtask(AnalysisTask):
             outFileName = '{}/{}'.format(baseDirectory,
                                          outFileName)
 
-        write_netcdf(ds, outFileName)
+        write_netcdf_with_fill(ds, outFileName)

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -16,7 +16,7 @@ import os
 from mpas_analysis.shared.plot import plot_vertical_section, plot_1D, savefig
 
 from mpas_analysis.shared.io.utility import make_directories, build_obs_path
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.shared.html import write_image_xml
@@ -264,7 +264,7 @@ class MeridionalHeatTransport(AnalysisTask):
                 annualClimatology['meridionalHeatTransportLatZ'] /= \
                     refLayerThickness
 
-            write_netcdf(annualClimatology, outFileName)
+            write_netcdf_with_fill(annualClimatology, outFileName)
 
         # **** Plot MHT ****
         maxTitleLength = 70

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -21,7 +21,7 @@ from geometric_features import FeatureCollection, read_feature_collection
 from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     get_files_year_month, make_directories, decode_strings
-from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
+from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf_with_fill
 from mpas_analysis.shared.timekeeping.utility import days_to_datetime
 from mpas_analysis.shared.climatology import compute_climatology
 from mpas_analysis.shared.constants import constants
@@ -419,7 +419,7 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):
         dsOut.coords['z'] = (('nVertLevels',), z)
         dsOut['z'].attrs['units'] = 'meters'
 
-        write_netcdf(dsOut, outputFileName)
+        write_netcdf_with_fill(dsOut, outputFileName)
 
     @staticmethod
     def _masked_area_sum(cellMasks, areaCell, var):
@@ -529,7 +529,7 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):
 
             ds['totalArea'] = ds['totalArea'].isel(Time=0)
 
-            write_netcdf(ds, outputFileName)
+            write_netcdf_with_fill(ds, outputFileName)
 
         regionNames = ds['regionNames']
         ds = ds.drop_vars('regionNames')
@@ -567,7 +567,7 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):
                     dsSeason['{}_mean'.format(prefix)] = mean
 
                 dsSeason.coords['regionNames'] = regionNames
-                write_netcdf(dsSeason, outputFileName)
+                write_netcdf_with_fill(dsSeason, outputFileName)
 
 
 class PlotRegionalProfileTimeSeriesSubtask(AnalysisTask):

--- a/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
+++ b/mpas_analysis/ocean/plot_depth_integrated_time_series_subtask.py
@@ -18,7 +18,7 @@ from mpas_analysis.shared import AnalysisTask
 
 from mpas_analysis.shared.plot import timeseries_analysis_plot, savefig
 
-from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
+from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf_with_fill
 
 from mpas_analysis.shared.timekeeping.utility import date_to_days, \
     days_to_datetime
@@ -378,7 +378,7 @@ class PlotDepthIntegratedTimeSeriesSubtask(AnalysisTask):
             # write out the data set and read it back as a single-file data set
             # (without dask)
             dsPreprocessed = dsPreprocessed.drop_vars('xtime')
-            write_netcdf(dsPreprocessed, self.preprocessedFileName)
+            write_netcdf_with_fill(dsPreprocessed, self.preprocessedFileName)
             dsPreprocessed = xarray.open_dataset(self.preprocessedFileName)
 
         if preprocessedReferenceRunName != 'None':

--- a/mpas_analysis/ocean/regional_ts_diagrams.py
+++ b/mpas_analysis/ocean/regional_ts_diagrams.py
@@ -28,7 +28,7 @@ from mpas_analysis.shared.analysis_task import AnalysisTask
 
 from mpas_analysis.shared.plot import savefig, add_inset
 
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 from mpas_analysis.shared.io.utility import decode_strings, \
     build_obs_path, build_config_full_path, make_directories
@@ -387,7 +387,7 @@ class ComputeObsTSClimatology(AnalysisTask):
             self.logger.info('  computing the dataset')
             ds.compute()
             self.logger.info('  writing temp file {}...'.format(temp_file_name))
-            write_netcdf(ds, temp_file_name)
+            write_netcdf_with_fill(ds, temp_file_name)
 
             chunk = {obsDict['latVar']: 400,
                      obsDict['lonVar']: 400}
@@ -414,7 +414,7 @@ class ComputeObsTSClimatology(AnalysisTask):
             self.logger.info('  computing the dataset')
             ds.compute()
             self.logger.info('  writing temp file {}...'.format(temp_file_name))
-            write_netcdf(ds, temp_file_name)
+            write_netcdf_with_fill(ds, temp_file_name)
             self.logger.info('  Reading back from {}...'.format(temp_file_name))
             ds = xarray.open_dataset(temp_file_name, chunks=chunk)
 
@@ -434,7 +434,7 @@ class ComputeObsTSClimatology(AnalysisTask):
             self.logger.info('  computing the dataset')
             ds.compute()
             self.logger.info('  writing {}...'.format(self.fileName))
-            write_netcdf(ds, self.fileName)
+            write_netcdf_with_fill(ds, self.fileName)
             for file_name in temp_files:
                 self.logger.info('  Deleting temp file {}'.format(file_name))
                 os.remove(file_name)
@@ -692,7 +692,7 @@ class ComputeRegionTSSubtask(AnalysisTask):
             dsOut['z'] = ('nPoints', zMid)
             dsOut['volume'] = ('nPoints', volume)
             dsOut['zbounds'] = ('nBounds', [zmin, zmax])
-            write_netcdf(dsOut, outFileName)
+            write_netcdf_with_fill(dsOut, outFileName)
 
         return zmin, zmax
 
@@ -784,7 +784,7 @@ class ComputeRegionTSSubtask(AnalysisTask):
             dsOut['z'] = ('nPoints', z)
             dsOut['volume'] = ('nPoints', volume)
             dsOut['zbounds'] = ('nBounds', [zmin, zmax])
-            write_netcdf(dsOut, outFileName)
+            write_netcdf_with_fill(dsOut, outFileName)
 
 
 class PlotRegionTSDiagramSubtask(AnalysisTask):

--- a/mpas_analysis/ocean/sose_transects.py
+++ b/mpas_analysis/ocean/sose_transects.py
@@ -25,7 +25,7 @@ from mpas_analysis.ocean.plot_transect_subtask import PlotTransectSubtask
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories, build_obs_path
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 
 class SoseTransects(AnalysisTask):
@@ -383,7 +383,7 @@ class SoseTransectsObservations(TransectsObservations):
         z = dsObs.z.values
         z[0] = 0.
         dsObs['z'] = ('z', z)
-        write_netcdf(dsObs, combinedFileName)
+        write_netcdf_with_fill(dsObs, combinedFileName)
 
         print('  Done.')
 

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -25,7 +25,7 @@ from mpas_analysis.shared.plot import plot_vertical_section_comparison, \
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories, get_files_year_month, get_region_mask
 
-from mpas_analysis.shared.io import open_mpas_dataset\
+from mpas_analysis.shared.io import open_mpas_dataset
 
 from mpas_analysis.shared.timekeeping.utility import days_to_datetime
 

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -582,8 +582,6 @@ class ComputeMOCClimatologySubtask(AnalysisTask):
                                                 layerThickness,
                                                 cellsOnEdge)
 
-                print(transportZ)
-
             regionCellMask = dictRegion[region]['cellMask']
             latBinSize = \
                 config.getfloat('streamfunctionMOC{}'.format(region),
@@ -598,7 +596,6 @@ class ComputeMOCClimatologySubtask(AnalysisTask):
                                     latBinSize)
             mocTop = _compute_moc(latBins, nVertLevels, latCell,
                                   regionCellMask, transportZ, velArea)
-            print(mocTop)
 
             # Store computed MOC to dictionary
             lat[region] = latBins
@@ -1659,12 +1656,10 @@ def _compute_transport(maxEdgesInTransect, transectEdgeGlobalIDs,
         coe1 = cellsOnEdge[iEdge, 1]
         layerThicknessEdge = 0.5*(layerThickness[coe0, :] +
                                   layerThickness[coe1, :])
-        print(i, layerThicknessEdge)
         transportZEdge[:, i] = horizontalVel[iEdge, :] * \
             transectEdgeMaskSigns[iEdge, np.newaxis] * \
             dvEdge[iEdge, np.newaxis] * \
             layerThicknessEdge[np.newaxis, :]
-        print(transportZEdge[:, i])
     transportZ = np.nansum(transportZEdge, axis=1)
     return transportZ
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -23,7 +23,7 @@ from mpas_analysis.shared.constants import constants
 from mpas_analysis.shared.plot import timeseries_analysis_plot, savefig, \
     add_inset
 
-from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
+from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf_with_fill
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories, build_obs_path, decode_strings
@@ -354,7 +354,7 @@ class ComputeMeltSubtask(AnalysisTask):
         dsOut.meltRates.attrs['description'] = \
             'Melt rate averaged over each ice shelf or region'
 
-        write_netcdf(dsOut, outFileName)
+        write_netcdf_with_fill(dsOut, outFileName)
 
 
 class CombineMeltSubtask(AnalysisTask):
@@ -421,7 +421,7 @@ class CombineMeltSubtask(AnalysisTask):
 
             ds.load()
 
-            write_netcdf(ds, outFileName)
+            write_netcdf_with_fill(ds, outFileName)
 
 
 class PlotMeltSubtask(AnalysisTask):

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -21,7 +21,7 @@ from mpas_analysis.shared.analysis_task import AnalysisTask
 from mpas_analysis.shared.plot import timeseries_analysis_plot, savefig, \
     add_inset
 
-from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
+from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf_with_fill
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     build_obs_path, get_files_year_month, decode_strings, get_region_mask
@@ -385,7 +385,7 @@ class ComputeRegionDepthMasksSubtask(AnalysisTask):
         dsOut['zbounds'] = (('nRegions', 'nbounds'), zbounds)
         dsOut['areaCell'] = areaCell
         dsOut['regionNames'] = dsRegionMask.regionNames
-        write_netcdf(dsOut, outFileName)
+        write_netcdf_with_fill(dsOut, outFileName)
 
 
 class ComputeRegionTimeSeriesSubtask(AnalysisTask):
@@ -648,7 +648,7 @@ class ComputeRegionTimeSeriesSubtask(AnalysisTask):
         dsOut.coords['month'] = (('Time',), months)
         dsOut['month'].attrs['units'] = 'months'
 
-        write_netcdf(dsOut, outFileName)
+        write_netcdf_with_fill(dsOut, outFileName)
 
     def _add_thermal_forcing(self, dsIn, cellMask):
         """ compute the thermal forcing """
@@ -763,7 +763,7 @@ class CombineRegionalProfileTimeSeriesSubtask(AnalysisTask):
             for var in ['totalArea', 'zbounds']:
                 ds[var] = ds[var].isel(Time=0, drop=True)
 
-            write_netcdf(ds, outFileName)
+            write_netcdf_with_fill(ds, outFileName)
 
 
 class ComputeObsRegionalTimeSeriesSubtask(AnalysisTask):
@@ -1001,7 +1001,7 @@ class ComputeObsRegionalTimeSeriesSubtask(AnalysisTask):
         dsOut['zbounds'] = ('nBounds', [zmin, zmax])
         dsOut['month'] = ('Time', numpy.array(ds.month.values, dtype=float))
         dsOut['year'] = ('Time', numpy.ones(ds.sizes[tDim]))
-        write_netcdf(dsOut, outFileName)
+        write_netcdf_with_fill(dsOut, outFileName)
 
 
 class PlotRegionTimeSeriesSubtask(AnalysisTask):

--- a/mpas_analysis/ocean/time_series_transport.py
+++ b/mpas_analysis/ocean/time_series_transport.py
@@ -22,7 +22,7 @@ from mpas_analysis.shared.constants import constants
 from mpas_analysis.shared.plot import timeseries_analysis_plot, savefig, \
     add_inset
 
-from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
+from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf_with_fill
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     get_files_year_month, decode_strings
@@ -383,7 +383,7 @@ class ComputeTransportSubtask(AnalysisTask):
         dsOut['year'].attrs['units'] = 'years'
         dsOut.coords['month'] = (('Time',), months)
         dsOut['month'].attrs['units'] = 'months'
-        write_netcdf(dsOut, outFileName)
+        write_netcdf_with_fill(dsOut, outFileName)
 
 
 class CombineTransportSubtask(AnalysisTask):
@@ -448,7 +448,7 @@ class CombineTransportSubtask(AnalysisTask):
             ds = xarray.open_mfdataset(inFileNames, combine='nested',
                                        concat_dim='Time', decode_times=False)
             ds.load()
-            write_netcdf(ds, outFileName)
+            write_netcdf_with_fill(ds, outFileName)
 
 
 class PlotTransportSubtask(AnalysisTask):

--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -25,7 +25,7 @@ from mpas_analysis.shared.timekeeping.MpasRelativeDelta import \
     MpasRelativeDelta
 
 from mpas_analysis.shared.time_series import combine_time_series_with_ncrcat
-from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf
+from mpas_analysis.shared.io import open_mpas_dataset, write_netcdf_with_fill
 
 from mpas_analysis.shared.html import write_image_xml
 
@@ -635,6 +635,6 @@ class TimeSeriesSeaIce(AnalysisTask):
 
             dsTimeSeries[hemisphere] = dsAreaSum
 
-            write_netcdf(dsAreaSum, outFileNames[hemisphere])
+            write_netcdf_with_fill(dsAreaSum, outFileNames[hemisphere])
 
         return dsTimeSeries

--- a/mpas_analysis/shared/climatology/climatology.py
+++ b/mpas_analysis/shared/climatology/climatology.py
@@ -20,6 +20,7 @@ import os
 import numpy
 from tempfile import TemporaryDirectory
 
+from mpas_tools.io import write_netcdf
 from pyremap import Remapper, LatLonGridDescriptor, ProjectionGridDescriptor
 
 from mpas_analysis.shared.constants import constants
@@ -28,7 +29,7 @@ from mpas_analysis.shared.timekeeping.utility import days_to_datetime
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories, fingerprint_generator
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 from mpas_analysis.shared.climatology.comparison_descriptors import \
     get_comparison_descriptor, known_comparison_grids
@@ -382,7 +383,7 @@ def remap_and_write_climatology(config, climatologyDataSet,
 
             remappedClimatology = remapper.remap(climatologyDataSet,
                                                  renormalizationThreshold)
-            write_netcdf(remappedClimatology, remappedFileName)
+            write_netcdf_with_fill(remappedClimatology, remappedFileName)
     return remappedClimatology
 
 
@@ -795,7 +796,7 @@ def _cache_individual_climatologies(ds, cacheInfo, printProgress,
         climatology.attrs['totalMonths'] = monthCount
         climatology.attrs['fingerprintClimo'] = fingerprint_generator()
 
-        write_netcdf(climatology, outputFileClimo)
+        write_netcdf_with_fill(climatology, outputFileClimo)
         climatology.close()
 
 
@@ -871,7 +872,7 @@ def _cache_aggregated_climatology(startYearClimo, endYearClimo, cachePrefix,
         climatology.attrs['totalMonths'] = totalMonths
         climatology.attrs['fingerprintClimo'] = fingerprint_generator()
 
-        write_netcdf(climatology, outputFileClimo)
+        write_netcdf_with_fill(climatology, outputFileClimo)
 
     return climatology
 

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -689,7 +689,7 @@ class MpasClimatologySeasonSubtask(AnalysisTask):
                                        combine='nested',
                                        concat_dim='Time',
                                        chunks={'nCells': chunkSize},
-                                       decode_cf=False, decode_times=False,
+                                       decode_times=False,
                                        preprocess=_preprocess) as ds:
 
                 ds.coords['year'] = ('Time', years)
@@ -717,7 +717,7 @@ class MpasClimatologySeasonSubtask(AnalysisTask):
             with xarray.open_mfdataset(fileNames, concat_dim='weight',
                                        combine='nested',
                                        chunks={'nCells': chunkSize},
-                                       decode_cf=False, decode_times=False,
+                                       decode_times=False,
                                        preprocess=_preprocess) as ds:
                 ds.coords['weight'] = ('weight', weights)
                 dsNew = ((ds.weight * ds).sum(dim='weight') /

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -18,6 +18,8 @@ import multiprocessing
 from multiprocessing.pool import ThreadPool
 import glob
 
+from mpas_tools.io import write_netcdf
+
 from mpas_analysis.shared.analysis_task import AnalysisTask
 
 from mpas_analysis.shared.climatology.climatology import \
@@ -27,8 +29,6 @@ from mpas_analysis.shared.climatology.climatology import \
 
 from mpas_analysis.shared.io.utility import make_directories, \
     get_files_year_month
-
-from mpas_analysis.shared.io import write_netcdf
 
 from mpas_analysis.shared.constants import constants
 

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -12,6 +12,8 @@
 import xarray as xr
 import numpy
 import os
+
+from mpas_tools.io import write_netcdf
 from pyremap import MpasMeshDescriptor
 
 from mpas_analysis.shared.analysis_task import AnalysisTask
@@ -20,7 +22,7 @@ from mpas_analysis.shared.constants import constants
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 from mpas_analysis.shared.climatology.climatology import get_remapper, \
     get_masked_mpas_climatology_file_name, \
@@ -616,4 +618,4 @@ class RemapMpasClimatologySubtask(AnalysisTask):
         remappedClimatology = self.customize_remapped_climatology(
             remappedClimatology, comparisonGridName, season)
 
-        write_netcdf(remappedClimatology, outFileName)
+        write_netcdf_with_fill(remappedClimatology, outFileName)

--- a/mpas_analysis/shared/climatology/remap_observed_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_observed_climatology_subtask.py
@@ -18,7 +18,7 @@ from mpas_analysis.shared.constants import constants
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 from mpas_analysis.shared.climatology.climatology import get_remapper, \
     remap_and_write_climatology, compute_climatology
@@ -126,7 +126,7 @@ class RemapObservedClimatologySubtask(AnalysisTask):
         obsFileName = self.get_file_name(stage='original')
         if not os.path.exists(obsFileName):
             ds = self.build_observational_dataset(self.fileName)
-            write_netcdf(ds, obsFileName)
+            write_netcdf_with_fill(ds, obsFileName)
 
     def run_task(self):
         """
@@ -171,7 +171,7 @@ class RemapObservedClimatologySubtask(AnalysisTask):
                         # climatology so assume this already is one
                         seasonalClimatology = ds
 
-                    write_netcdf(seasonalClimatology, climatologyFileName)
+                    write_netcdf_with_fill(seasonalClimatology, climatologyFileName)
 
                     remapper = self.remappers[comparisonGridName]
 

--- a/mpas_analysis/shared/io/__init__.py
+++ b/mpas_analysis/shared/io/__init__.py
@@ -1,5 +1,5 @@
 from mpas_analysis.shared.io.namelist_streams_interface import NameList, \
     StreamsFile
 from mpas_analysis.shared.io.utility import paths, decode_strings
-from mpas_analysis.shared.io.write_netcdf import write_netcdf
+from mpas_analysis.shared.io.write_netcdf import write_netcdf_with_fill
 from mpas_analysis.shared.io.mpas_reader import open_mpas_dataset

--- a/mpas_analysis/shared/regions/compute_region_masks_subtask.py
+++ b/mpas_analysis/shared/regions/compute_region_masks_subtask.py
@@ -21,7 +21,7 @@ from mpas_tools.logging import check_call
 from mpas_analysis.shared.analysis_task import AnalysisTask
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories, get_region_mask
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 
 def get_feature_list(geojsonFileName):
@@ -57,7 +57,7 @@ def compute_mpas_region_masks(geojsonFileName, meshFileName, maskFileName,
         fcMask = read_feature_collection(geojsonFileName)
         dsMasks = mpas_tools.conversion.mask(dsMesh=dsMesh, fcMask=fcMask,
                                              logger=logger, dir=dir)
-        write_netcdf(dsMasks, maskFileName)
+        write_netcdf_with_fill(dsMasks, maskFileName)
 
     else:
         args = ['compute_mpas_region_masks',

--- a/mpas_analysis/shared/transects/compute_transect_masks_subtask.py
+++ b/mpas_analysis/shared/transects/compute_transect_masks_subtask.py
@@ -21,7 +21,7 @@ from mpas_analysis.shared.analysis_task import AnalysisTask
 
 from mpas_analysis.shared.io.utility import build_config_full_path, \
     make_directories, get_region_mask
-from mpas_analysis.shared.io import write_netcdf
+from mpas_analysis.shared.io import write_netcdf_with_fill
 
 from mpas_analysis.shared.regions import get_feature_list
 
@@ -47,7 +47,7 @@ def compute_mpas_transect_masks(geojsonFileName, meshFileName, maskFileName,
         dsMask = mpas_tools.conversion.mask(dsMesh=dsMesh, fcMask=fcMask,
                                             logger=logger, dir=dir)
 
-        write_netcdf(dsMask, maskFileName)
+        write_netcdf_with_fill(dsMask, maskFileName)
     else:
         args = ['compute_mpas_transect_masks',
                 '-m', meshFileName,

--- a/suite/main_vs_ctrl.cfg
+++ b/suite/main_vs_ctrl.cfg
@@ -12,5 +12,5 @@ controlRunConfigFile = ../ctrl.cfg
 # remapped to the comparison grid and time series have been extracted.
 # Leave this option commented out if the analysis for the main run should be
 # performed.
-mainRunConfigFile = ../main_py3.10.cfg
+mainRunConfigFile = ../main.cfg
 

--- a/suite/moc_am.cfg
+++ b/suite/moc_am.cfg
@@ -1,0 +1,12 @@
+[streamfunctionMOC]
+## options related to plotting the streamfunction of the meridional overturning
+## circulation (MOC)
+
+# Use postprocessing script to compute the MOC? You want this to be True
+# for low-resolution simulations that use GM to parameterize eddies, because
+# the online MOC analysis member currently does not include the bolus velocity
+# in its calculation, whereas the postprocessing script does.
+# NOTE: this is a temporary option that will be removed once the online
+# MOC takes into account the bolus velocity when GM is on.
+usePostprocessingScript = False
+

--- a/suite/run_dev_suite.bash
+++ b/suite/run_dev_suite.bash
@@ -26,6 +26,7 @@ py=3.11
 ./suite/setup.py -p ${py} -r wc_defaults -b ${branch} --no_polar_regions -e ${env_name}
 ./suite/setup.py -p ${py} -r moc_am -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r no_ncclimo -b ${branch} -e ${env_name}
+./suite/setup.py -p ${py} -r main -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r ctrl -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r main_vs_ctrl -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r no_polar_regions -b ${branch} --no_polar_regions -e ${env_name}

--- a/suite/run_dev_suite.bash
+++ b/suite/run_dev_suite.bash
@@ -24,6 +24,7 @@ machine=$(python -c "from mache import discover_machine; print(discover_machine(
 py=3.11
 ./suite/setup.py -p ${py} -r main_py${py} -b ${branch} --copy_docs --clean -e ${env_name}
 ./suite/setup.py -p ${py} -r wc_defaults -b ${branch} --no_polar_regions -e ${env_name}
+./suite/setup.py -p ${py} -r moc_am -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r no_ncclimo -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r ctrl -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r main_vs_ctrl -b ${branch} -e ${env_name}
@@ -45,7 +46,7 @@ echo main_vs_ctrl
 sbatch --dependency=afterok:${RES##* } --kill-on-invalid-dep=yes job_script.bash
 cd ..
 
-for run in wc_defaults no_ncclimo no_polar_regions \
+for run in wc_defaults moc_am no_ncclimo no_polar_regions \
     mesh_rename QU480
 do
     cd ${run}

--- a/suite/run_e3sm_unified_suite.bash
+++ b/suite/run_e3sm_unified_suite.bash
@@ -13,6 +13,7 @@ machine=${E3SMU_MACHINE}
 ./suite/setup.py -p ${py} -r wc_defaults -b ${branch} --no_polar_regions
 ./suite/setup.py -p ${py} -r moc_am -b ${branch}
 ./suite/setup.py -p ${py} -r no_ncclimo -b ${branch}
+./suite/setup.py -p ${py} -r main -b ${branch}
 ./suite/setup.py -p ${py} -r ctrl -b ${branch}
 ./suite/setup.py -p ${py} -r main_vs_ctrl -b ${branch}
 ./suite/setup.py -p ${py} -r no_polar_regions -b ${branch} --no_polar_regions

--- a/suite/run_e3sm_unified_suite.bash
+++ b/suite/run_e3sm_unified_suite.bash
@@ -11,6 +11,7 @@ machine=${E3SMU_MACHINE}
 
 ./suite/setup.py -p ${py} -r main_py${py} -b ${branch} --clean
 ./suite/setup.py -p ${py} -r wc_defaults -b ${branch} --no_polar_regions
+./suite/setup.py -p ${py} -r moc_am -b ${branch}
 ./suite/setup.py -p ${py} -r no_ncclimo -b ${branch}
 ./suite/setup.py -p ${py} -r ctrl -b ${branch}
 ./suite/setup.py -p ${py} -r main_vs_ctrl -b ${branch}
@@ -30,7 +31,7 @@ echo main_vs_ctrl
 sbatch --dependency=afterok:${RES##* } --kill-on-invalid-dep=yes job_script.bash
 cd ..
 
-for run in wc_defaults no_ncclimo no_polar_regions mesh_rename
+for run in wc_defaults moc_am no_ncclimo no_polar_regions mesh_rename
 do
     cd ${run}
     echo ${run}

--- a/suite/run_suite.bash
+++ b/suite/run_suite.bash
@@ -60,6 +60,7 @@ conda deactivate
 
 py=${alt_py}
 conda activate test_mpas_analysis_py${py}
+./suite/setup.py -p ${py} -r main -b ${branch}
 ./suite/setup.py -p ${py} -r main_py${py} -b ${branch}
 conda deactivate
 

--- a/suite/run_suite.bash
+++ b/suite/run_suite.bash
@@ -49,6 +49,7 @@ machine=$(python -c "from mache import discover_machine; print(discover_machine(
 
 ./suite/setup.py -p ${py} -r main_py${py} -b ${branch} --copy_docs --clean
 ./suite/setup.py -p ${py} -r wc_defaults -b ${branch} --no_polar_regions
+./suite/setup.py -p ${py} -r moc_am -b ${branch}
 ./suite/setup.py -p ${py} -r no_ncclimo -b ${branch}
 ./suite/setup.py -p ${py} -r ctrl -b ${branch}
 ./suite/setup.py -p ${py} -r main_vs_ctrl -b ${branch}
@@ -75,7 +76,7 @@ echo main_vs_ctrl
 sbatch --dependency=afterok:${RES##* } --kill-on-invalid-dep=yes job_script.bash
 cd ..
 
-for run in main_py${alt_py} wc_defaults no_ncclimo no_polar_regions \
+for run in main_py${alt_py} wc_defaults moc_am no_ncclimo no_polar_regions \
     mesh_rename xarray_main QU480
 do
     cd ${run}

--- a/suite/setup.py
+++ b/suite/setup.py
@@ -131,7 +131,7 @@ def main():
     config = os.path.join(suite_path, f'{args.run}.cfg')
     config_from_job = os.path.join('..', f'{args.run}.cfg')
 
-    if args.run == 'ctrl':
+    if args.run in ['main', 'ctrl']:
         out_subdir = os.path.join(machine, args.branch, f'main_py{args.python}')
     else:
         out_subdir = os.path.join(machine, args.branch, args.run)
@@ -154,7 +154,7 @@ def main():
             [config_from_job,
              os.path.join('..', '..', 'suite', f'{args.run}.cfg')])
 
-    if args.run != 'ctrl':
+    if args.run not in ['main', 'ctrl']:
         try:
             os.makedirs(os.path.join(suite_path, args.run))
         except FileExistsError:

--- a/suite/setup.py
+++ b/suite/setup.py
@@ -148,7 +148,7 @@ def main():
     with open(config, 'w') as config_file:
         config_file.write(config_text)
 
-    if args.run in ['main_vs_ctrl', 'no_ncclimo', 'wc_defaults']:
+    if args.run in ['main_vs_ctrl', 'moc_am', 'no_ncclimo', 'wc_defaults']:
         # add the run-specific config second
         config_from_job = ' '.join(
             [config_from_job,


### PR DESCRIPTION
This merge renames `write_netcdf` --> `write_netcdf_with_fill` to avoid confusion with MPAS-Tools, where the `write_netcdf` function also exists and is only for MPAS data.  For clarity, we want the functionality in the MPAS-Analysis version to be more explicit.

The merge aslo switches to using `write_netcdf_with_fill` in most places where `write_netcdf` was previously used.

For more complete testing, I also added a test for the MOC analysis member (the MOC is postprocessed in MPAS-Analysis by default).  It fixes the "main vs. control" run to work properly with the developer and E3SM-Unified suites (where only one version of python is tested), in addition to the default one.

This merge switches to parsing CF when using xarray for MPAS climatologies.  This is necessary to correctly handle fill values now that they are present in some MPAS output.  The fill values are otherwise not converted to NaNs by xarray, leading to undesirable behavior.

Finally, thie merge removes some debug output from the MOC task accidentally left in #955