### PR TITLE
Set under/over indices for sea ice conc and thickness

### DIFF
--- a/docs/users_guide/tasks/climatologyMapSeaIceConcNH.rst
+++ b/docs/users_guide/tasks/climatologyMapSeaIceConcNH.rst
@@ -18,11 +18,13 @@ The following configuration options are available for this task::
 
   [climatologyMapSeaIceConcNH]
   ## options related to plotting horizontally remapped climatologies of
-  ## sea ice concentration against reference model results and observations
+  ## sea ice concentration against control model results and observations
   ## in the northern hemisphere (NH)
 
   # colormap for model/observations
   colormapNameResult = ice
+  # whether the colormap is indexed or continuous
+  colormapTypeResult = indexed
   # color indices into colormapName for filled contours
   colormapIndicesResult = [20, 80, 110, 140, 170, 200, 230, 255]
   # colormap levels/values for contour boundaries
@@ -30,29 +32,28 @@ The following configuration options are available for this task::
 
   # colormap for differences
   colormapNameDifference = balance
+  # whether the colormap is indexed or continuous
+  colormapTypeDifference = indexed
   # color indices into colormapName for filled contours
-  colormapIndicesDifference = [0, 32, 64, 96, 112, 128, 128, 144, 160, 192,
-                               224, 255]
+  colormapIndicesDifference = [0, 0,  26,  51,  77, 102, 128, 128, 153, 179, 204, 230, 255, 255]
   # colormap levels/values for contour boundaries
-  colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, -0.1, 0, 0.1, 0.2,
-                              0.4, 0.6, 0.8, 1.]
+  colorbarLevelsDifference = [-0.5, -0.4, -0.3, -0.2, -0.1, -0.05, 0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
 
   # Months or seasons to plot (These should be left unchanged, since
   # observations are only available for these seasons)
   seasons =  ['JFM', 'JAS']
 
-  # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-  comparisonGrids = ['latlon']
-
-  # reference lat/lon for sea ice plots in the northern hemisphere
-  minimumLatitude = 50
-  referenceLongitude = 0
+  # comparison grid(s) (typically 'arctic_extended') on which to plot analysis
+  comparisonGrids = ['arctic_extended']
 
   # a list of prefixes describing the sources of the observations to be used
   observationPrefixes = ['NASATeam', 'Bootstrap']
 
   # arrange subplots vertically?
   vertical = False
+
+  # the minimum threshold below which concentration is masked out
+  minConcentration = 0.15
 
   # observations files
   concentrationNASATeamNH_JFM = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_NH_jfm.interp0.5x0.5_20180710.nc

--- a/docs/users_guide/tasks/climatologyMapSeaIceConcSH.rst
+++ b/docs/users_guide/tasks/climatologyMapSeaIceConcSH.rst
@@ -18,11 +18,13 @@ The following configuration options are available for this task::
 
   [climatologyMapSeaIceConcSH]
   ## options related to plotting horizontally remapped climatologies of
-  ## sea ice concentration against reference model results and observations
+  ## sea ice concentration against control model results and observations
   ## in the southern hemisphere (SH)
 
   # colormap for model/observations
   colormapNameResult = ice
+  # whether the colormap is indexed or continuous
+  colormapTypeResult = indexed
   # color indices into colormapName for filled contours
   colormapIndicesResult = [20, 80, 110, 140, 170, 200, 230, 255]
   # colormap levels/values for contour boundaries
@@ -30,29 +32,28 @@ The following configuration options are available for this task::
 
   # colormap for differences
   colormapNameDifference = balance
+  # whether the colormap is indexed or continuous
+  colormapTypeDifference = indexed
   # color indices into colormapName for filled contours
-  colormapIndicesDifference = [0, 32, 64, 96, 112, 128, 128, 144, 160, 192,
-                               224, 255]
+  colormapIndicesDifference = [0, 0,  26,  51,  77, 102, 128, 128, 153, 179, 204, 230, 255, 255]
   # colormap levels/values for contour boundaries
-  colorbarLevelsDifference = [-1., -0.8, -0.6, -0.4, -0.2, -0.1, 0, 0.1, 0.2,
-                              0.4, 0.6, 0.8, 1.]
+  colorbarLevelsDifference = [-0.5, -0.4, -0.3, -0.2, -0.1, -0.05, 0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
 
   # Months or seasons to plot (These should be left unchanged, since
   # observations are only available for these seasons)
   seasons =  ['DJF', 'JJA']
 
-  # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-  comparisonGrids = ['latlon']
-
-  # reference lat/lon for sea ice plots in the northern hemisphere
-  minimumLatitude = -50
-  referenceLongitude = 180
+  # comparison grid(s) (typically 'antarctic_extended') on which to plot analysis
+  comparisonGrids = ['antarctic_extended']
 
   # a list of prefixes describing the sources of the observations to be used
   observationPrefixes = ['NASATeam', 'Bootstrap']
 
   # arrange subplots vertically?
   vertical = False
+
+  # the minimum threshold below which concentration is masked out
+  minConcentration = 0.15
 
   # observations files
   concentrationNASATeamSH_DJF = SSMI/NASATeam_NSIDC0051/SSMI_NASATeam_gridded_concentration_SH_djf.interp0.5x0.5_20180710.nc

--- a/docs/users_guide/tasks/climatologyMapSeaIceThickNH.rst
+++ b/docs/users_guide/tasks/climatologyMapSeaIceThickNH.rst
@@ -19,11 +19,13 @@ The following configuration options are available for this task::
 
   [climatologyMapSeaIceThickNH]
   ## options related to plotting horizontally remapped climatologies of
-  ## sea ice thickness against reference model results and observations
+  ## sea ice thickness against control model results and observations
   ## in the northern hemisphere (NH)
 
   # colormap for model/observations
-  colormapNameResult = ice
+  colormapNameResult = davos
+  # whether the colormap is indexed or continuous
+  colormapTypeResult = indexed
   # color indices into colormapName for filled contours
   colormapIndicesResult = [20, 80, 110, 140, 170, 200, 230, 255]
   # colormap levels/values for contour boundaries
@@ -31,8 +33,10 @@ The following configuration options are available for this task::
 
   # colormap for differences
   colormapNameDifference = balance
+  # whether the colormap is indexed or continuous
+  colormapTypeDifference = indexed
   # color indices into colormapName for filled contours
-  colormapIndicesDifference = [0, 32, 64, 96, 128, 128, 160, 192, 224, 255]
+  colormapIndicesDifference = [0, 0, 32, 64, 96, 128, 128, 160, 192, 223, 255, 255]
   # colormap levels/values for contour boundaries
   colorbarLevelsDifference = [-3., -2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5, 3.]
 
@@ -40,12 +44,8 @@ The following configuration options are available for this task::
   # observations are only available for these seasons)
   seasons =  ['FM', 'ON']
 
-  # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-  comparisonGrids = ['latlon']
-
-  # reference lat/lon for sea ice plots in the northern hemisphere
-  minimumLatitude = 50
-  referenceLongitude = 0
+  # comparison grid(s) (typically 'arctic_extended') on which to plot analysis
+  comparisonGrids = ['arctic_extended']
 
   # a list of prefixes describing the sources of the observations to be used
   observationPrefixes = ['']

--- a/docs/users_guide/tasks/climatologyMapSeaIceThickSH.rst
+++ b/docs/users_guide/tasks/climatologyMapSeaIceThickSH.rst
@@ -19,11 +19,13 @@ The following configuration options are available for this task::
 
   [climatologyMapSeaIceThickSH]
   ## options related to plotting horizontally remapped climatologies of
-  ## sea ice thickness against reference model results and observations
+  ## sea ice thickness against control model results and observations
   ## in the southern hemisphere (SH)
 
   # colormap for model/observations
-  colormapNameResult = ice
+  colormapNameResult = davos
+  # whether the colormap is indexed or continuous
+  colormapTypeResult = indexed
   # color indices into colormapName for filled contours
   colormapIndicesResult = [20, 80, 110, 140, 170, 200, 230, 255]
   # colormap levels/values for contour boundaries
@@ -31,8 +33,10 @@ The following configuration options are available for this task::
 
   # colormap for differences
   colormapNameDifference = balance
+  # whether the colormap is indexed or continuous
+  colormapTypeDifference = indexed
   # color indices into colormapName for filled contours
-  colormapIndicesDifference = [0, 32, 64, 96, 128, 128, 160, 192, 224, 255]
+  colormapIndicesDifference = [0, 0, 32, 64, 96, 128, 128, 160, 192, 223, 255, 255]
   # colormap levels/values for contour boundaries
   colorbarLevelsDifference = [-3., -2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5, 3.]
 
@@ -40,12 +44,8 @@ The following configuration options are available for this task::
   # observations are only available for these seasons)
   seasons =  ['FM', 'ON']
 
-  # comparison grid(s) ('latlon', 'antarctic') on which to plot analysis
-  comparisonGrids = ['latlon']
-
-  # reference lat/lon for sea ice plots in the northern hemisphere
-  minimumLatitude = -50
-  referenceLongitude = 180
+  # comparison grid(s) (typically 'antarctic_extended') on which to plot analysis
+  comparisonGrids = ['antarctic_extended']
 
   # a list of prefixes describing the sources of the observations to be used
   observationPrefixes = ['']

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -4502,7 +4502,7 @@ colormapNameDifference = balance
 # whether the colormap is indexed or continuous
 colormapTypeDifference = indexed
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 32, 64, 96, 112, 128, 128, 144, 160, 192, 224, 255]
+colormapIndicesDifference = [0, 0,  26,  51,  77, 102, 128, 128, 153, 179, 204, 230, 255, 255]
 # colormap levels/values for contour boundaries
 colorbarLevelsDifference = [-0.5, -0.4, -0.3, -0.2, -0.1, -0.05, 0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
 
@@ -4548,7 +4548,7 @@ colormapNameDifference = balance
 # whether the colormap is indexed or continuous
 colormapTypeDifference = indexed
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 32, 64, 96, 112, 128, 128, 144, 160, 192, 224, 255]
+colormapIndicesDifference = [0, 0,  26,  51,  77, 102, 128, 128, 153, 179, 204, 230, 255, 255]
 # colormap levels/values for contour boundaries
 colorbarLevelsDifference = [-0.5, -0.4, -0.3, -0.2, -0.1, -0.05, 0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5]
 
@@ -4594,7 +4594,7 @@ colormapNameDifference = balance
 # whether the colormap is indexed or continuous
 colormapTypeDifference = indexed
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 32, 64, 96, 128, 128, 160, 192, 224, 255]
+colormapIndicesDifference = [0, 0, 32, 64, 96, 128, 128, 160, 192, 223, 255, 255]
 # colormap levels/values for contour boundaries
 colorbarLevelsDifference = [-3., -2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5, 3.]
 
@@ -4635,7 +4635,7 @@ colormapNameDifference = balance
 # whether the colormap is indexed or continuous
 colormapTypeDifference = indexed
 # color indices into colormapName for filled contours
-colormapIndicesDifference = [0, 32, 64, 96, 128, 128, 160, 192, 224, 255]
+colormapIndicesDifference = [0, 0, 32, 64, 96, 128, 128, 160, 192, 223, 255, 255]
 # colormap levels/values for contour boundaries
 colorbarLevelsDifference = [-3., -2.5, -2, -0.5, -0.1, 0, 0.1, 0.5, 2, 2.5, 3.]
 

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_conc.py
@@ -184,7 +184,7 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                         galleryName='Observations: SSM/I {}'.format(
                             prefix),
                         maskMinThreshold=minConcentration,
-                        extend='neither',
+                        extend='both',
                         prependComparisonGrid=False)
 
                     self.add_subtask(subtask)
@@ -231,7 +231,7 @@ class ClimatologyMapSeaIceConc(AnalysisTask):
                     groupLink='{}_conc'.format(hemisphere.lower()),
                     galleryName=galleryName,
                     maskMinThreshold=minConcentration,
-                    extend='neither',
+                    extend='both',
                     prependComparisonGrid=False)
 
                 self.add_subtask(subtask)

--- a/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
+++ b/mpas_analysis/sea_ice/climatology_map_sea_ice_thick.py
@@ -166,7 +166,7 @@ class ClimatologyMapSeaIceThick(AnalysisTask):
                     groupLink=f'{hemisphere.lower()}_thick',
                     galleryName=galleryName,
                     maskMinThreshold=0,
-                    extend='neither',
+                    extend='both',
                     prependComparisonGrid=False)
 
                 self.add_subtask(subtask)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge sets `extend` to `both`, rather than `neither` for difference plots of sea-ice concentration and thickness.  The previous value of `neither` led to plots like this one:
![image](https://github.com/user-attachments/assets/fe3ca35d-8dee-436a-919b-2e0d3cd74e8d)

In this PR have slightly updated the indices into the colormap and explicitly added indices for the unser/over (not necessary but there for clarity).

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] User's Guide has been updated
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->
Fixes #1082 
