### PR TITLE
Set `decode_timedelta=False` to avoid future warnings in `xarray.open_dataset()` calls

### DIFF
--- a/mpas_analysis/ocean/conservation.py
+++ b/mpas_analysis/ocean/conservation.py
@@ -13,7 +13,7 @@
 # -------
 # Carolyn Begeman
 
-from distutils.spawn import find_executable
+import shutil
 import numpy as np
 import matplotlib.pyplot as plt
 import os
@@ -565,7 +565,7 @@ class ConservationTask(AnalysisTask):
                 ts_file = ts_files[0]
                 if not os.path.exists(ts_file):
                    raise ValueError(f'Could not find timeMonthlyStats file {ts_file}')
-                var = 'timeMonthly_avg_areaCellGlobal' 
+                var = 'timeMonthly_avg_areaCellGlobal'
                 ds_ts = open_mpas_dataset(fileName=ts_file,
                                           calendar=self.calendar,
                                           variableList=[var])
@@ -615,7 +615,7 @@ class ConservationTask(AnalysisTask):
             If ``ncrcat`` is not in the system path.
         """
 
-        if find_executable('ncrcat') is None:
+        if shutil.which('ncrcat') is None:
             raise OSError('ncrcat not found. Make sure the latest nco '
                           'package is installed: \n'
                           'conda install nco\n'

--- a/mpas_analysis/ocean/meridional_heat_transport.py
+++ b/mpas_analysis/ocean/meridional_heat_transport.py
@@ -213,7 +213,7 @@ class MeridionalHeatTransport(AnalysisTask):
                     raise IOError('At least one file from stream {} is needed '
                                   'to compute MHT'.format(streamName))
 
-                with xr.open_dataset(inputFile) as ds:
+                with xr.open_dataset(inputFile, decode_timedelta=False) as ds:
                     if 'binBoundaryMerHeatTrans' in ds.data_vars:
                         binBoundaryMerHeatTrans = \
                             ds.binBoundaryMerHeatTrans

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -12,7 +12,7 @@
 import xarray
 import os
 import subprocess
-from distutils.spawn import find_executable
+import shutil
 import dask
 import multiprocessing
 from multiprocessing.pool import ThreadPool
@@ -463,7 +463,7 @@ class MpasClimatologyTask(AnalysisTask):
         # -------
         # Xylar Asay-Davis
 
-        if find_executable('ncclimo') is None:
+        if shutil.which('ncclimo') is None:
             raise OSError('ncclimo not found. Make sure the latest nco '
                           'package is installed: \n'
                           'conda install nco\n'

--- a/mpas_analysis/shared/climatology/mpas_climatology_task.py
+++ b/mpas_analysis/shared/climatology/mpas_climatology_task.py
@@ -287,7 +287,8 @@ class MpasClimatologyTask(AnalysisTask):
 
         self.symlinkDirectory = self._create_symlinks()
 
-        with xarray.open_dataset(self.inputFiles[0]) as ds:
+        with xarray.open_dataset(self.inputFiles[0],
+                                 decode_timedelta=False) as ds:
             self.allVariables = list(ds.data_vars.keys())
 
     def run_task(self):

--- a/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
+++ b/mpas_analysis/shared/climatology/remap_mpas_climatology_subtask.py
@@ -237,7 +237,8 @@ class RemapMpasClimatologySubtask(AnalysisTask):
         self.logger.info('\nRemapping climatology {}'.format(
             self.climatologyName))
 
-        dsMask = xr.open_dataset(self.mpasClimatologyTask.inputFiles[0])
+        dsMask = xr.open_dataset(self.mpasClimatologyTask.inputFiles[0],
+                                 decode_timedelta=False)
         dsMask = dsMask[self.variableList]
         iselValues = {'Time': 0}
         if self.iselValues is not None:

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -11,7 +11,7 @@
 
 import os
 import subprocess
-from distutils.spawn import find_executable
+import shutil
 import xarray as xr
 import numpy
 
@@ -237,7 +237,7 @@ class MpasTimeSeriesTask(AnalysisTask):
         Xylar Asay-Davis
         """
 
-        if find_executable('ncrcat') is None:
+        if shutil.which('ncrcat') is None:
             raise OSError('ncrcat not found. Make sure the latest nco '
                           'package is installed: \n'
                           'conda install nco\n'

--- a/mpas_analysis/shared/time_series/mpas_time_series_task.py
+++ b/mpas_analysis/shared/time_series/mpas_time_series_task.py
@@ -203,7 +203,8 @@ class MpasTimeSeriesTask(AnalysisTask):
 
         self.inputFiles = sorted(self.inputFiles)
 
-        with xr.open_dataset(self.inputFiles[0]) as ds:
+        with xr.open_dataset(self.inputFiles[0],
+                             decode_timedelta=False) as ds:
             self.allVariables = list(ds.data_vars.keys())
 
     def run_task(self):

--- a/mpas_analysis/shared/time_series/time_series.py
+++ b/mpas_analysis/shared/time_series/time_series.py
@@ -18,7 +18,7 @@ Utility functions related to time-series data sets
 import xarray as xr
 import numpy
 import os
-from distutils.spawn import find_executable
+import shutil
 import glob
 import subprocess
 
@@ -53,7 +53,7 @@ def combine_time_series_with_ncrcat(inFileNames, outFileName,
     Xylar Asay-Davis
     """
 
-    if find_executable('ncrcat') is None:
+    if shutil.which('ncrcat') is None:
         raise OSError('ncrcat not found. Make sure the latest nco '
                       'package is installed: \n'
                       'conda install nco\n'


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This clean-up PR also switches from `find_executable()` from `distutil` (which is deprecated) with `shutil.which()`.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

