### PR TITLE
Add `regionNames` coordinate to NetCDF output with "standard" region names

### DIFF
--- a/docs/developers_guide/api.rst
+++ b/docs/developers_guide/api.rst
@@ -94,6 +94,9 @@ Ocean tasks
    WoaTransects
    WoceTransects
 
+Ocean subtasks
+--------------
+
 .. currentmodule:: mpas_analysis.ocean.compute_anomaly_subtask
 
 .. autosummary::
@@ -114,6 +117,19 @@ Ocean tasks
    :toctree: generated/
 
    PlotHovmollerSubtask
+
+
+Ocean utilities
+---------------
+
+.. currentmodule:: mpas_analysis.ocean.utility
+
+.. autosummary::
+   :toctree: generated/
+
+   add_standard_regions_and_subset
+   get_standard_region_names
+   compute_zmid
 
 
 Sea ice tasks

--- a/docs/users_guide/config/regions.rst
+++ b/docs/users_guide/config/regions.rst
@@ -15,10 +15,10 @@ within MPAS-Analysis using region mask files::
 
   # list of region names (needs to be in the same order as region indices in
   # time-series stats)
-  regions = ['arctic', 'equatorial', 'so', 'nino3', 'nino4', 'nino3.4', 'global']
-  # list of plot titles (needs to be in the same order as region indices in
-  # time-series stats)
-  plotTitles = ['Arctic', 'Equatorial (15S-15N)', 'Southern Ocean', 'Nino 3',
+  regionShortNames = ['arctic', 'equatorial', 'so', 'nino3', 'nino4', 'nino3.4',
+                      'global']
+  # list of full names (e.g. for plot titles) same order as regionShortNames
+  regionNames = ['Arctic', 'Equatorial (15S-15N)', 'Southern Ocean', 'Nino 3',
                 'Nino 4', 'Nino 3.4', 'Global Ocean']
 
 

--- a/docs/users_guide/tasks/timeSeriesOHCAnomaly.rst
+++ b/docs/users_guide/tasks/timeSeriesOHCAnomaly.rst
@@ -21,8 +21,8 @@ The following configuration options are available for this task::
   ## options related to plotting time series of ocean heat content (OHC)
   ## anomalies from year 1
 
-  # list of regions to plot from the region list in [regions] below
-  regions = ['global']
+  # list of region shrot names to plot from the region list in [regions] above
+  regionShortNames = ['global']
 
   # approximate depths (m) separating plots of the upper, middle and lower ocean
   depths = [700, 2000]

--- a/docs/users_guide/tasks/timeSeriesSST.rst
+++ b/docs/users_guide/tasks/timeSeriesSST.rst
@@ -20,8 +20,8 @@ The following configuration options are available for this task::
   [timeSeriesSST]
   ## options related to plotting time series of sea surface temperature (SST)
 
-  # list of regions to plot from the region list in [regions] below
-  regions = ['global']
+  # list of region shrot names to plot from the region list in [regions] above
+  regionShortNames = ['global']
 
   # Number of points over which to compute moving average (e.g., for monthly
   # output, movingAveragePoints=12 corresponds to a 12-month moving average

--- a/docs/users_guide/tasks/timeSeriesSalinityAnomaly.rst
+++ b/docs/users_guide/tasks/timeSeriesSalinityAnomaly.rst
@@ -20,8 +20,8 @@ The following configuration options are available for this task::
   [hovmollerSalinityAnomaly]
   ## options related to plotting time series of salinity vs. depth
 
-  # list of regions to plot from the region list in [regions] below
-  regions = ['global']
+  # list of region shrot names to plot from the region list in [regions] above
+  regionShortNames = ['global']
 
   # Number of points over which to compute moving average(e.g., for monthly
   # output, movingAveragePoints=12 corresponds to a 12-month moving average

--- a/docs/users_guide/tasks/timeSeriesTemperatureAnomaly.rst
+++ b/docs/users_guide/tasks/timeSeriesTemperatureAnomaly.rst
@@ -20,8 +20,8 @@ The following configuration options are available for this task::
   [hovmollerTemperatureAnomaly]
   ## options related to plotting time series of potential temperature vs. depth
 
-  # list of regions to plot from the region list in [regions] below
-  regions = ['global']
+  # list of region shrot names to plot from the region list in [regions] above
+  regionShortNames = ['global']
 
   # Number of points over which to compute moving average(e.g., for monthly
   # output, movingAveragePoints=12 corresponds to a 12-month moving average

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -358,11 +358,11 @@ endYear = 20
 
 # list of region names (needs to be in the same order as region indices in
 # time-series stats)
-regions = ['arctic', 'equatorial', 'so', 'nino3', 'nino4', 'nino3.4', 'global']
-# list of plot titles (needs to be in the same order as region indices in
-# time-series stats)
-plotTitles = ['Arctic', 'Equatorial (15S-15N)', 'Southern Ocean', 'Nino 3',
-              'Nino 4', 'Nino 3.4', 'Global Ocean']
+regionShortNames = ['arctic', 'equatorial', 'so', 'nino3', 'nino4', 'nino3.4',
+                    'global']
+# list of full names (e.g. for plot titles) same order as regionShortNames
+regionNames = ['Arctic', 'Equatorial (15S-15N)', 'Southern Ocean', 'Nino 3',
+               'Nino 4', 'Nino 3.4', 'Global Ocean']
 
 
 [plot]
@@ -608,8 +608,8 @@ concentrationAltibergSH = Altiberg/Altiberg_1991-2017_20180308.nc
 ## options related to plotting time series of ocean heat content (OHC)
 ## anomalies from year 1
 
-# list of regions to plot from the region list in [regions] below
-regions = ['global']
+# list of region short names to plot from the region list in [regions] above
+regionShortNames = ['global']
 
 # approximate depths (m) separating plots of the upper, middle and lower ocean
 depths = [700, 2000]
@@ -672,8 +672,8 @@ movingAveragePoints = 12
 [hovmollerTemperatureAnomaly]
 ## options related to plotting time series of potential temperature vs. depth
 
-# list of regions to plot from the region list in [regions] below
-regions = ['global']
+# list of region short names to plot from the region list in [regions] above
+regionShortNames = ['global']
 
 # Number of points over which to compute moving average(e.g., for monthly
 # output, movingAveragePoints=12 corresponds to a 12-month moving average
@@ -706,8 +706,8 @@ contourLevelsResult = np.arange(-5.0, 5.51, 0.5)
 [hovmollerSalinityAnomaly]
 ## options related to plotting time series of salinity vs. depth
 
-# list of regions to plot from the region list in [regions] below
-regions = ['global']
+# list of region short names to plot from the region list in [regions] above
+regionShortNames = ['global']
 
 # Number of points over which to compute moving average(e.g., for monthly
 # output, movingAveragePoints=12 corresponds to a 12-month moving average
@@ -743,7 +743,7 @@ contourLevelsResult = np.arange(-2., 2.01, 0.2)
 ## options related to plotting time series of sea surface temperature (SST)
 
 # list of regions to plot from the region list in [regions] below
-regions = ['global']
+regionShortNames = ['global']
 
 # Number of points over which to compute moving average (e.g., for monthly
 # output, movingAveragePoints=12 corresponds to a 12-month moving average

--- a/mpas_analysis/ocean/compute_anomaly_subtask.py
+++ b/mpas_analysis/ocean/compute_anomaly_subtask.py
@@ -28,6 +28,8 @@ from mpas_analysis.shared.io.utility import build_config_full_path
 from mpas_analysis.shared.time_series import \
     compute_moving_avg_anomaly_from_start
 
+from mpas_analysis.ocean.utility import add_standard_regions_and_subset
+
 
 class ComputeAnomalySubtask(AnalysisTask):
     """
@@ -183,6 +185,9 @@ class ComputeAnomalySubtask(AnalysisTask):
             calendar=self.calendar,
             movingAveragePoints=self.movingAveragePoints,
             alter_dataset=self.alter_dataset)
+
+        if 'nOceanRegions' in ds.dims or 'nOceanRegionsTmp' in ds.dims:
+            ds = add_standard_regions_and_subset(ds, config)
 
         outFileName = self.outFileName
         if not os.path.isabs(outFileName):

--- a/mpas_analysis/ocean/time_series_ohc_anomaly.py
+++ b/mpas_analysis/ocean/time_series_ohc_anomaly.py
@@ -25,6 +25,7 @@ from mpas_analysis.ocean.plot_depth_integrated_time_series_subtask import \
     PlotDepthIntegratedTimeSeriesSubtask
 
 from mpas_analysis.shared.constants import constants as mpas_constants
+from mpas_analysis.ocean.utility import get_standard_region_names
 
 
 class TimeSeriesOHCAnomaly(AnalysisTask):
@@ -63,7 +64,8 @@ class TimeSeriesOHCAnomaly(AnalysisTask):
             tags=['timeSeries', 'ohc', 'publicObs', 'anomaly'])
 
         sectionName = 'timeSeriesOHCAnomaly'
-        regionNames = config.getexpression(sectionName, 'regions')
+        regionShortNames = config.getexpression(sectionName,
+                                                'regionShortNames')
         movingAveragePoints = config.getint(sectionName, 'movingAveragePoints')
 
         self.variableDict = {}
@@ -85,6 +87,7 @@ class TimeSeriesOHCAnomaly(AnalysisTask):
             alter_dataset=self._compute_ohc)
         self.add_subtask(anomalyTask)
 
+        regionNames = get_standard_region_names(config, regionShortNames)
         for regionName in regionNames:
             caption = 'Trend of {} OHC Anomaly vs depth'.format(
                 regionName)
@@ -133,10 +136,6 @@ class TimeSeriesOHCAnomaly(AnalysisTask):
         """
         Compute the OHC time series.
         """
-
-        # regionNames = self.config.getexpression('regions', 'regions')
-        # ds['regionNames'] = ('nOceanRegionsTmp', regionNames)
-
         # for convenience, rename the variables to simpler, shorter names
         ds = ds.rename(self.variableDict)
 

--- a/mpas_analysis/ocean/time_series_salinity_anomaly.py
+++ b/mpas_analysis/ocean/time_series_salinity_anomaly.py
@@ -16,6 +16,8 @@ from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.ocean.compute_anomaly_subtask import ComputeAnomalySubtask
 from mpas_analysis.ocean.plot_hovmoller_subtask import PlotHovmollerSubtask
 
+from mpas_analysis.ocean.utility import get_standard_region_names
+
 
 class TimeSeriesSalinityAnomaly(AnalysisTask):
     """
@@ -50,7 +52,8 @@ class TimeSeriesSalinityAnomaly(AnalysisTask):
             tags=['timeSeries', 'salinity', 'publicObs', 'anomaly'])
 
         sectionName = 'hovmollerSalinityAnomaly'
-        regionNames = config.getexpression(sectionName, 'regions')
+        regionShortNames = config.getexpression(sectionName,
+                                                'regionShortNames')
         movingAveragePoints = config.getint(sectionName, 'movingAveragePoints')
 
         mpasFieldName = 'timeMonthly_avg_avgValueWithinOceanLayerRegion_' \
@@ -66,9 +69,10 @@ class TimeSeriesSalinityAnomaly(AnalysisTask):
             movingAveragePoints=movingAveragePoints)
         self.add_subtask(anomalyTask)
 
+        regionNames = get_standard_region_names(config, regionShortNames)
+
         for regionName in regionNames:
-            caption = 'Trend of {} Salinity Anomaly vs depth'.format(
-                regionName)
+            caption = f'Trend of {regionName} Salinity Anomaly vs depth'
             plotTask = PlotHovmollerSubtask(
                 parentTask=self,
                 regionName=regionName,

--- a/mpas_analysis/ocean/time_series_temperature_anomaly.py
+++ b/mpas_analysis/ocean/time_series_temperature_anomaly.py
@@ -16,6 +16,8 @@ from mpas_analysis.shared import AnalysisTask
 from mpas_analysis.ocean.compute_anomaly_subtask import ComputeAnomalySubtask
 from mpas_analysis.ocean.plot_hovmoller_subtask import PlotHovmollerSubtask
 
+from mpas_analysis.ocean.utility import get_standard_region_names
+
 
 class TimeSeriesTemperatureAnomaly(AnalysisTask):
     """
@@ -50,7 +52,8 @@ class TimeSeriesTemperatureAnomaly(AnalysisTask):
             tags=['timeSeries', 'temperature', 'publicObs', 'anomaly'])
 
         sectionName = 'hovmollerTemperatureAnomaly'
-        regionNames = config.getexpression(sectionName, 'regions')
+        regionShortNames = config.getexpression(sectionName,
+                                                'regionShortNames')
         movingAveragePoints = config.getint(sectionName, 'movingAveragePoints')
 
         mpasFieldName = 'timeMonthly_avg_avgValueWithinOceanLayerRegion_' \
@@ -66,9 +69,11 @@ class TimeSeriesTemperatureAnomaly(AnalysisTask):
             movingAveragePoints=movingAveragePoints)
         self.add_subtask(anomalyTask)
 
+        regionNames = get_standard_region_names(config, regionShortNames)
+
         for regionName in regionNames:
-            caption = 'Trend of {} Potential Temperature Anomaly vs ' \
-                      'Depth'.format(regionName)
+            caption = \
+                f'Trend of {regionName} Potential Temperature Anomaly vs Depth'
             plotTask = PlotHovmollerSubtask(
                 parentTask=self,
                 regionName=regionName,


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Two MPAS-Ocean analysis members use ocean regions that are hard-coded and for which no coordinate array or other metadata is provided.  This merge adds both `regionNames` and `regionShortNames` coordinates to datasets that use these standard regions.  Here, we also rename `nOceanRegionsTmp` to `nOceanRegions` because the `Tmp` suffix is confusing and needless.

All analysis using the hard-coded ocean regions has been updated.  The config option `regions` has been renamed to `regionShortNames` for clarity, and `plotTitle` has been renamed to `regionNames`, since these long names are more rightly the names of the regions.

This should help folks that wish to use the NetCDF output from MPAS-Analysis for their own plots.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [x] Documentation has been [built locally](https://mpas-dev.github.io/MPAS-Analysis/develop/users_guide/quick_start.html#generating-documentation) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #1065
