### PR TITLE
Add task for plotting maps of wind stress curl

### DIFF
--- a/mpas_analysis/__main__.py
+++ b/mpas_analysis/__main__.py
@@ -189,6 +189,11 @@ def build_analysis_list(config, controlConfig):
     analyses.append(ocean.ClimatologyMapCustom(
         config, oceanClimatologyTasks['avg'], controlConfig))
 
+
+    analyses.append(ocean.ClimatologyMapWindStressCurl(
+        config, oceanClimatologyTasks['avg'], controlConfig)
+    )
+
     analyses.append(ocean.ConservationTask(
         config, controlConfig))
 

--- a/mpas_analysis/default.cfg
+++ b/mpas_analysis/default.cfg
@@ -1691,6 +1691,37 @@ makeTables = False
 iceShelvesInTable = []
 
 
+[climatologyMapWindStressCurl]
+## options related to plotting horizontally remapped climatologies of
+## wind stress curl against control model results
+
+# colormap for model/observations
+colormapNameResult = cmo.curl
+# whether the colormap is indexed or continuous
+colormapTypeResult = continuous
+# color indices into colormapName for filled contours
+# the type of norm used in the colormap
+normTypeResult = linear
+# A dictionary with keywords for the norm
+normArgsResult = {'vmin': -1e-6, 'vmax': 1e-6}
+
+# colormap for differences
+colormapNameDifference = cmo.balance
+# whether the colormap is indexed or continuous
+colormapTypeDifference = continuous
+# the type of norm used in the colormap
+normTypeDifference = linear
+# A dictionary with keywords for the norm
+normArgsDifference = {'vmin': -2e-7, 'vmax': 2e-7}
+
+# Months or seasons to plot (Jan, Feb, Mar, Apr, May, Jun, Jul, Aug, Sep, Oct,
+# Nov, Dec, JFM, AMJ, JAS, OND, ANN)
+seasons =  ['ANN']
+
+# comparison grid(s) on which to plot analysis
+comparisonGrids = ['latlon']
+
+
 [timeSeriesAntarcticMelt]
 ## options related to plotting time series of melt below Antarctic ice shelves
 

--- a/mpas_analysis/ocean/__init__.py
+++ b/mpas_analysis/ocean/__init__.py
@@ -29,6 +29,10 @@ from mpas_analysis.ocean.climatology_map_custom import (
    ClimatologyMapCustom
 )
 
+from mpas_analysis.ocean.climatology_map_wind_stress_curl import (
+   ClimatologyMapWindStressCurl
+)
+
 from mpas_analysis.ocean.conservation import ConservationTask
 
 from mpas_analysis.ocean.time_series_temperature_anomaly import \

--- a/mpas_analysis/ocean/climatology_map_wind_stress_curl.py
+++ b/mpas_analysis/ocean/climatology_map_wind_stress_curl.py
@@ -1,0 +1,212 @@
+# This software is open source software available under the BSD-3 license.
+#
+# Copyright (c) 2022 Triad National Security, LLC. All rights reserved.
+# Copyright (c) 2022 Lawrence Livermore National Security, LLC. All rights
+# reserved.
+# Copyright (c) 2022 UT-Battelle, LLC. All rights reserved.
+#
+# Additional copyright and license information can be found in the LICENSE file
+# distributed with this code, or at
+# https://raw.githubusercontent.com/MPAS-Dev/MPAS-Analysis/main/LICENSE
+
+import xarray as xr
+
+from mpas_tools.ocean.streamfunction.vorticity import (
+    compute_vertically_integrated_vorticity,
+)
+
+from mpas_analysis.ocean.utility import (
+    vector_cell_to_edge_isotropic,
+    vector_to_edge_normal,
+)
+from mpas_analysis.shared import AnalysisTask
+from mpas_analysis.shared.climatology import RemapMpasClimatologySubtask
+from mpas_analysis.shared.plot import PlotClimatologyMapSubtask
+
+
+class ClimatologyMapWindStressCurl(AnalysisTask):
+    """
+    An analysis task for computing and plotting maps of the wind stress curl.
+    """
+
+    def __init__(self, config, mpas_climatology_task, control_config=None):
+        """
+        Construct the analysis task.
+
+        Parameters
+        ----------
+        config : mpas_tools.config.MpasConfigParser
+            Configuration options
+
+        mpas_climatology_task : mpas_analysis.shared.climatology.MpasClimatologyTask
+            The task that produced the climatology to be remapped and plotted
+
+        control_config : mpas_tools.config.MpasConfigParser, optional
+            Configuration options for a control run (if any)
+        """  # noqa: E501
+
+        field_name = 'windStressCurl'
+        super().__init__(
+            config=config,
+            taskName='climatologyMapWindStressCurl',
+            componentName='ocean',
+            tags=[
+                'climatology', 'horizontalMap', field_name, 'publicObs'
+            ],
+        )
+
+        section_name = self.taskName
+
+        # read in what seasons we want to plot
+        seasons = config.getexpression(section_name, 'seasons')
+        if len(seasons) == 0:
+            raise ValueError(
+                f'config section {section_name} does not contain '
+                f'valid list of seasons'
+            )
+
+        comparison_grid_names = config.getexpression(
+            section_name, 'comparisonGrids'
+        )
+
+        if len(comparison_grid_names) == 0:
+            raise ValueError(
+                f'config section {section_name} does not contain '
+                f'valid list of comparison grids'
+            )
+
+        variable_list = list(RemapMpasWindStressCurl.VARIABLES)
+        remap_climatology_subtask = RemapMpasWindStressCurl(
+            mpasClimatologyTask=mpas_climatology_task,
+            parentTask=self,
+            climatologyName=field_name,
+            variableList=variable_list,
+            seasons=seasons,
+            comparisonGridNames=comparison_grid_names,
+            subtaskName='remapWindStressCurl',
+            vertices=True,
+        )
+
+        self.add_subtask(remap_climatology_subtask)
+
+        out_file_label = field_name
+        field_title = 'Wind Stress Curl'
+        remap_observations_subtask = None
+
+        mpas_field_name = field_name
+        if control_config is None:
+            ref_field_name = None
+            ref_title_label = None
+            diff_title_label = 'Model - Observations'
+
+        else:
+            control_run_name = control_config.get('runs', 'mainRunName')
+            ref_field_name = mpas_field_name
+            ref_title_label = f'Control: {control_run_name}'
+            diff_title_label = 'Main - Control'
+
+        for comparison_grid_name in comparison_grid_names:
+            for season in seasons:
+                # make a new subtask for this season and comparison grid
+                subtask_name = f'plot{season}_{comparison_grid_name}'
+
+                subtask = PlotClimatologyMapSubtask(
+                    self, season, comparison_grid_name,
+                    remap_climatology_subtask, remap_observations_subtask,
+                    controlConfig=control_config, subtaskName=subtask_name)
+                subtask.set_plot_info(
+                    outFileLabel=out_file_label,
+                    fieldNameInTitle=field_title,
+                    mpasFieldName=mpas_field_name,
+                    refFieldName=ref_field_name,
+                    refTitleLabel=ref_title_label,
+                    diffTitleLabel=diff_title_label,
+                    unitsLabel=r'N m$^{-3}$ $s^{-1}$',
+                    imageCaption=field_title,
+                    galleryGroup='Wind Stress Curl',
+                    groupSubtitle=None,
+                    groupLink='wsc',
+                    galleryName=None,
+                    configSectionName=section_name)
+
+                self.add_subtask(subtask)
+
+
+class RemapMpasWindStressCurl(RemapMpasClimatologySubtask):
+    """
+    A subtask for computing climatologies of the wind stress curl before
+    it gets remapped to a comparison grid.
+    """
+
+    VARIABLES = (
+        'timeMonthly_avg_windStressZonal',
+        'timeMonthly_avg_windStressMeridional',
+    )
+
+    def setup_and_check(self):
+        """
+        Add the variables needed for computing wind stress curl to the
+        climatology task
+        """
+        super().setup_and_check()
+
+        # Add the variables and seasons, now that we have the variable list
+        self.mpasClimatologyTask.add_variables(
+            list(self.VARIABLES), self.seasons
+        )
+
+    def customize_masked_climatology(self, climatology, season):
+        """
+        Compute the wind stress curl and add it to the climatology.
+
+        Parameters
+        ----------
+        climatology : xarray.Dataset
+            the climatology data set
+
+        season : str
+            The name of the season to be masked
+
+        Returns
+        -------
+        climatology : xarray.Dataset
+            the modified climatology data set
+        """
+        logger = self.logger
+
+        ds_mesh = xr.open_dataset(self.restartFileName)
+        var_list = [
+            'verticesOnEdge',
+            'cellsOnVertex',
+            'kiteAreasOnVertex',
+            'angleEdge',
+            'areaTriangle',
+            'dcEdge',
+            'edgesOnVertex',
+            'verticesOnEdge',
+            'latVertex',
+        ]
+        ds_mesh = ds_mesh[var_list]
+
+        ws_zonal_cell = climatology['timeMonthly_avg_windStressZonal']
+        ws_meridional_cell = (
+            climatology['timeMonthly_avg_windStressMeridional']
+        )
+        ws_zonal_edge, ws_meridional_edge = vector_cell_to_edge_isotropic(
+            ds_mesh, ws_zonal_cell, ws_meridional_cell
+        )
+        ws_normal_edge = vector_to_edge_normal(
+            ds_mesh, ws_zonal_edge, ws_meridional_edge
+        )
+
+        # despite the name, this is the curl operator
+        wind_sress_curl, _ = compute_vertically_integrated_vorticity(
+            ds_mesh, ws_normal_edge, logger
+        )
+        climatology['windStressCurl'] = wind_sress_curl
+        climatology['windStressCurl'].attrs['units'] = 'N m-3 s-1'
+
+        # drop the original wind stress variables
+        climatology = climatology.drop_vars(list(self.VARIABLES))
+
+        return climatology

--- a/mpas_analysis/polar_regions.cfg
+++ b/mpas_analysis/polar_regions.cfg
@@ -788,6 +788,15 @@ makeTables = True
 # ['all'] for all 106 ice shelves and regions.
 iceShelvesInTable = ['all']
 
+
+[climatologyMapWindStressCurl]
+## options related to plotting horizontally remapped climatologies of
+## wind stress curl against control model results
+
+# comparison grid(s) on which to plot analysis
+comparisonGrids = ['latlon', 'arctic_extended', 'antarctic_extended']
+
+
 [timeSeriesTransport]
 ## options related to plotting time series of transport through transects
 transportGroups = ['Transport Transects', 'Arctic Transport Transects']


### PR DESCRIPTION
The wind stress curl is first computed on the native grid (at vertices) and then is remapped to comparison grids.

The reconstruciton of the wind stress at edges is computed with a utility funciton `vector_cell_to_edge_isotropic()`, analogous to the subroutine with the same name in the MPAS framework.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] If this PR adds a new analysis task, it has also been added to the user's guide
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://mpas-dev.github.io/MPAS-Analysis/develop/users_guide/quick_start.html#generating-documentation) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

