### PR TITLE
Update to mpas_tools >=1.3.0

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - lxml
     - mache >=1.11.0
     - matplotlib-base >=3.9.0
-    - mpas_tools >=1.2.2,<2.0.0
+    - mpas_tools >=1.3.0,<2.0.0
     - nco >=4.8.1,!=5.2.6
     - netcdf4
     - numpy >=2.0,<3.0

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -15,7 +15,7 @@ gsw
 lxml
 mache >=1.11.0
 matplotlib-base>=3.9.0
-mpas_tools >=1.2.2,<2.0.0
+mpas_tools >=1.3.0,<2.0.0
 nco>=4.8.1,!=5.2.6
 netcdf4
 numpy>=2.0,<3.0

--- a/mpas_analysis/shared/io/write_netcdf.py
+++ b/mpas_analysis/shared/io/write_netcdf.py
@@ -56,4 +56,10 @@ def write_netcdf_with_fill(ds, fileName, fillValues=netCDF4.default_fillvals):
         if dtype.type is numpy.bytes_:
             encodingDict[variableName] = {'dtype': str}
 
+    unlimited_dims = ds.encoding.get('unlimited_dims', None)
+    if unlimited_dims is not None:
+        if isinstance(unlimited_dims, str):
+            unlimited_dims = {unlimited_dims}
+        unlimited_dims = [dim for dim in unlimited_dims if dim in ds.dims]
+        ds.encoding['unlimited_dims'] = set(unlimited_dims)
     ds.to_netcdf(fileName, encoding=encodingDict)


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This PR also drops unlimited_dims if they aren't in the dataset.  Both of these updates are intended to handle a recent regression in `xarray` in which `unlimited_dims` present in the encoding dictionary but not in the dataset itself raise an error.  This frequently occurs when slicing the `Time` dimension in MPAS datasets.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

