### PR TITLE
Add Greenland shelf regions to ocean analysis tasks

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -30,7 +30,7 @@ requirements:
     - esmf >=8.4.2,<8.7.0
     - esmf=*=mpi_mpich_*
     - f90nml
-    - geometric_features >=1.2.0
+    - geometric_features >=1.4.0
     - gsw
     - lxml
     - mache >=1.11.0

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -11,7 +11,7 @@ dask
 esmf >=8.4.2,<8.7.0
 esmf=*=mpi_mpich_*
 f90nml
-geometric_features>=1.2.0
+geometric_features>=1.4.0
 gsw
 lxml
 mache >=1.11.0

--- a/docs/users_guide/config/regions.rst
+++ b/docs/users_guide/config/regions.rst
@@ -46,7 +46,7 @@ Several tasks (:ref:`task_hovmollerOceanRegions`, :ref:`task_oceanHistogram`,
 :ref:`task_oceanRegionalProfiles`, :ref:`task_regionalTSDiagrams`, and
 :ref:`task_timeSeriesOceanRegions`) can use any of the defined region groups.
 Currently, available region groups are: ``Artic Ocean Regions``, ``Antarctic Regions``,
-``Ocean Basins``, ``Ice Shelves``, and ``Ocean Subbasins``.
+``Greenland Regions``, ``Ocean Basins``, ``Ice Shelves``, and ``Ocean Subbasins``.
 
 The option ``regionMaskSubdirectory`` in the ``[diagnostics]`` section specifies
 the path to cached mask files for these region groups, typically

--- a/docs/users_guide/tasks/regionalTSDiagrams.rst
+++ b/docs/users_guide/tasks/regionalTSDiagrams.rst
@@ -121,6 +121,8 @@ The following configuration options are available for this task:
     # Obserational data sets to compare against
     obs = ['WOA18']
 
+Similar config sections are included for other region groups.
+
 Region Groups
 -------------
 

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -1779,11 +1779,54 @@ normType = log
 # Obserational data sets to compare against
 obs = ['SOSE', 'WOA18']
 
-[TSDiagramsForArcticOceanRegions]
-## options related to plotting T/S diagrams of Antarctic regions
+[TSDiagramsForGreenlandRegions]
+## options related to plotting T/S diagrams of Greenland regions
 
 # list of regions to plot or ['all'] for all regions in the masks file.
 # See "regionNames" in the antarcticRegions masks file in
+# regionMaskSubdirectory for details.
+regionNames = []
+
+# diagram type, either 'volumetric' or 'scatter', depending on if the points
+# should be binned the plot should show the volume fraction in each bin or
+# scattered points colored by their depth
+diagramType = volumetric
+
+# if diagramType == 'volumetric', the bin boundaries for T and S
+# if diagramType == 'scatter', only the min and max are important (and the
+#   bins are only used for computing neutral density contours)
+Tbins = numpy.linspace(-2.5, 8.0, 211)
+Sbins = numpy.linspace(33.5, 35.5, 401)
+
+# density contour interval
+rhoInterval = 0.3
+
+# The color map for depth or volume
+colormap = cmo.deep
+# The following is more appropriate if diagramType == 'scatter'
+# colormap = cmo.deep_r
+# the type of norm used in the colormap {'linear', 'log'}
+normType = log
+
+# The minimum and maximum depth over which fields are plotted, default is
+# to take these values from the geojson feature's zmin and zmax properties.
+# Add these to a custom config file to override the defaults.
+zmin = -6000
+zmax = 0
+
+# the minimum and maximum volume for the colorbar, default is the minimum and
+# maximum over the mode output
+#volMin = 3e9
+#volMax = 1e12
+
+# Obserational data sets to compare against
+obs = ['WOA18']
+
+[TSDiagramsForArcticOceanRegions]
+## options related to plotting T/S diagrams of Arctic regions
+
+# list of regions to plot or ['all'] for all regions in the masks file.
+# See "regionNames" in the arcticRegions masks file in
 # regionMaskSubdirectory for details.
 regionNames = []
 

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -1783,7 +1783,7 @@ obs = ['SOSE', 'WOA18']
 ## options related to plotting T/S diagrams of Greenland regions
 
 # list of regions to plot or ['all'] for all regions in the masks file.
-# See "regionNames" in the antarcticRegions masks file in
+# See "regionNames" in the greenlandRegions masks file in
 # regionMaskSubdirectory for details.
 regionNames = []
 

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -42,6 +42,19 @@ normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
 # the names of region groups to plot, each with its own section below
 regionGroups = ['Antarctic Regions', 'Arctic Ocean Regions', 'Ocean Basins']
 
+[TSDiagramsForGreenlandRegions]
+## options related to plotting T/S diagrams of Antarctic regions
+
+# list of regions to plot or ['all'] for all regions in the masks file.
+# See "regionNames" in the antarcticRegions masks file in
+# regionMaskSubdirectory for details.
+regionNames = ['all']
+
+# The minimum and maximum depth over which fields are plotted, default is
+# to take these values from the geojson feature's zmin and zmax properties.
+zmin = -1000
+zmax = 0
+
 [TSDiagramsForAntarcticRegions]
 ## options related to plotting T/S diagrams of Antarctic regions
 
@@ -229,6 +242,41 @@ colorbarLevelsDifference = [-0.5, -0.2, -0.1, -0.05, -0.02, 0,  0.02, 0.05,
 regionGroups = ['Arctic Ocean Regions', 'Antarctic Regions']
 
 
+[profilesGreenlandRegions]
+## options related to plotting vertical profiles Greenland regions
+
+
+# a list of dictionaries for each field to plot.  The dictionary includes
+# prefix (used for file names, task names and sections) as well as the mpas
+# name of the field, units for colorbars and a the name as it should appear
+# in figure titles and captions.
+fields =
+    [{'prefix': 'potentialTemperature',
+      'mpas': 'timeMonthly_avg_activeTracers_temperature',
+      'units': r'$$\degree$$C',
+      'titleName': 'Potential Temperature'},
+     {'prefix': 'salinity',
+      'mpas': 'timeMonthly_avg_activeTracers_salinity',
+      'units': r'PSU',
+      'titleName': 'Salinity'},
+     {'prefix': 'potentialDensity',
+      'mpas': 'timeMonthly_avg_potentialDensity',
+      'units': r'kg m$$^{-3}$$',
+      'titleName': 'Potential Density'}]
+
+# Times for comparison times (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['ANN']
+
+# minimum and maximum depth of profile plots, or empty for the full depth range
+depthRange = []
+
+# a list of region names from the region masks file to plot
+regionNames = ['all']
+
+# web gallery options
+profileGalleryGroup = Greenland Regional Profiles
+
 [profilesArcticOceanRegions]
 ## options related to plotting vertical profiles Antarctic regions
 
@@ -311,6 +359,39 @@ profileGalleryGroup = Antarctic Regional Profiles
 
 # the names of region groups to plot, each with its own section below
 regionGroups = ['Arctic Ocean Regions', 'Antarctic Regions']
+
+
+[hovmollerGreenlandRegions]
+## options related to plotting Hovmoller diagrams of Arctic Ocean Regions
+
+# a list of dictionaries for each field to plot.  The dictionary includes
+# prefix (used for file names, task names and sections) as well as the MPAS
+# name of the field, units for colorbars and a the name as it should appear
+# in figure titles and captions.
+fields =
+    [{'prefix': 'potentialTemperature',
+      'mpas': 'timeMonthly_avg_activeTracers_temperature',
+      'units': r'$$\degree$$C',
+      'titleName': 'Potential Temperature'},
+     {'prefix': 'salinity',
+      'mpas': 'timeMonthly_avg_activeTracers_salinity',
+      'units': r'PSU',
+      'titleName': 'Salinity'},
+     {'prefix': 'potentialDensity',
+      'mpas': 'timeMonthly_avg_potentialDensity',
+      'units': r'kg m$$^{-3}$$',
+      'titleName': 'Potential Density'}]
+
+# a list of region names from the region masks file to plot
+regionNames = ['all']
+
+# whether to compute an anomaly with respect to the start of the time series
+computeAnomaly = False
+
+# Number of points over which to compute moving average(e.g., for monthly
+# output, movingAveragePoints=12 corresponds to a 12-month moving average
+# window)
+movingAveragePoints = 12
 
 
 [hovmollerArcticOceanRegions]

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -40,7 +40,8 @@ normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
 ## options related to plotting T/S diagrams of ocean regions
 
 # the names of region groups to plot, each with its own section below
-regionGroups = ['Antarctic Regions', 'Arctic Ocean Regions', 'Ocean Basins']
+regionGroups = ['Ocean Basins', 'Arctic Ocean Regions', 
+                'Greenland Regions', 'Antarctic Regions']
 
 [TSDiagramsForGreenlandRegions]
 ## options related to plotting T/S diagrams of Greenland regions
@@ -239,7 +240,7 @@ colorbarLevelsDifference = [-0.5, -0.2, -0.1, -0.05, -0.02, 0,  0.02, 0.05,
 ## options related to plotting vertical profiles of regional means (and
 ## variability) of 3D MPAS fields
 
-regionGroups = ['Arctic Ocean Regions', 'Antarctic Regions']
+regionGroups = ['Arctic Ocean Regions', 'Greenland Regions', 'Antarctic Regions']
 
 
 [profilesGreenlandRegions]
@@ -358,7 +359,7 @@ profileGalleryGroup = Antarctic Regional Profiles
 ## regional means of 3D MPAS fields
 
 # the names of region groups to plot, each with its own section below
-regionGroups = ['Arctic Ocean Regions', 'Antarctic Regions']
+regionGroups = ['Arctic Ocean Regions', 'Greenland Regions', 'Antarctic Regions']
 
 
 [hovmollerGreenlandRegions]

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -43,7 +43,7 @@ normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
 regionGroups = ['Antarctic Regions', 'Arctic Ocean Regions', 'Ocean Basins']
 
 [TSDiagramsForGreenlandRegions]
-## options related to plotting T/S diagrams of Antarctic regions
+## options related to plotting T/S diagrams of Greenland regions
 
 # list of regions to plot or ['all'] for all regions in the masks file.
 # See "regionNames" in the antarcticRegions masks file in


### PR DESCRIPTION
Adds a default config section for Greenland regional TS Diagrams, hovmoller plots, and regional profiles. All new plots are off by default.

The option to designate 'all' regions in a regionGroup was added to the regional ocean profiles task.