### PR TITLE
Fix hangs in ocean conservation

### DIFF
--- a/mpas_analysis/ocean/conservation.py
+++ b/mpas_analysis/ocean/conservation.py
@@ -769,6 +769,9 @@ class ConservationTask(AnalysisTask):
         unique_indices = sorted(unique_indices)  # Ensure ascending order
         ds = ds.isel(Time=unique_indices)
 
+        # seeing hanging during saving.  Let's try loading
+        ds.load()
+
         if append:
             # Load the existing dataset and combine it with the new dataset
             self.logger.info(
@@ -784,6 +787,9 @@ class ConservationTask(AnalysisTask):
         # Sort by `xtime` to ensure the time series is in ascending order
         self.logger.info('Sorting by xtime...')
         ds = ds.sortby('xtime')
+
+        # again, seeing hanging during saving.  Let's try loading
+        ds.load()
 
         # Save the resulting dataset to the output file
         self.logger.info(


### PR DESCRIPTION
A recent change (#1080) switched to using xarray to concatinate ocean conservation data together.  However, recent testing showed hangs if the datasets are not manually loaded.  This merge adds 2 places where such manual loads are included.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

