### PR TITLE
Switch CI from miniconda to micromamba

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -53,21 +53,22 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: "mpas_analysis_ci"
-          miniforge-version: latest
-          channels: conda-forge
-          channel-priority: strict
-          auto-update-conda: false
-          python-version: ${{ matrix.python-version }}
+          environment-name: mpas_analysis_dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels:
+                - conda-forge
+          create-args: >-
+            python=${{ matrix.python-version }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install mpas_analysis
         run: |
-          conda create -n mpas_analysis_dev --file dev-spec.txt \
-              python=${{ matrix.python-version }}
-          conda activate mpas_analysis_dev
+          conda install -y --file dev-spec.txt \
+            python=${{ matrix.python-version }}
           python -m pip install --no-deps --no-build-isolation -vv -e .
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
@@ -76,7 +77,6 @@ jobs:
            CHECK_IMAGES: False
         run: |
           set -e
-          conda activate mpas_analysis_dev
           pip check
           pytest --pyargs mpas_analysis
           mpas_analysis --help
@@ -85,7 +85,6 @@ jobs:
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Build Sphinx Docs
         run: |
-          conda activate mpas_analysis_dev
           # sphinx-multiversion expects at least a "main" branch
           git branch main || echo "branch main already exists."
           cd docs

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -37,28 +37,28 @@ jobs:
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Set up Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: "mpas_analysis_ci"
-          miniforge-version: latest
-          channels: conda-forge
-          channel-priority: strict
-          auto-update-conda: false
-          python-version: ${{ env.PYTHON_VERSION }}
+          environment-name: mpas_analysis_dev
+          init-shell: bash
+          condarc: |
+            channel_priority: strict
+            channels: 
+                - conda-forge
+          create-args: >-
+            python=${{ env.PYTHON_VERSION }}
 
       - if: ${{ steps.skip_check.outputs.should_skip != 'true' }}
         name: Install mpas_analysis
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-          conda create -n mpas_analysis_dev --file dev-spec.txt \
+          conda install -y --file dev-spec.txt \
             python=${{ env.PYTHON_VERSION }}
-          conda activate mpas_analysis_dev
           python -m pip install -vv --no-deps --no-build-isolation -e .
 
       - name: Build Sphinx Docs
         run: |
           set -e
-          conda activate mpas_analysis_dev
           pip check
           mpas_analysis sync diags --help
           cd docs
@@ -66,7 +66,6 @@ jobs:
       - name: Copy Docs and Commit
         run: |
           set -e
-          conda activate mpas_analysis_dev
           pip check
           mpas_analysis sync diags --help
           cd docs


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->
This PR switches CI to use the `setup-micromamba` GitHub action instead of the `setup-miniconda` GitHub action, in an effort to fix CI crashes caused by the latest `miniconda` version. 
<!--
Below are a few things we ask you or your reviewers to kindly check. 
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] Documentation has been [built locally](https://docs.e3sm.org/mache/main/developers_guide/building_docs.html) and changes look as expected
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

