### PR TITLE
Don't use `srun` to call `ncremap` on PM and Chicoma

### DIFF
--- a/mpas_analysis/configuration/chicoma-cpu.cfg
+++ b/mpas_analysis/configuration/chicoma-cpu.cfg
@@ -27,4 +27,4 @@ mapParallelExec = srun
 
 # "None" if ncremap should perform remapping without a command, or "srun"
 # possibly with some flags if it should be run with that command
-ncremapParallelExec = srun
+ncremapParallelExec = None

--- a/mpas_analysis/configuration/pm-cpu.cfg
+++ b/mpas_analysis/configuration/pm-cpu.cfg
@@ -27,4 +27,4 @@ mapParallelExec = srun
 
 # "None" if ncremap should perform remapping without a command, or "srun"
 # possibly with some flags if it should be run with that command
-ncremapParallelExec = srun
+ncremapParallelExec = None


### PR DESCRIPTION
This seems to be causing trouble in E3SM-Unified 1.9.3rc2 testing.