### PR TITLE
Switch from WOA18 to WOA23

### DIFF
--- a/docs/users_guide/tasks/climatologyMapWoa.rst
+++ b/docs/users_guide/tasks/climatologyMapWoa.rst
@@ -4,7 +4,7 @@ climatologyMapWoa
 =================
 
 An analysis task for comparing potential temperature and salinity
-at various depths against WOA18 climatology.
+at various depths against WOA23 climatology.
 
 Component and Tags::
 
@@ -40,7 +40,7 @@ The following configuration options are available for this task::
   [climatologyMapWoaTemperature]
   ## options related to plotting climatology maps of potential temperature
   ## at various levels, including the sea floor against control model results
-  ## and WOA18 climatological data
+  ## and WOA23 climatological data
 
   # colormap for model/observations
   colormapNameResult = RdYlBu_r
@@ -66,8 +66,8 @@ The following configuration options are available for this task::
 
   [climatologyMapWoaSalinity]
   ## options related to plotting climatology maps of salinity
-  ## at various levels, including the sea floor against control model results 
-  ## and WOA18 climatological data
+  ## at various levels, including the sea floor against control model results
+  ## and WOA23 climatological data
 
   # colormap for model/observations
   colormapNameResult = haline
@@ -98,14 +98,14 @@ For more details, see:
 
 The option ``depths`` is a list of (approximate) depths at which to sample
 the temperature and salinity fields.  A value of ``'top'`` indicates the sea
-surface. Note that, for the annual climatology, WOA18 data is available down
-to 5500 m, whereas, for the seasonal or monthly climatologies, WOA18 data
+surface. Note that, for the annual climatology, WOA23 data is available down
+to 5500 m, whereas, for the seasonal or monthly climatologies, WOA23 data
 is only available down to 1500 m.
 
 Observations
 ------------
 
-:ref:`woa18_t_s`
+:ref:`woa23_t_s`
 
 Example Result
 --------------

--- a/docs/users_guide/tasks/regionalTSDiagrams.rst
+++ b/docs/users_guide/tasks/regionalTSDiagrams.rst
@@ -80,7 +80,7 @@ The following configuration options are available for this task:
     # volMax = 1e12
 
     # Obserational data sets to compare against
-    obs = ['SOSE', 'WOA18']
+    obs = ['SOSE', 'WOA23']
 
     [TSDiagramsForOceanBasins]
     ## options related to plotting T/S diagrams of major ocean basins
@@ -119,7 +119,7 @@ The following configuration options are available for this task:
     zmax = 0
 
     # Obserational data sets to compare against
-    obs = ['WOA18']
+    obs = ['WOA23']
 
 Similar config sections are included for other region groups.
 
@@ -193,11 +193,11 @@ default is to read them from geojson file.
 Observations
 ------------
 The ``obs`` option contains a list of the names of observational data sets.
-Currently, "SOSE" and "WOA18" are the only data sets available, but we
+Currently, "SOSE" and "WOA23" are the only data sets available, but we
 anticipate adding several additional data sets in the near future.
 
 :ref:`sose`
-:ref:`woa18_t_s`
+:ref:`woa23_t_s`
 
 Other Config Options
 --------------------

--- a/docs/users_guide/tasks/timeSeriesOceanRegions.rst
+++ b/docs/users_guide/tasks/timeSeriesOceanRegions.rst
@@ -58,7 +58,7 @@ The following configuration options are available for this task:
     # zmax = -400
 
     # Observational data sets to compare against
-    obs = ['SOSE', 'WOA18']
+    obs = ['SOSE', 'WOA23']
 
 Region Groups
 -------------
@@ -121,12 +121,12 @@ Observations
 ------------
 
 ``obs`` is a list of the observational data sets to plot as reference lines
-(constant in time).  Possible values are ``'SOSE'`` and ``'WOA18'``.  An empty
+(constant in time).  Possible values are ``'SOSE'`` and ``'WOA23'``.  An empty
 list can be provided if no observations should be plotted.
 
 :ref:`sose`
 
-:ref:`woa18_t_s`
+:ref:`woa23_t_s`
 
 Example Result
 --------------

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -517,7 +517,7 @@ meltSubdirectory = Melt
 soseSubdirectory = SOSE
 sshSubdirectory = SSH
 argoSubdirectory = ARGO
-woa18Subdirectory = WOA18
+woa23Subdirectory = WOA23
 schmidtkoSubdirectory = Schmidtko
 woceSubdirectory = WOCE
 no3Subdirectory = BGC/NO3
@@ -1716,7 +1716,7 @@ zmin = -1000
 zmax = 0
 
 # Observational data sets to compare against
-obs = ['WOA18']
+obs = ['WOA23']
 
 
 [timeSeriesAntarcticRegions]
@@ -1758,7 +1758,7 @@ variables = [{'name': 'temperature',
 # zmax = -400
 
 # Observational data sets to compare against
-obs = ['SOSE', 'WOA18']
+obs = ['SOSE', 'WOA23']
 
 
 [timeSeriesTransport]
@@ -1874,7 +1874,7 @@ normType = log
 # volMax = 1e12
 
 # Obserational data sets to compare against
-obs = ['SOSE', 'WOA18']
+obs = ['SOSE', 'WOA23']
 
 [TSDiagramsForGreenlandRegions]
 ## options related to plotting T/S diagrams of Greenland regions
@@ -1917,7 +1917,7 @@ zmax = 0
 #volMax = 1e12
 
 # Obserational data sets to compare against
-obs = ['WOA18']
+obs = ['WOA23']
 
 [TSDiagramsForArcticOceanRegions]
 ## options related to plotting T/S diagrams of Arctic regions
@@ -1960,7 +1960,7 @@ zmax = 0
 #volMax = 1e12
 
 # Obserational data sets to compare against
-obs = ['WOA18']
+obs = ['WOA23']
 
 [TSDiagramsForOceanBasins]
 ## options related to plotting T/S diagrams of major ocean basins
@@ -1999,7 +1999,7 @@ zmin = -1000
 zmax = 0
 
 # Obserational data sets to compare against
-obs = ['WOA18']
+obs = ['WOA23']
 
 
 [climatologyMapVel]
@@ -2463,7 +2463,7 @@ shallowVsDeepColormapDepth = -1000
 [climatologyMapWoaTemperatureShallow]
 ## options related to plotting climatology maps of potential temperature
 ## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
+## and WOA23 climatological data
 
 # colormap for model/observations
 colormapNameResult = RdYlBu_r
@@ -2490,7 +2490,7 @@ normArgsDifference = {'vmin': -5., 'vmax': 5.}
 [climatologyMapWoaTemperatureDeep]
 ## options related to plotting climatology maps of potential temperature
 ## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
+## and WOA23 climatological data
 
 # colormap for model/observations
 colormapNameResult = RdYlBu_r
@@ -2518,7 +2518,7 @@ normArgsDifference = {'vmin': -2., 'vmax': 2.}
 [climatologyMapWoaSalinityShallow]
 ## options related to plotting climatology maps of salinity
 ## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
+## and WOA23 climatological data
 
 # colormap for model/observations
 colormapNameResult = haline
@@ -2545,7 +2545,7 @@ normArgsDifference = {'vmin': -1.5, 'vmax': 1.5}
 [climatologyMapWoaSalinityDeep]
 ## options related to plotting climatology maps of salinity
 ## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
+## and WOA23 climatological data
 
 # colormap for model/observations
 colormapNameResult = haline

--- a/mpas_analysis/obs/observational_datasets.xml
+++ b/mpas_analysis/obs/observational_datasets.xml
@@ -190,6 +190,73 @@
 
   <observation>
     <name>
+      WOA23 Temperature and Salinity Climatology
+    </name>
+    <component>
+      ocean
+    </component>
+    <description>
+      The World Ocean Atlas 2023 (WOA23) was released on February 14, 2024 and
+      includes temperature, salinity, oxygen (and parameters Apparent Oxygen
+      Utilization and percent oxygen saturation) and inorganic nutrients
+      (phosphate, silicate, and nitrate). WOA23 includes approximately 1.8
+      million new oceanographic casts added to the WOD since WOA18’s release,
+      as well as renewed and updated quality controls.
+    </description>
+    <source>
+      [NOAA National Centers for Environmental Information (NCEI) website]
+      (https://www.ncei.noaa.gov/products/world-ocean-atlas)
+    </source>
+    <releasePolicy>
+      These data are openly available to the public. Please acknowledge the
+      use of these data with the text given in the acknowledgment attribute.
+    </releasePolicy>
+    <references>
+      - [Locarnini et al. (2024)](https://repository.library.noaa.gov/view/noaa/60599)
+      - [Reagan et al. (2024)](https://repository.library.noaa.gov/view/noaa/60600)
+    </references>
+    <bibtex>
+      @manual{locarnini_world_nodate,
+      title = {World Ocean Atlas 2023, Volume 1: Temperature},
+      url = {https://repository.library.noaa.gov/view/noaa/60599},
+      shorttitle = {World Ocean Atlas 2023, Volume 1},
+      year = {2024},
+      author = {Locarnini, Ricardo A. and Mishonov, Alexey V. and Baranova,
+      Olga K. and Reagan, James R. and Boyer, Timothy P. and Seidov, Dan and
+      Wang, Zhankun and Garcia, Hernan E. and Bouchard, Courtney and Cross,
+      Scott L. and Paver, Christopher R. and Dukhovskoy, Dmitry},
+      }
+
+      @manual{reagan_world_nodate,
+      title = {World Ocean Atlas 2023, Volume 2: Salinity},
+      url = {https://repository.library.noaa.gov/view/noaa/60600},
+      shorttitle = {World Ocean Atlas 2023, Volume 2},
+      author = {Reagan, James R. and Seidov, Dan and Wang, Zhankun and
+      Dukhovskoy, Dmitry and Boyer, Timothy P. and Locarnini, Ricardo A. and
+      Baranova, Olga K. and Mishonov, Alexey V. and Garcia, Hernan E. and
+      Bouchard, Courtney and Cross, Scott L. and Paver, Christopher R.},
+      year = {2024},
+      }
+    </bibtex>
+    <dataUrls>
+      - https://www.ncei.noaa.gov/access/world-ocean-atlas-2023/
+    </dataUrls>
+    <preprocessing>
+      - preprocess_observations/preprocess_woa23.py
+    </preprocessing>
+    <tasks>
+      - climatologyMapWoa
+    </tasks>
+    <subdirectory>
+      Ocean/WOA23
+    </subdirectory>
+    <nameInDocs>
+      woa23_t_s
+    </nameInDocs>
+  </observation>
+
+  <observation>
+    <name>
       AVISO Absolute Dynamic Topography
     </name>
     <component>

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -22,7 +22,7 @@ depths = ['top', -50, -200, -400, -600, -800]
 [climatologyMapWoaTemperature]
 ## options related to plotting climatology maps of potential temperature
 ## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
+## and WOA23 climatological data
 
 # A dictionary with keywords for the norm
 normArgsResult = {'vmin': -2., 'vmax': 2.}
@@ -30,7 +30,7 @@ normArgsResult = {'vmin': -2., 'vmax': 2.}
 [climatologyMapWoaSalinity]
 ## options related to plotting climatology maps of salinity
 ## at various levels, including the sea floor against control model results
-## and WOA18 climatological data
+## and WOA23 climatological data
 
 # A dictionary with keywords for the norm
 normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
@@ -40,7 +40,7 @@ normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
 ## options related to plotting T/S diagrams of ocean regions
 
 # the names of region groups to plot, each with its own section below
-regionGroups = ['Ocean Basins', 'Arctic Ocean Regions', 
+regionGroups = ['Ocean Basins', 'Arctic Ocean Regions',
                 'Greenland Regions', 'Antarctic Regions']
 
 [TSDiagramsForGreenlandRegions]

--- a/mpas_analysis/shared/climatology/remap_observed_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_observed_climatology_subtask.py
@@ -159,8 +159,7 @@ class RemapObservedClimatologySubtask(AnalysisTask):
                         stage='climatology',
                         season=season,
                         comparisonGridName=comparisonGridName)
-                    if 'month' in ds.variables.keys() and \
-                            'year' in ds.variables.keys():
+                    if 'month' in ds.coords and 'year' in ds.coords:
                         # this data set is not yet a climatology, so compute
                         # the climatology
                         monthValues = constants.monthDictionary[season]
@@ -171,7 +170,8 @@ class RemapObservedClimatologySubtask(AnalysisTask):
                         # climatology so assume this already is one
                         seasonalClimatology = ds
 
-                    write_netcdf_with_fill(seasonalClimatology, climatologyFileName)
+                    write_netcdf_with_fill(seasonalClimatology,
+                                           climatologyFileName)
 
                     remapper = self.remappers[comparisonGridName]
 

--- a/preprocess_observations/preprocess_woa23.py
+++ b/preprocess_observations/preprocess_woa23.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python
+import os
+from datetime import datetime
+
+import gsw
+import numpy as np
+import xarray as xr
+from mpas_analysis.shared.climatology import compute_climatology
+from mpas_analysis.shared.constants import constants
+from mpas_analysis.shared.io.download import download_files
+from mpas_analysis.shared.io import write_netcdf
+from mpas_tools.cime.constants import constants as cime_constants
+
+
+def download_woa():
+    """
+    Download 0.25 degree WOA23 annual and monthly files
+    """
+    base_url = \
+        'https://www.ncei.noaa.gov/thredds-ocean/fileServer/woa23/DATA'
+
+    for field in ['temperature', 'salinity']:
+        for index in range(13):
+            woa_filename = f'woa23_decav91C0_{field[0]}{index:02d}_04.nc'
+            woa_url = f'{base_url}/{field}/netcdf/decav91C0/0.25/'
+
+            if os.path.exists(woa_filename):
+                continue
+
+            download_files(fileList=[woa_filename],
+                           urlBase=woa_url,
+                           outDir='.')
+
+
+def combine():
+    """
+    Run this step of the test case
+    """
+    now = datetime.now()
+    datestring = now.strftime("%Y%m%d")
+    out_filename = f'woa23_decav_04_pt_s_mon_ann.{datestring}.nc'
+    if os.path.exists(out_filename):
+        return
+
+    ds_ann = xr.open_dataset('woa23_decav91C0_t00_04.nc', decode_times=False)
+
+    ds_out = xr.Dataset()
+
+    for var in ['lon', 'lat', 'depth']:
+        ds_out[var] = ds_ann[var]
+        ds_out[f'{var}_bnds'] = ds_ann[f'{var}_bnds']
+
+    for field in ['temperature', 'salinity']:
+        var = f'{field[0]}_an'
+        ann_filename = f'woa23_decav91C0_{field[0]}00_04.nc'
+        ds_ann = xr.open_dataset(
+            ann_filename, decode_times=False).isel(time=0).drop_vars('time')
+
+        time_slices = []
+        for month in range(1, 13):
+            depth_slices = []
+            ds_month = xr.open_dataset(
+                f'woa23_decav91C0_{field[0]}{month:02d}_04.nc',
+                decode_times=False).isel(time=0).drop_vars('time')
+            for depth_index in range(ds_ann.sizes['depth']):
+                if depth_index < ds_month.sizes['depth']:
+                    ds = ds_month
+                else:
+                    ds = ds_ann
+                depth_slices.append(ds[var].isel(depth=depth_index))
+
+            da_month = xr.concat(depth_slices, dim='depth')
+            print(month, da_month)
+            time_slices.append(da_month)
+
+        ds_out[var] = xr.concat(time_slices, dim='time')
+        ds_out[var] = ds_out[var].transpose('time', 'lat', 'lon', 'depth')
+        ds_out[var].attrs = ds_ann[var].attrs
+
+    ds_out['month'] = ('time', np.arange(1, 13))
+    ds_out = _temp_to_pot_temp(ds_out)
+    ds_out.to_netcdf(out_filename)
+
+
+def compute_obs_ts_climatology(season):
+    """
+    season : str
+        The season over which to compute the climatology
+    """
+    now = datetime.now()
+    datestring = now.strftime("%Y%m%d")
+
+    in_filename = f'woa23_decav_04_pt_s_mon_ann.{datestring}.nc'
+    out_filename = f'woa23_{season}_decav_04_pt_s_z_vol.{datestring}.nc'
+
+    if os.path.exists(out_filename):
+        return
+
+    print("\n computing T S climatogy for WOA23...")
+
+    print(f'  Reading from {in_filename}...')
+    ds = xr.open_dataset(in_filename)
+
+    # compute volume from lat, lon, depth bounds
+    print('  Computing volume...')
+    lat_bnds = ds['lat_bnds']
+    lon_bnds = ds['lon_bnds']
+    depth_bnds = ds['depth_bnds']
+    dlat = np.deg2rad(lat_bnds[:, 1] - lat_bnds[:, 0])
+    dlon = np.deg2rad(lon_bnds[:, 1] - lon_bnds[:, 0])
+    lat = np.deg2rad(ds['lat'])
+    dz = depth_bnds[:, 1] - depth_bnds[:, 0]
+    radius = cime_constants['SHR_CONST_REARTH']
+    area = radius**2*np.cos(lat)*dlat*dlon
+    ds['volume'] = dz*area
+
+    ds = ds.rename({'time': 'Time'})
+    ds = ds.set_coords('month')
+    ds.coords['year'] = np.ones(ds.sizes['Time'], int)
+
+    month_values = constants.monthDictionary[season]
+    print('  Computing climatology...')
+    ds = compute_climatology(ds, month_values, maskVaries=True)
+
+    print('  Broadcasting z coordinate...')
+    attrs = ds['depth'].attrs
+    ds['depth'] = -ds['depth']
+    ds['depth'].attrs = attrs
+    ds['depth'].attrs['positive'] = 'up'
+
+    _, _, z = xr.broadcast(ds['pt_an'], ds['s_an'], ds['depth'])
+
+    ds['zBroadcast'] = z
+
+    print(f'  writing {out_filename}...')
+    write_netcdf.write_netcdf_with_fill(ds, out_filename)
+    print('  Done!')
+
+
+def main():
+    download_woa()
+    combine()
+    for season in ['ANN', 'JFM', 'JAS']:
+        compute_obs_ts_climatology(season)
+
+
+def _temp_to_pot_temp(ds):
+    dims = ds.t_an.dims
+
+    slices = list()
+    for depth_index in range(ds.sizes['depth']):
+        temp_slice = ds.t_an.isel(depth=depth_index)
+        in_situ_temp = temp_slice.values
+        salin = ds.s_an.isel(depth=depth_index).values
+        lat = ds.lat.broadcast_like(temp_slice).values
+        lon = ds.lon.broadcast_like(temp_slice).values
+        z = -ds.depth.isel(depth=depth_index).values
+        pressure = gsw.p_from_z(z, lat)
+        mask = np.isfinite(in_situ_temp)
+        SA = gsw.SA_from_SP(salin[mask], pressure[mask], lon[mask],
+                            lat[mask])
+        pot_temp = np.nan * np.ones(in_situ_temp.shape)
+        pot_temp[mask] = gsw.pt_from_t(SA, in_situ_temp[mask],
+                                       pressure[mask], p_ref=0.)
+        pot_temp_slice = xr.DataArray(data=pot_temp, dims=temp_slice.dims,
+                                      attrs=temp_slice.attrs)
+
+        slices.append(pot_temp_slice)
+
+    ds['pt_an'] = xr.concat(slices, dim='depth').transpose(*dims)
+
+    ds.pt_an.attrs['standard_name'] = \
+        'sea_water_potential_temperature'
+    ds.pt_an.attrs['long_name'] = \
+        'Objectively analyzed mean fields for ' \
+        'sea_water_potential_temperature at standard depth levels.'
+
+    ds = ds.drop_vars('t_an')
+    return ds
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This PR adds a preprocessing script for WOA23 and updates 3 analysis tasks, `climatologyMapWoa`, `timeSeriesOceanRegions` and `regionalTSDiagrams`, to use WOA23 instead of WOA18.

The observational database and documentation have also been updated.

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] Documentation has been [built locally](https://mpas-dev.github.io/MPAS-Analysis/latest/users_guide/quick_start.html#generating-documentation) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

