### PR TITLE
Fix `cm.get_cmap()` calls

### DIFF
--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -19,7 +19,7 @@ observations or reference data.
 import xarray as xr
 import numpy
 from matplotlib import colors
-from matplotlib import cm
+import matplotlib.pyplot as plt
 
 from geometric_features import FeatureCollection
 
@@ -860,7 +860,7 @@ class PlotTransectSubtask(AnalysisTask):
     def _get_contour_colormap():
         # https://stackoverflow.com/a/18926541/7728169
 
-        cmap = cm.get_cmap('hot')
+        cmap = plt.get_cmap('hot')
         cmap = colors.LinearSegmentedColormap.from_list(
             f'trunc_{cmap.name}', cmap(numpy.linspace(0.1, 0.85, 100)))
 

--- a/mpas_analysis/shared/plot/colormap.py
+++ b/mpas_analysis/shared/plot/colormap.py
@@ -296,7 +296,7 @@ def register_custom_colormaps():
 
     name = 'white_cmo_deep'
     # modify cmo.deep to start at white
-    colors2 = plt.cm.get_cmap('cmo.deep')(np.linspace(0, 1, 224))
+    colors2 = plt.get_cmap('cmo.deep')(np.linspace(0, 1, 224))
     colorCount = 32
     colors1 = np.ones((colorCount, 4), float)
     x = np.linspace(0., 1., colorCount+1)[0:-1]


### PR DESCRIPTION
The `matplotlib.cm.get_cmap()` function no longer exists and we should use `matplotlib.pyplot.get_cmap()` instead.