### PR TITLE
Cleanup and minor CI bug fixes

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -28,6 +28,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+      fail-fast: false
     steps:
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@master

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     steps:
       - id: skip_check

--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -48,7 +48,7 @@ jobs:
           path: ~/conda_pkgs_dir
           key:
             ${{ runner.os }}-${{ matrix.python-version }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('dev-spec.txt,setup.py') }}
+            hashFiles('dev-spec.txt,pyproject.toml') }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -9,6 +9,9 @@ on:
   release:
     types: [published]
 
+env:
+  PYTHON_VERSION: "3.10"
+
 jobs:
   publish-docs:
     runs-on: ubuntu-latest
@@ -41,14 +44,14 @@ jobs:
           channels: conda-forge
           channel-priority: strict
           auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install mpas_analysis
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
           conda create -n mpas_analysis_dev --file dev-spec.txt \
-            python=${{ matrix.python-version }}
+            python=${{ env.PYTHON_VERSION }}
           conda activate mpas_analysis_dev
           python -m pip install -vv --no-deps --no-build-isolation -e .
 

--- a/ci/python3.9.yaml
+++ b/ci/python3.9.yaml
@@ -1,0 +1,8 @@
+channel_sources:
+- conda-forge,defaults
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,21 +66,6 @@ dependencies = [
     "xarray>=0.14.1"
 ]
 
-[tool.isort]
-multi_line_output = "3"
-include_trailing_comma = true
-force_grid_wrap = "0"
-use_parentheses = true
-line_length = "79"
-
-[tool.mypy]
-python_version = "3.10"
-check_untyped_defs = true
-ignore_missing_imports = true
-warn_unused_ignores = true
-warn_redundant_casts = true
-warn_unused_configs = true
-
 [build-system]
 requires = ["setuptools>=60"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
In this PR, I fixed a few minor issues:
1. The docs CI workflow was trying to reference a nonexistent variable to set the python version. I've changed this to reference a variable local to this file which will have to be manually changed if we want to build the docs in a later version of python (it's currently set to 3.10).
2. The build workflow was being skipped in relation to changes made in the `setup.py` file, but this should have been changed to `pyproject.toml` during #1044  
3. I added the `fail-fast` attribute to the build workflow so that jobs won't cancel other jobs if they fail, which will allow for more precise debugging for different python versions.
4. Some settings related to code linting were added during #1044 and should not have been as we don't have `pre-commit` set up for MPAS-Analysis.
5. We prematurely dropped python 3.9 from CI, so I've added it back.
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

