### PR TITLE
Add FRIS comparison grid

### DIFF
--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -262,6 +262,11 @@ comparisonSubpolarNorthAtlanticWidth = 7000.
 comparisonSubpolarNorthAtlanticHeight = 4000.
 comparisonSubpolarNorthAtlanticResolution = 20.
 
+# The comparison FRIS Antarctic polar stereographic grid size and resolution in km
+comparisonFrisBounds = [-1800., -400., 100., 1500.]
+# comparisonFrisWidth = 6000.
+comparisonFrisResolution = 10.
+
 # interpolation order for model and observation results. Likely values are
 #   'bilinear', 'neareststod' (nearest neighbor) or 'conserve'
 mpasInterpolationMethod = bilinear
@@ -492,6 +497,21 @@ lonLines = np.arange(-180., 181., 30.)
 onePanelFigSize = (8, 5)
 threePanelVertFigSize = (8.5, 11)
 threePanelHorizFigSize = (21, 5)
+
+# whether to use the cartopy coastline (as opposed to the model coastline)
+useCartopyCoastline = True
+
+# latitude and longitude grid lines
+latLines = np.arange(-80., 81., 10.)
+lonLines = np.arange(-180., 181., 30.)
+
+[plot_fris]
+## options related to FRIS Antarctic projection plots
+
+# figure sizes for different numbers of panels and layouts
+onePanelFigSize = (8, 8.5)
+threePanelVertFigSize = (8, 22)
+threePanelHorizFigSize = (22, 7.5)
 
 # whether to use the cartopy coastline (as opposed to the model coastline)
 useCartopyCoastline = True

--- a/mpas_analysis/shared/climatology/comparison_descriptors.py
+++ b/mpas_analysis/shared/climatology/comparison_descriptors.py
@@ -34,7 +34,7 @@ def get_comparison_descriptor(config, comparison_grid_name):
         Contains configuration options
 
     comparison_grid_name : {'latlon', 'antarctic', 'arctic', 'north_atlantic',
-                            'north_pacific', 'subpolar_north_atlantic'}
+                            'north_pacific', 'subpolar_north_atlantic', 'fris'}
         The name of the comparison grid to use for remapping.
 
     Raises
@@ -125,7 +125,8 @@ def _get_projection_comparison_descriptor(config, comparison_grid_name):
                        'arctic_extended': 'ArcticExtended',
                        'north_atlantic': 'NorthAtlantic',
                        'north_pacific': 'NorthPacific',
-                       'subpolar_north_atlantic': 'SubpolarNorthAtlantic'}
+                       'subpolar_north_atlantic': 'SubpolarNorthAtlantic',
+                       'fris': 'Fris'}
 
     grid_suffixes = {'antarctic': 'Antarctic_stereo',
                      'arctic': 'Arctic_stereo',
@@ -133,7 +134,8 @@ def _get_projection_comparison_descriptor(config, comparison_grid_name):
                      'arctic_extended': 'Arctic_stereo',
                      'north_atlantic': 'North_Atlantic',
                      'north_pacific': 'North_Pacific',
-                     'subpolar_north_atlantic': 'Subpolar_North_Atlantic'}
+                     'subpolar_north_atlantic': 'Subpolar_North_Atlantic',
+                     'fris': 'Fris'}
 
     if comparison_grid_name not in option_suffixes:
         raise ValueError(f'{comparison_grid_name} is not one of the supported '
@@ -143,23 +145,32 @@ def _get_projection_comparison_descriptor(config, comparison_grid_name):
 
     option_suffix = option_suffixes[comparison_grid_name]
     grid_suffix = grid_suffixes[comparison_grid_name]
-    width = config.getfloat(
-        section, f'comparison{option_suffix}Width')
-    option = f'comparison{option_suffix}Height'
+    option = f'comparison{option_suffix}Bounds'
     if config.has_option(section, option):
-        height = config.getfloat(section, option)
+        bounds = config.getexpression(section, option)
+        bounds = [1e3 * bound for bound in bounds]
     else:
-        height = width
+        width = config.getfloat(
+            section, f'comparison{option_suffix}Width')
+        option = f'comparison{option_suffix}Height'
+
+        if config.has_option(section, option):
+            height = config.getfloat(section, option)
+        else:
+            height = width
+        xmax = 0.5 * width * 1e3
+        ymax = 0.5 * height * 1e3
+        bounds = [-xmax, xmax, -ymax, ymax]
+    width = (bounds[1] - bounds[0]) / 1e3
+    height = (bounds[3] - bounds[2]) / 1e3
     res = config.getfloat(
         section, f'comparison{option_suffix}Resolution')
 
-    xmax = 0.5 * width * 1e3
     nx = int(width / res) + 1
-    x = numpy.linspace(-xmax, xmax, nx)
+    x = numpy.linspace(bounds[0], bounds[1], nx)
 
-    ymax = 0.5 * height * 1e3
     ny = int(height / res) + 1
-    y = numpy.linspace(-ymax, ymax, ny)
+    y = numpy.linspace(bounds[2], bounds[3], ny)
 
     mesh_name = f'{width}x{height}km_{res}km_{grid_suffix}'
     descriptor = ProjectionGridDescriptor.create(projection, x, y, mesh_name)

--- a/mpas_analysis/shared/projection/__init__.py
+++ b/mpas_analysis/shared/projection/__init__.py
@@ -15,7 +15,7 @@ import cartopy
 
 known_comparison_grids = ['latlon', 'antarctic', 'antarctic_extended',
                           'arctic', 'arctic_extended', 'north_atlantic',
-                          'north_pacific', 'subpolar_north_atlantic']
+                          'north_pacific', 'subpolar_north_atlantic', 'fris']
 
 
 def get_pyproj_projection(comparison_grid_name):
@@ -49,7 +49,7 @@ def get_pyproj_projection(comparison_grid_name):
 
     if comparison_grid_name == 'latlon':
         raise ValueError('latlon is not a projection grid.')
-    elif comparison_grid_name in ['antarctic', 'antarctic_extended']:
+    elif comparison_grid_name in ['antarctic', 'antarctic_extended', 'fris']:
         projection = pyproj.Proj(
             '+proj=stere +lat_ts=-71.0 +lat_0=-90 +lon_0=0.0  +k_0=1.0 '
             '+x_0=0.0 +y_0=0.0 +ellps=WGS84')
@@ -105,7 +105,7 @@ def get_cartopy_projection(comparison_grid_name):
     if comparison_grid_name == 'latlon':
         raise ValueError('latlon is not a projection grid.')
 
-    elif comparison_grid_name in ['antarctic', 'antarctic_extended']:
+    elif comparison_grid_name in ['antarctic', 'antarctic_extended', 'fris']:
         projection = cartopy.crs.Stereographic(
             central_latitude=-90., central_longitude=0.0,
             true_scale_latitude=-71.0)

--- a/suite/template.cfg
+++ b/suite/template.cfg
@@ -146,4 +146,4 @@ usePostprocessingScript = True
 
 # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
 comparisonGrids = ['latlon', 'antarctic', 'arctic', 'north_atlantic',
-                   'north_pacific']
+                   'north_pacific', 'fris']


### PR DESCRIPTION
Adds the option to make plots on a grid that focuses on the Filchner-Ronne cavity.

Here is an example bsf plot with that option:
![barotropicStreamfunction_fris_S12_fris_orig_ANN_years0020-0020](https://github.com/user-attachments/assets/5353d365-6f16-42d8-b079-d338748ca3ba)



