### PR TITLE
Transpose transect obs dims to match model dims

### DIFF
--- a/mpas_analysis/ocean/plot_transect_subtask.py
+++ b/mpas_analysis/ocean/plot_transect_subtask.py
@@ -434,6 +434,8 @@ class PlotTransectSubtask(AnalysisTask):
             bias = None
         else:
             refOutput = remappedRefClimatology[self.refFieldName]
+            # make sure the dimension order is the same
+            refOutput = refOutput.transpose(*modelOutput.dims)
             bias = modelOutput - refOutput
 
         filePrefix = self.filePrefix


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

Following #1092, the observational data on some transects is transposed compared with that from the model, leading to problems when plotting both together as contours.  This merge fixes the issue by transposing observations to match the model.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

