### PR TITLE
Add support for maximum allowed sea-ice thickness

### DIFF
--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -3970,6 +3970,9 @@ areaSH = IceArea_timeseries/iceAreaSH_climo_20180710.nc
 volNH = PIOMAS/PIOMASvolume_monthly_climo_20180710.nc
 volSH = none
 
+# mask sea ice that is thicker than this a threshold (m)
+maxAllowedSeaIceThickness = None
+
 
 [climatologyMapSeaIceProductionNH]
 # options related to plotting horizontally remapped climatologies of


### PR DESCRIPTION
This allows us to mask out "bad" sea-ice cells that accumulate unphysical amounts of sea ice from the area, volume and mean thickness time series.

This is needed in order for us to produce useful analysis for the SORRM v2.1 simulations, where there is a cell with 90 km of sea ice(!!!) that we need to mask out.