### PR TITLE
Remove the comparison grid name from sea ice gallery groups

### DIFF
--- a/mpas_analysis/sea_ice/climatology_map_berg_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_berg_conc.py
@@ -158,7 +158,8 @@ class ClimatologyMapIcebergConc(AnalysisTask):
                     groupSubtitle=None,
                     groupLink='{}_conc'.format(hemisphere.lower()),
                     galleryName=galleryName,
-                    extend='neither')
+                    extend='neither',
+                    prependComparisonGrid=False)
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/sea_ice/climatology_map_melting.py
+++ b/mpas_analysis/sea_ice/climatology_map_melting.py
@@ -161,7 +161,8 @@ class ClimatologyMapSeaIceMelting(AnalysisTask):
                     groupSubtitle=None,
                     groupLink=f'{hemisphere.lower()}_melting',
                     galleryName=gallery_name,
-                    extend='max')
+                    extend='max',
+                    prependComparisonGrid=False)
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/sea_ice/climatology_map_production.py
+++ b/mpas_analysis/sea_ice/climatology_map_production.py
@@ -161,7 +161,8 @@ class ClimatologyMapSeaIceProduction(AnalysisTask):
                     groupSubtitle=None,
                     groupLink=f'{hemisphere.lower()}_production',
                     galleryName=gallery_name,
-                    extend='max')
+                    extend='max',
+                    prependComparisonGrid=False)
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -184,7 +184,8 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                         galleryName='Observations: SSM/I {}'.format(
                             prefix),
                         maskMinThreshold=minConcentration,
-                        extend='neither')
+                        extend='neither',
+                        prependComparisonGrid=False)
 
                     self.add_subtask(subtask)
 
@@ -230,7 +231,8 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                     groupLink='{}_conc'.format(hemisphere.lower()),
                     galleryName=galleryName,
                     maskMinThreshold=minConcentration,
-                    extend='neither')
+                    extend='neither',
+                    prependComparisonGrid=False)
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -166,7 +166,8 @@ class ClimatologyMapSeaIceThick(AnalysisTask):
                     groupLink=f'{hemisphere.lower()}_thick',
                     galleryName=galleryName,
                     maskMinThreshold=0,
-                    extend='neither')
+                    extend='neither',
+                    prependComparisonGrid=False)
 
                 self.add_subtask(subtask)
 

--- a/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
+++ b/mpas_analysis/shared/plot/plot_climatology_map_subtask.py
@@ -219,13 +219,15 @@ class PlotClimatologyMapSubtask(AnalysisTask):
         self.maskMinThreshold = None
         self.maskMaxThreshold = None
         self.extend = 'both'
+        self.prependComparisonGrid = None
 
     def set_plot_info(self, outFileLabel, fieldNameInTitle, mpasFieldName,
                       refFieldName, refTitleLabel, unitsLabel,
                       imageCaption, galleryGroup, groupSubtitle, groupLink,
                       galleryName, diffTitleLabel='Model - Observations',
                       configSectionName=None, maskMinThreshold=None,
-                      maskMaxThreshold=None, extend=None):
+                      maskMaxThreshold=None, extend=None,
+                      prependComparisonGrid=True):
         """
         Store attributes related to plots, plot file names and HTML output.
 
@@ -282,7 +284,11 @@ class PlotClimatologyMapSubtask(AnalysisTask):
 
         extend : {'neither', 'both', 'min', 'max'}, optional
             Determines the ``contourf``-coloring of values that are outside the
-            range of the levels provided if using an indexed colormap.
+            range of the levels provided if using an indexed colormap
+
+        prependComparisonGrid : bool, optional
+            Whether to prepend the name of the comparison grid to the gallery
+            group
         """
 
         self.outFileLabel = outFileLabel
@@ -324,6 +330,8 @@ class PlotClimatologyMapSubtask(AnalysisTask):
 
         if extend is not None:
             self.extend = extend
+
+        self.prependComparisonGrid = prependComparisonGrid
 
     def setup_and_check(self):
         """
@@ -647,14 +655,19 @@ class PlotClimatologyMapSubtask(AnalysisTask):
             vertical=vertical,
             extend=self.extend)
 
-        upperGridName = capwords(comparisonGridName.replace('_', ' '))
+        if self.prependComparisonGrid:
+            upperGridName = capwords(comparisonGridName.replace('_', ' '))
+            galleryGroup = f'{upperGridName} {self.galleryGroup}'
+        else:
+            galleryGroup = self.galleryGroup
+
         caption = f'{season} {self.imageCaption}'
         write_image_xml(
             config,
             filePrefix,
             componentName=componentName,
             componentSubdirectory=componentSubdirectory,
-            galleryGroup=f'{upperGridName} {self.galleryGroup}',
+            galleryGroup=galleryGroup,
             groupSubtitle=self.groupSubtitle,
             groupLink=f'{comparisonGridName}_{self.groupLink}',
             gallery=self.galleryName,


### PR DESCRIPTION
The comparison grid name is confusing and redundant.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

