### PR TITLE
Fix `numpy.string_` --> `numpy.bytes_`

### DIFF
--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -16,7 +16,7 @@ gsw
 lxml
 mache >=1.11.0
 matplotlib-base>=3.9.0
-mpas_tools>=0.34.0
+mpas_tools>=0.34.1
 nco>=4.8.1,!=5.2.6
 netcdf4
 numpy>=2.0,<3.0

--- a/mpas_analysis/shared/io/utility.py
+++ b/mpas_analysis/shared/io/utility.py
@@ -353,7 +353,7 @@ def decode_strings(da):
     # -------
     # Xylar Asay-Davis
 
-    if da.dtype.type is numpy.string_:
+    if da.dtype.type is numpy.bytes_:
         strings = [bytes.decode(name) for name in da.values]
     else:
         strings = [name for name in da.values]


### PR DESCRIPTION
This got missed in #1011.

This merge also updates the constraint on `mpas_tools` to `>=0.34.1` to bring in some matplotlib fixes.