### PR TITLE
Removed `errorOnMissing` and `endYear = end` config options

### DIFF
--- a/docs/tutorials/dev_getting_started.rst
+++ b/docs/tutorials/dev_getting_started.rst
@@ -642,24 +642,16 @@ climate index.
     ## options related to producing time series plots, often to compare against
     ## observations and previous runs
 
-    # start and end years for timeseries analysis. Use endYear = end to indicate
-    # that the full range of the data should be used.  If errorOnMissing = False,
-    # the start and end year will be clipped to the valid range.  Otherwise, out
-    # of bounds values will lead to an error.  In a "control" config file used in
-    # a "main vs. control" analysis run, the range of years must be valid and
-    # cannot include "end" because the original data may not be available.
+    # start and end years for timeseries analysis.  Out-of-bounds values will lead
+    # to an error.
     startYear = 1
     endYear = 5
 
     [index]
     ## options related to producing nino index.
 
-    # start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
-    # that the full range of the data should be used.  If errorOnMissing = False,
-    # the start and end year will be clipped to the valid range.  Otherwise, out
-    # of bounds values will lead to an error.  In a "control" config file used in
-    # a "main vs. control" analysis run, the range of years must be valid and
-    # cannot include "end" because the original data may not be available.
+    # start and end years for El Nino 3.4 analysis.  Out-of-bounds values will lead
+    # to an error.
     startYear = 1
     endYear = 5
 

--- a/docs/tutorials/getting_started.rst
+++ b/docs/tutorials/getting_started.rst
@@ -443,24 +443,16 @@ climate index.
     ## options related to producing time series plots, often to compare against
     ## observations and previous runs
 
-    # start and end years for timeseries analysis. Use endYear = end to indicate
-    # that the full range of the data should be used.  If errorOnMissing = False,
-    # the start and end year will be clipped to the valid range.  Otherwise, out
-    # of bounds values will lead to an error.  In a "control" config file used in
-    # a "main vs. control" analysis run, the range of years must be valid and
-    # cannot include "end" because the original data may not be available.
+    # start and end years for timeseries analysis.  Out-of-bounds values will lead
+    # to an error.
     startYear = 1
     endYear = 5
 
     [index]
     ## options related to producing nino index.
 
-    # start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
-    # that the full range of the data should be used.  If errorOnMissing = False,
-    # the start and end year will be clipped to the valid range.  Otherwise, out
-    # of bounds values will lead to an error.  In a "control" config file used in
-    # a "main vs. control" analysis run, the range of years must be valid and
-    # cannot include "end" because the original data may not be available.
+    # start and end years for timeseries analysis.  Out-of-bounds values will lead
+    # to an error.
     startYear = 1
     endYear = 5
 

--- a/docs/users_guide/config/index.rst
+++ b/docs/users_guide/config/index.rst
@@ -13,22 +13,15 @@ determine the start and end years of climate indices (such as El Ni |n~| o
   [index]
   ## options related to producing nino index.
 
-  # start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
-  # that the full range of the data should be used.  If errorOnMissing = False,
-  # the start and end year will be clipped to the valid range.  Otherwise, out
-  # of bounds values will lead to an error.  In a "control" config file used in
-  # a "main vs. control" analysis run, the range of years must be valid and
-  # cannot include "end" because the original data may not be available.
+  # start and end years for El Nino 3.4 analysis.  Out-of-bounds values will lead
+  # to an error.
   startYear = 1
-  endYear = end
+  endYear = 20
 
 Start and End Year
 ------------------
 
 A custom config file should specify a start and end year for time axis.
-If ``errorOnMissing = False`` in the ``input`` section and the start or end
-year is beyond the range of the simulation, the range will be reduced to those
-dates with available data and a warning message will be displayed.  If
-``errorOnMissing = True``, out of range year will produce an error.
+Out of range year will produce an error.
 
 

--- a/docs/users_guide/config/timeSeries.rst
+++ b/docs/users_guide/config/timeSeries.rst
@@ -16,23 +16,16 @@ for anomalies::
   # only the anomaly over a later span of years is of interest.
   # anomalyRefYear = 249
 
-  # start and end years for timeseries analysis. Use endYear = end to indicate
-  # that the full range of the data should be used.  If errorOnMissing = False,
-  # the start and end year will be clipped to the valid range.  Otherwise, out
-  # of bounds values will lead to an error.  In a "control" config file used in
-  # a "main vs. control" analysis run, the range of years must be valid and
-  # cannot include "end" because the original data may not be available.
+  # start and end years for timeseries analysis.  Out-of-bounds values will lead
+  # to an error.
   startYear = 1
-  endYear = end
+  endYear = 20
 
 Start and End Year
 ------------------
 
 A custom config file should specify a start and end year for time series.
-If ``errorOnMissing = False`` in the ``input`` section and the start or end
-year is beyond the range of the simulation, the range will be reduced to those
-dates with available data and a warning message will be displayed.  If
-``errorOnMissing = True``, out of range year will produce an error.
+Out of range year will produce an error.
 
 
 Anomaly Reference Year

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -294,14 +294,10 @@ subprocessCount = 1
 # only the anomaly over a later span of years is of interest.
 # anomalyRefYear = 249
 
-# start and end years for timeseries analysis. Use endYear = end to indicate
-# that the full range of the data should be used.  If errorOnMissing = False,
-# the start and end year will be clipped to the valid range.  Otherwise, out
-# of bounds values will lead to an error.  In a "control" config file used in
-# a "main vs. control" analysis run, the range of years must be valid and
-# cannot include "end" because the original data may not be available.
+# start and end years for timeseries analysis.  Out-of-bounds values will lead
+# to an error.
 startYear = 1
-endYear = end
+endYear = 20
 
 
 # line colors for the main, control and obs curves
@@ -320,14 +316,10 @@ fitColor1 = tab:blue
 [index]
 ## options related to producing nino index.
 
-# start and end years for El Nino 3.4 analysis. Use endYear = end to indicate
-# that the full range of the data should be used.  If errorOnMissing = False,
-# the start and end year will be clipped to the valid range.  Otherwise, out
-# of bounds values will lead to an error.  In a "control" config file used in
-# a "main vs. control" analysis run, the range of years must be valid and
-# cannot include "end" because the original data may not be available.
+# start and end years for El Nino 3.4 analysis.  Out-of-bounds values will lead
+# to an error.
 startYear = 1
-endYear = end
+endYear = 20
 
 
 [regions]

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -151,11 +151,6 @@ file_cache_maxsize = 1200
 # with a single time slice.
 maxChunkSize = 10000
 
-# Whether missing input data should produce an error.  If not, the user gets
-# a warning and the time bounds are adjusted to the beginning and end of the
-# available data
-errorOnMissing = False
-
 
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,

--- a/mpas_analysis/ocean/hovmoller_ocean_regions.py
+++ b/mpas_analysis/ocean/hovmoller_ocean_regions.py
@@ -72,13 +72,7 @@ class HovmollerOceanRegions(AnalysisTask):
             tags=['profiles', 'timeSeries', 'hovmoller'])
 
         startYear = config.getint('timeSeries', 'startYear')
-        endYear = config.get('timeSeries', 'endYear')
-        if endYear == 'end':
-            # a valid end year wasn't found, so likely the run was not found,
-            # perhaps because we're just listing analysis tasks
-            endYear = startYear
-        else:
-            endYear = int(endYear)
+        endYear = config.getint('timeSeries', 'endYear')
 
         regionGroups = config.getexpression('hovmollerOceanRegions',
                                             'regionGroups')

--- a/mpas_analysis/ocean/streamfunction_moc.py
+++ b/mpas_analysis/ocean/streamfunction_moc.py
@@ -88,13 +88,7 @@ class StreamfunctionMOC(AnalysisTask):
         plotClimSubtask.run_after(computeClimSubtask)
 
         startYear = config.getint('timeSeries', 'startYear')
-        endYear = config.get('timeSeries', 'endYear')
-        if endYear == 'end':
-            # a valid end year wasn't found, so likely the run was not found,
-            # perhaps because we're just listing analysis tasks
-            endYear = startYear
-        else:
-            endYear = int(endYear)
+        endYear = config.getint('timeSeries', 'endYear')
 
         years = range(startYear, endYear + 1)
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -87,13 +87,7 @@ class TimeSeriesAntarcticMelt(AnalysisTask):
         iceShelvesToPlot = masksSubtask.expand_region_names(iceShelvesToPlot)
 
         startYear = config.getint('timeSeries', 'startYear')
-        endYear = config.get('timeSeries', 'endYear')
-        if endYear == 'end':
-            # a valid end year wasn't found, so likely the run was not found,
-            # perhaps because we're just listing analysis tasks
-            endYear = startYear
-        else:
-            endYear = int(endYear)
+        endYear = config.getint('timeSeries', 'endYear')
 
         years = list(range(startYear, endYear + 1))
 

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -70,13 +70,7 @@ class TimeSeriesOceanRegions(AnalysisTask):
             tags=['timeSeries', 'regions', 'antarctic'])
 
         startYear = config.getint('timeSeries', 'startYear')
-        endYear = config.get('timeSeries', 'endYear')
-        if endYear == 'end':
-            # a valid end year wasn't found, so likely the run was not found,
-            # perhaps because we're just listing analysis tasks
-            endYear = startYear
-        else:
-            endYear = int(endYear)
+        endYear = config.getint('timeSeries', 'endYear')
 
         regionGroups = config.getexpression(self.taskName, 'regionGroups')
 

--- a/mpas_analysis/ocean/time_series_transport.py
+++ b/mpas_analysis/ocean/time_series_transport.py
@@ -67,13 +67,7 @@ class TimeSeriesTransport(AnalysisTask):
             tags=['timeSeries', 'transport'])
 
         startYear = config.getint('timeSeries', 'startYear')
-        endYear = config.get('timeSeries', 'endYear')
-        if endYear == 'end':
-            # a valid end year wasn't found, so likely the run was not found,
-            # perhaps because we're just listing analysis tasks
-            endYear = startYear
-        else:
-            endYear = int(endYear)
+        endYear = config.getint('timeSeries', 'endYear')
 
         years = [year for year in range(startYear, endYear + 1)]
 

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -1,11 +1,3 @@
-[input]
-## options related to reading in the results to be analyzed
-
-# Whether missing input data should produce an error.  If not, the user gets
-# a warning and the time bounds are adjusted to the beginning and end of the
-# available data
-errorOnMissing = True
-
 [output]
 ## options related to writing out plots, intermediate cached data sets, logs,
 ## etc.

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -587,8 +587,6 @@ def update_time_bounds_from_file_names(config, section, componentName):
         '{}HistorySubdirectory'.format(componentName),
         defaultPath=runDirectory)
 
-    errorOnMissing = config.getboolean('input', 'errorOnMissing')
-
     namelistFileName = build_config_full_path(
         config, 'input',
         '{}NamelistFileName'.format(componentName))
@@ -660,24 +658,12 @@ def update_time_bounds_from_file_names(config, section, componentName):
         requestedEndYear = endYear
 
     if startYear != requestedStartYear or endYear != requestedEndYear:
-        if errorOnMissing:
-            raise ValueError(
-                "{} start and/or end year different from requested\n"
-                "requested: {:04d}-{:04d}\n"
-                "actual:   {:04d}-{:04d}\n".format(
-                    section, requestedStartYear, requestedEndYear, startYear,
-                    endYear))
-        else:
-            print("Warning: {} start and/or end year different from "
-                  "requested\n"
-                  "requested: {:04d}-{:04d}\n"
-                  "actual:   {:04d}-{:04d}\n".format(section,
-                                                     requestedStartYear,
-                                                     requestedEndYear,
-                                                     startYear,
-                                                     endYear))
-            config.set(section, 'startYear', str(startYear))
-            config.set(section, 'endYear', str(endYear))
+        raise ValueError(
+            "{} start and/or end year different from requested\n"
+            "requested: {:04d}-{:04d}\n"
+            "actual:   {:04d}-{:04d}\n".format(
+                section, requestedStartYear, requestedEndYear, startYear,
+                endYear))
 
     startDate = '{:04d}-01-01_00:00:00'.format(startYear)
     config.set(section, 'startDate', startDate)

--- a/mpas_analysis/shared/analysis_task.py
+++ b/mpas_analysis/shared/analysis_task.py
@@ -609,18 +609,10 @@ def update_time_bounds_from_file_names(config, section, componentName):
     calendar = namelist.get('config_calendar_type')
 
     requestedStartYear = config.getint(section, 'startYear')
-    requestedEndYear = config.get(section, 'endYear')
-    if requestedEndYear == 'end':
-        requestedEndYear = None
-    else:
-        # get it again as an integer
-        requestedEndYear = config.getint(section, 'endYear')
+    requestedEndYear = config.getint(section, 'endYear')
 
     startDate = '{:04d}-01-01_00:00:00'.format(requestedStartYear)
-    if requestedEndYear is None:
-        endDate = None
-    else:
-        endDate = '{:04d}-12-31_23:59:59'.format(requestedEndYear)
+    endDate = '{:04d}-12-31_23:59:59'.format(requestedEndYear)
 
     streamName = 'timeSeriesStatsMonthlyOutput'
     try:
@@ -652,10 +644,6 @@ def update_time_bounds_from_file_names(config, section, componentName):
     while (lastIndex >= 0 and months[lastIndex] != 12):
         lastIndex -= 1
     endYear = years[lastIndex]
-
-    if requestedEndYear is None:
-        config.set(section, 'endYear', str(endYear))
-        requestedEndYear = endYear
 
     if startYear != requestedStartYear or endYear != requestedEndYear:
         raise ValueError(

--- a/mpas_analysis/test/test_climatology.py
+++ b/mpas_analysis/test/test_climatology.py
@@ -214,7 +214,7 @@ class TestClimatology(TestCase):
         monthValues = constants.monthDictionary[monthNames]
         dsClimatology = compute_climatology(ds, monthValues, calendar)
 
-        assert('Time' not in dsClimatology.dims.keys())
+        assert('Time' not in dsClimatology.dims)
 
         self.assertEqual(list(dsClimatology.data_vars.keys()), ['mld'])
 

--- a/mpas_analysis/test/test_mpas_climatology_task.py
+++ b/mpas_analysis/test/test_mpas_climatology_task.py
@@ -138,7 +138,7 @@ class TestMpasClimatologyTask(TestCase):
         mpasClimatologyTask = self.setup_task()
         config = mpasClimatologyTask.config
 
-        # first make sure the start and end years stay unchanged when we use
+        # make sure the start and end years stay unchanged when we use
         # the start and end years already in the config file
         startYear = 2
         endYear = 2
@@ -165,18 +165,10 @@ class TestMpasClimatologyTask(TestCase):
         config.set('climatology', 'startDate', startDate)
         config.set('climatology', 'endDate', endDate)
 
-        update_time_bounds_from_file_names(config, 'climatology', 'ocean')
-        mpasClimatologyTask._create_symlinks()
-
-        startYear = 2
-        endYear = 2
-        startDate = '{:04d}-01-01_00:00:00'.format(startYear)
-        endDate = '{:04d}-12-31_23:59:59'.format(endYear)
-
-        assert(mpasClimatologyTask.startYear == startYear)
-        assert(mpasClimatologyTask.endYear == endYear)
-        assert(mpasClimatologyTask.startDate == startDate)
-        assert(mpasClimatologyTask.endDate == endDate)
+        with self.assertRaisesRegex(ValueError,
+                                    'climatology start and/or end year '
+                                    'different from requested'):
+            update_time_bounds_from_file_names(config, 'climatology', 'ocean')
 
     def test_subtask_run_analysis(self):
         mpasClimatologyTask = self.setup_task()

--- a/mpas_analysis/test/test_mpas_climatology_task/QU240.cfg
+++ b/mpas_analysis/test/test_mpas_climatology_task/QU240.cfg
@@ -20,7 +20,6 @@ oceanHistorySubdirectory = .
 oceanNamelistFileName = mpas-o_in
 oceanStreamsFileName = streams.ocean
 mpasMeshName = oQU240
-errorOnMissing = False
 
 [output]
 baseDirectory = /dir/for/analysis/output

--- a/mpas_analysis/test/test_remap_obs_clim_subtask/remap_obs.cfg
+++ b/mpas_analysis/test/test_remap_obs_clim_subtask/remap_obs.cfg
@@ -14,7 +14,6 @@ runSubdirectory = .
 oceanHistorySubdirectory = .
 oceanNamelistFileName = mpas-o_in
 oceanStreamsFileName = streams.ocean
-errorOnMissing = False
 
 [output]
 baseDirectory = /dir/for/analysis/output


### PR DESCRIPTION
This merge removes the config option `errorOnMissing` from the `[input]` section.  In practice, we always want an error on missing data, rather than simply providing a warning using available data.

This merge also drops support for the `end` value for `endYear`.  For developers, `end` has been more difficult to support than it is worth.  For users, it isn't a great idea to have the same analysis run produce different results depending on how far along a simulation is.  In practice, we always want to run fresh analysis when we want a longer time series.