### PR TITLE
Fix masking of remapped MPAS climatology maps

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - mpas_tools >=0.30.0
     - nco >=4.8.1,!=5.2.6
     - netcdf4
-    - numpy
+    - numpy <2.0
     - pandas
     - pillow >=10.0.0,<11.0.0
     - progressbar2

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - mache >=1.11.0
     - matplotlib-base >=3.6.0,!=3.7.2
     - mpas_tools >=0.30.0
-    - nco >=4.8.1
+    - nco >=4.8.1,!=5.2.6
     - netcdf4
     - numpy
     - pandas

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -19,7 +19,7 @@ mache >=1.11.0
 # https://github.com/matplotlib/matplotlib/pull/26291
 matplotlib-base>=3.6.0,!=3.7.2
 mpas_tools>=0.30.0
-nco>=4.8.1
+nco>=4.8.1,!=5.2.6
 netcdf4
 numpy
 pandas

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -21,7 +21,7 @@ matplotlib-base>=3.6.0,!=3.7.2
 mpas_tools>=0.30.0
 nco>=4.8.1,!=5.2.6
 netcdf4
-numpy
+numpy<2.0
 pandas
 pillow >=10.0.0,<11.0.0
 progressbar2

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -600,16 +600,16 @@ class RemapMpasClimatologySubtask(AnalysisTask):
             parallel_exec = None
 
         if self.useNcremap:
+            basename, ext = os.path.splitext(outFileName)
+            ncremapFilename = f'{basename}_ncremap{ext}'
             remapper.remap_file(inFileName=inFileName,
-                                outFileName=outFileName,
+                                outFileName=ncremapFilename,
                                 overwrite=True,
                                 renormalize=renormalizationThreshold,
                                 logger=self.logger,
                                 parallel_exec=parallel_exec)
 
-            remappedClimatology = xr.open_dataset(outFileName)
-            remappedClimatology.load()
-            remappedClimatology.close()
+            remappedClimatology = xr.open_dataset(ncremapFilename)
         else:
 
             climatologyDataSet = xr.open_dataset(inFileName)


### PR DESCRIPTION
This PR skips NCO 5.2.6, which seems to have an issue in which `ncremap` is not producing the desired `_FillValue` attribute even when requested with the `--add_fill_value` flag.

This PR also restricts `numpy < 2.0` for now, since it appears that the MPAS-Tools function `write_netcdf()` is not compatible and an updated version of MPAS-Tools is not yet available to fix this.

fixes #1008 
