### PR TITLE
Shorten titles of Frazil Accretion Rate plots

### DIFF
--- a/mpas_analysis/ocean/climatology_map_antarctic_melt.py
+++ b/mpas_analysis/ocean/climatology_map_antarctic_melt.py
@@ -248,7 +248,7 @@ class ClimatologyMapAntarcticMelt(AnalysisTask):
 
                 subtask.set_plot_info(
                     outFileLabel='antFrazil',
-                    fieldNameInTitle='Frazil Accretion Rate, negative upward',
+                    fieldNameInTitle='Frazil Accretion Rate, neg. upward',
                     mpasFieldName=mpasFieldName,
                     refFieldName=refFieldName,
                     refTitleLabel=refTitleLabel,


### PR DESCRIPTION
@irenavankova pointed out in https://github.com/MPAS-Dev/MPAS-Analysis/pull/989#issuecomment-1975020772 that the title is too long and thus produces figures that are slightly shifted depending on the season.