### PR TITLE
Rename Greenland Regions --> ISMIP6 Greenland Regions

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - esmf >=8.4.2,<8.7.0
     - esmf=*=mpi_mpich_*
     - f90nml
-    - geometric_features >=1.4.0
+    - geometric_features >=1.6.0
     - gsw
     - lxml
     - mache >=1.11.0

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -10,7 +10,7 @@ dask
 esmf >=8.4.2,<8.7.0
 esmf=*=mpi_mpich_*
 f90nml
-geometric_features>=1.4.0
+geometric_features>=1.6.0
 gsw
 lxml
 mache >=1.11.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -189,7 +189,7 @@ intersphinx_mapping = {
     'geometric_features':
         ('http://mpas-dev.github.io/geometric_features/main/', None),
     'mpas_tools':
-        ('http://mpas-dev.github.io/MPAS-Tools/stable/', None)}
+        ('http://mpas-dev.github.io/MPAS-Tools/master/', None)}
 
 
 cwd = os.getcwd()

--- a/docs/users_guide/config/regions.rst
+++ b/docs/users_guide/config/regions.rst
@@ -46,7 +46,7 @@ Several tasks (:ref:`task_hovmollerOceanRegions`, :ref:`task_oceanHistogram`,
 :ref:`task_oceanRegionalProfiles`, :ref:`task_regionalTSDiagrams`, and
 :ref:`task_timeSeriesOceanRegions`) can use any of the defined region groups.
 Currently, available region groups are: ``Artic Ocean Regions``, ``Antarctic Regions``,
-``Greenland Regions``, ``Ocean Basins``, ``Ice Shelves``, and ``Ocean Subbasins``.
+``ISMIP6 Greenland Regions``, ``Ocean Basins``, ``Ice Shelves``, and ``Ocean Subbasins``.
 
 The option ``regionMaskSubdirectory`` in the ``[diagnostics]`` section specifies
 the path to cached mask files for these region groups, typically

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -1877,7 +1877,7 @@ normType = log
 # Obserational data sets to compare against
 obs = ['SOSE', 'WOA23']
 
-[TSDiagramsForGreenlandRegions]
+[TSDiagramsForISMIP6GreenlandRegions]
 ## options related to plotting T/S diagrams of Greenland regions
 
 # list of regions to plot or ['all'] for all regions in the masks file.

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -41,9 +41,9 @@ normArgsResult = {'vmin': 33.8, 'vmax': 35.0}
 
 # the names of region groups to plot, each with its own section below
 regionGroups = ['Ocean Basins', 'Arctic Ocean Regions',
-                'Greenland Regions', 'Antarctic Regions']
+                'ISMIP6 Greenland Regions', 'Antarctic Regions']
 
-[TSDiagramsForGreenlandRegions]
+[TSDiagramsForISMIP6GreenlandRegions]
 ## options related to plotting T/S diagrams of Greenland regions
 
 # list of regions to plot or ['all'] for all regions in the masks file.
@@ -324,10 +324,10 @@ seasons =  ['JFM']
 ## options related to plotting vertical profiles of regional means (and
 ## variability) of 3D MPAS fields
 
-regionGroups = ['Arctic Ocean Regions', 'Greenland Regions', 'Antarctic Regions']
+regionGroups = ['Arctic Ocean Regions', 'ISMIP6 Greenland Regions', 'Antarctic Regions']
 
 
-[profilesGreenlandRegions]
+[profilesISMIP6GreenlandRegions]
 ## options related to plotting vertical profiles Greenland regions
 
 
@@ -452,10 +452,10 @@ profileGalleryGroup = Antarctic Regional Profiles
 ## regional means of 3D MPAS fields
 
 # the names of region groups to plot, each with its own section below
-regionGroups = ['Arctic Ocean Regions', 'Greenland Regions', 'Antarctic Regions']
+regionGroups = ['Arctic Ocean Regions', 'ISMIP6 Greenland Regions', 'Antarctic Regions']
 
 
-[hovmollerGreenlandRegions]
+[hovmollerISMIP6GreenlandRegions]
 ## options related to plotting Hovmoller diagrams of Arctic Ocean Regions
 
 # a list of dictionaries for each field to plot.  The dictionary includes


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge requires geometric_features 1.6.0, where a breaking change was made that renamed Greenland Regions to ISMIP6 Greenland Regions for clarity.  (NASA Greenland Regions were also added.)

This merge also fixes an issue with the docs in which the intersphinx link to MPAS-Tools is corrected (stable --> master).

<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

