### PR TITLE
Fix colorbars on OHC and BSF difference plots

### DIFF
--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -1509,9 +1509,9 @@ colormapNameDifference = balance
 # whether the colormap is indexed or continuous
 colormapTypeDifference = indexed
 # color indices into colormapName for filled contours
-colormapIndicesDifference = numpy.array(numpy.linspace(0, 255, 9), int)
+colormapIndicesDifference = numpy.array(numpy.linspace(0, 255, 12), int)
 # colormap levels/values for contour boundaries
-colorbarLevelsDifference = numpy.linspace(-2., 2., 10)
+colorbarLevelsDifference = numpy.linspace(-3., 3., 13)
 
 # Months or seasons to plot (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -1507,7 +1507,7 @@ colormapNameDifference = balance
 # whether the colormap is indexed or continuous
 colormapTypeDifference = indexed
 # color indices into colormapName for filled contours
-colormapIndicesDifference = numpy.array(numpy.linspace(0, 255, 12), int)
+colormapIndicesDifference = numpy.array(numpy.linspace(0, 255, 14), int)
 # colormap levels/values for contour boundaries
 colorbarLevelsDifference = numpy.linspace(-3., 3., 13)
 

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -1436,7 +1436,7 @@ normTypeDifference = linear
 # A dictionary with keywords for the norm
 normArgsDifference = {'vmin': -300., 'vmax': 300.}
 # place the ticks automatically by default
-# colorbarTicksDifference = numpy.linspace(-2., 2., 9
+# colorbarTicksDifference = numpy.linspace(-2., 2., 9)
 
 # Months or seasons to plot (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)
@@ -1473,12 +1473,10 @@ colormapNameDifference = cmo.balance
 # whether the colormap is indexed or continuous
 colormapTypeDifference = continuous
 # the type of norm used in the colormap
-normTypeDifference = symLog
+normTypeDifference = linear
 # A dictionary with keywords for the norm
-normArgsDifference = {'linthresh': 0.1, 'linscale': 0.5, 'vmin': -10.,
-                      'vmax': 10.}
-colorbarTicksDifference = [-10., -3., -1., -0.3, -0.1, 0., 0.1, 0.3, 1., 3.,
-                           10.]
+normArgsDifference = {'vmin': -10., 'vmax': 10.}
+# colorbarTicksDifference = numpy.linspace(-10., 10., 9)
 
 # Months or seasons to plot (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
 # Nov, Dec, JFM, AMJ, JAS, OND, ANN)


### PR DESCRIPTION
Before this fix, we were seeing weird colorbars for OHC difference plots, e.g.:
![image](https://github.com/MPAS-Dev/MPAS-Analysis/assets/4179064/62fab327-0630-4a1d-b45c-89cc927ea812)

and weird color maps for BSF difference plots, e.g.:
![image](https://github.com/MPAS-Dev/MPAS-Analysis/assets/4179064/6546dd0c-f048-4405-b841-f834a7d8c715)
