### PR TITLE
Bug fixes for time series conservation task

### DIFF
--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -331,6 +331,10 @@ fitColor1 = tab:blue
 #    land_ice_mass_flux_components : Mass fluxes from land ice
 plotTypes = ['absolute_energy_error', 'absolute_salt_error', 'total_mass_change']
 
+# Number of points over which to compute moving average(e.g., for monthly
+# output, movingAveragePoints=12 corresponds to a 12-month moving average
+# window)
+movingAveragePoints = 365
 
 [index]
 ## options related to producing nino index.

--- a/mpas_analysis/ocean/conservation.py
+++ b/mpas_analysis/ocean/conservation.py
@@ -468,9 +468,11 @@ class ConservationTask(AnalysisTask):
                 lineStyles.append(lineStylesBase[index])
 
         lineWidths = [3 for i in fields]
-        if config.has_option('timeSeries', 'movingAveragePoints'):
-            movingAveragePoints = config.getint('timeSeries',
-                                                'movingAveragePoints')
+        if config.has_option('timeSeriesConservation', 'movingAveragePoints'):
+            # We assume here that movingAveragePoints is given in months
+            # and conservation output has daily frequency
+            movingAveragePoints = \
+                config.getint('timeSeriesConservation', 'movingAveragePoints')
         else:
             movingAveragePoints = None
 

--- a/mpas_analysis/shared/io/mpas_reader.py
+++ b/mpas_analysis/shared/io/mpas_reader.py
@@ -195,7 +195,8 @@ def _parse_dataset_time(ds, inTimeVariableName, calendar,
         timeStrings = [''.join(xtime.astype('U')).strip()
                        for xtime in timeVar.values]
         for i, timeString in enumerate(timeStrings):
-             if timeString[8:] == '15_00:00:00' and i +1 < len(timeStrings):
+             if timeString == '0000-01-15_00:00:00' and \
+                     i + 1 < len(timeStrings):
                  timeStrings[i] = f'{timeStrings[i + 1][:7]}-01_00:00:00'
         days = string_to_days_since_date(dateString=timeStrings,
                                          referenceDate=referenceDate,

--- a/suite/setup.py
+++ b/suite/setup.py
@@ -54,7 +54,7 @@ def main():
         simulation = '20200305.A_WCYCL1850.ne4_oQU480.anvil'
         mesh = 'QU480'
     else:
-        simulation = '20230406.GMPAS-IAF-ISMF.T62_oQU240wLI.chrysalis'
+        simulation = '20240718.GMPAS-IAF-PISMF.T62_oQU240wLI.chrysalis'
         mesh = 'oQU240wLI'
     if machine in ['anvil', 'chrysalis']:
         input_base = '/lcrc/group/e3sm/public_html/diagnostics/mpas_analysis/example_simulations'


### PR DESCRIPTION
Since we have changed the output frequency for the conservation AM to daily https://github.com/E3SM-Project/E3SM/pull/6412, I have noticed that this causes a bug with time averaging. The time averaging config option `movingAveragePoints` assumes that the output frequency for all the time series tasks is the same. This PR introduces a factor of 30 to `movingAveragePoints` for the conservation task and fixes an issue with the time string correction for restarts.