### PR TITLE
Fix conservation when list of inputs is empty

### DIFF
--- a/mpas_analysis/ocean/conservation.py
+++ b/mpas_analysis/ocean/conservation.py
@@ -743,6 +743,10 @@ class ConservationTask(AnalysisTask):
 
         append, inputFiles = self._check_output_safe_to_append(variable_list)
 
+        if len(inputFiles) == 0:
+            # nothing to do
+            return
+
         # Open all input files as a single dataset
         self.logger.info(
             f'Opening input files with xarray: {inputFiles[0]} ... '


### PR DESCRIPTION
When recomputing the conservation analysis (e.g. in a main vs. control run or if analysis successfully ran previously), we can end up with an empty list of remaining inputs to process.  In this case, we should just move on rather than trying to print the empty list.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

