### PR TITLE
Time series edits

### DIFF
--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -349,6 +349,8 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):
         dsMesh = xr.open_dataset(meshFilename)
         dsMesh = dsMesh.isel(Time=0)
         areaCell = dsMesh.areaCell
+        landIceFloatingMask = dsMesh.landIceFloatingMask.isel(Time=0)
+        landIceFloatingMask = -1*(landIceFloatingMask-1)
 
         nVertLevels = dsMesh.sizes['nVertLevels']
 
@@ -407,7 +409,14 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):
                 prefix = field['prefix']
                 self.logger.info('      {}'.format(field['titleName']))
 
-                var = dsLocal[variableName].where(vertDepthMask)
+                var_mpas = dsLocal[variableName]
+                print('DIMS-------------')
+                print(var_mpas.dims)
+                print(landIceFloatingMask.dims)
+                var_mpas_masked = var_mpas*landIceFloatingMask
+                print(var_mpas_masked.dims)
+                var = var_mpas_masked.where(vertDepthMask)
+                print(var.dims)
 
                 meanName = '{}_mean'.format(prefix)
                 dsLocal[meanName] = \

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -349,7 +349,7 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):
         dsMesh = xr.open_dataset(meshFilename)
         dsMesh = dsMesh.isel(Time=0)
         areaCell = dsMesh.areaCell
-        landIceFraction = dsMesh.landIceFraction.isel(Time=0)
+        landIceFraction = dsMesh.landIceFraction
         landIceFraction = xr.where(landIceFraction > 0, 1, landIceFraction)
         landIceFraction = -1*(landIceFraction-1)
 

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -349,8 +349,9 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):
         dsMesh = xr.open_dataset(meshFilename)
         dsMesh = dsMesh.isel(Time=0)
         areaCell = dsMesh.areaCell
-        landIceFloatingMask = dsMesh.landIceFloatingMask.isel(Time=0)
-        landIceFloatingMask = -1*(landIceFloatingMask-1)
+        landIceFraction = dsMesh.landIceFraction.isel(Time=0)
+        landIceFraction = xr.where(landIceFraction > 0, 1, landIceFraction)
+        landIceFraction = -1*(landIceFraction-1)
 
         nVertLevels = dsMesh.sizes['nVertLevels']
 
@@ -412,8 +413,8 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):
                 var_mpas = dsLocal[variableName]
                 print('DIMS-------------')
                 print(var_mpas.dims)
-                print(landIceFloatingMask.dims)
-                var_mpas_masked = var_mpas*landIceFloatingMask
+                print(landIceFraction.dims)
+                var_mpas_masked = var_mpas*landIceFraction
                 print(var_mpas_masked.dims)
                 var = var_mpas_masked.where(vertDepthMask)
                 print(var.dims)

--- a/mpas_analysis/ocean/ocean_regional_profiles.py
+++ b/mpas_analysis/ocean/ocean_regional_profiles.py
@@ -411,13 +411,8 @@ class ComputeRegionalProfileTimeSeriesSubtask(AnalysisTask):
                 self.logger.info('      {}'.format(field['titleName']))
 
                 var_mpas = dsLocal[variableName]
-                print('DIMS-------------')
-                print(var_mpas.dims)
-                print(landIceFraction.dims)
                 var_mpas_masked = var_mpas*landIceFraction
-                print(var_mpas_masked.dims)
                 var = var_mpas_masked.where(vertDepthMask)
-                print(var.dims)
 
                 meanName = '{}_mean'.format(prefix)
                 dsLocal[meanName] = \

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -790,7 +790,7 @@ class PlotMeltSubtask(AnalysisTask):
         plt.tight_layout()
 
         #add_inset(fig, fc, width=2.0, height=2.0)
-        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.01, ybuffer=0.01)
+        add_inset(fig, fc, width=1.0, height=1.0, lowerleft=[0.0, 0.0], xbuffer=0.01, ybuffer=0.01)
 
         savefig(outFileName, config)
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -723,7 +723,7 @@ class PlotMeltSubtask(AnalysisTask):
         # and cartopy doesn't play too well with tight_layout anyway
         plt.tight_layout()
 
-        add_inset(fig, fc, width=2.0, height=2.0)
+        #add_inset(fig, fc, width=2.0, height=2.0)
 
         savefig(outFileName, config)
 
@@ -788,7 +788,7 @@ class PlotMeltSubtask(AnalysisTask):
         # and cartopy doesn't play too well with tight_layout anyway
         plt.tight_layout()
 
-        add_inset(fig, fc, width=2.0, height=2.0)
+        #add_inset(fig, fc, width=2.0, height=2.0)
 
         savefig(outFileName, config)
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -724,6 +724,7 @@ class PlotMeltSubtask(AnalysisTask):
         plt.tight_layout()
 
         #add_inset(fig, fc, width=2.0, height=2.0)
+        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.1, ybuffer=0.1)
 
         savefig(outFileName, config)
 
@@ -789,6 +790,7 @@ class PlotMeltSubtask(AnalysisTask):
         plt.tight_layout()
 
         #add_inset(fig, fc, width=2.0, height=2.0)
+        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.1, ybuffer=0.1)
 
         savefig(outFileName, config)
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -724,7 +724,7 @@ class PlotMeltSubtask(AnalysisTask):
         plt.tight_layout()
 
         #add_inset(fig, fc, width=2.0, height=2.0)
-        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.01, ybuffer=0.01)
+        add_inset(fig, fc, width=1.0, height=1.0, lowerleft=[0.0, 0.0], xbuffer=0.01, ybuffer=0.01)
 
         savefig(outFileName, config)
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -724,7 +724,7 @@ class PlotMeltSubtask(AnalysisTask):
         plt.tight_layout()
 
         #add_inset(fig, fc, width=2.0, height=2.0)
-        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.1, ybuffer=0.1)
+        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.3, ybuffer=0.3)
 
         savefig(outFileName, config)
 
@@ -790,7 +790,7 @@ class PlotMeltSubtask(AnalysisTask):
         plt.tight_layout()
 
         #add_inset(fig, fc, width=2.0, height=2.0)
-        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.1, ybuffer=0.1)
+        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.3, ybuffer=0.3)
 
         savefig(outFileName, config)
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -724,7 +724,7 @@ class PlotMeltSubtask(AnalysisTask):
         plt.tight_layout()
 
         #add_inset(fig, fc, width=2.0, height=2.0)
-        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.3, ybuffer=0.3)
+        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.01, ybuffer=0.01)
 
         savefig(outFileName, config)
 
@@ -790,7 +790,7 @@ class PlotMeltSubtask(AnalysisTask):
         plt.tight_layout()
 
         #add_inset(fig, fc, width=2.0, height=2.0)
-        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.3, ybuffer=0.3)
+        add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.01, ybuffer=0.01)
 
         savefig(outFileName, config)
 

--- a/mpas_analysis/ocean/time_series_antarctic_melt.py
+++ b/mpas_analysis/ocean/time_series_antarctic_melt.py
@@ -342,7 +342,7 @@ class ComputeMeltSubtask(AnalysisTask):
 
         dsOut = xarray.concat(objs=datasets, dim='Time')
         dsOut['regionNames'] = dsRegionMask.regionNames
-        dsOut.integratedMeltFlux.attrs['units'] = 'GT a$^{-1}$'
+        dsOut.integratedMeltFlux.attrs['units'] = 'Gt a$^{-1}$'
         dsOut.integratedMeltFlux.attrs['description'] = \
             'Integrated melt flux summed over each ice shelf or region'
         dsOut.meltRates.attrs['units'] = 'm a$^{-1}$'
@@ -662,7 +662,7 @@ class PlotMeltSubtask(AnalysisTask):
         suffix = self.iceShelf.replace(' ', '_')
 
         xLabel = 'Time (yr)'
-        yLabel = 'Melt Flux (GT/yr)'
+        yLabel = 'Melt Flux (Gt/yr)'
 
         timeSeries = integratedMeltFlux.isel(nRegions=self.regionIndex)
 

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -1350,7 +1350,7 @@ class PlotRegionTimeSeriesSubtask(AnalysisTask):
             # and cartopy doesn't play too well with tight_layout anyway
             plt.tight_layout()
 
-            add_inset(fig, fc, width=2.0, height=2.0)
+            #add_inset(fig, fc, width=2.0, height=2.0)
 
             savefig(outFileName, config, tight=False)
 

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -1351,7 +1351,7 @@ class PlotRegionTimeSeriesSubtask(AnalysisTask):
             plt.tight_layout()
 
             #add_inset(fig, fc, width=2.0, height=2.0)
-            add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.01, ybuffer=0.01)
+            add_inset(fig, fc, width=1.0, height=1.0, lowerleft=[0.0, 0.0], xbuffer=0.01, ybuffer=0.01)
 
             savefig(outFileName, config, tight=False)
 

--- a/mpas_analysis/ocean/time_series_ocean_regions.py
+++ b/mpas_analysis/ocean/time_series_ocean_regions.py
@@ -1351,6 +1351,7 @@ class PlotRegionTimeSeriesSubtask(AnalysisTask):
             plt.tight_layout()
 
             #add_inset(fig, fc, width=2.0, height=2.0)
+            add_inset(fig, fc, width=1.0, height=1.0, xbuffer=0.01, ybuffer=0.01)
 
             savefig(outFileName, config, tight=False)
 


### PR DESCRIPTION
Small changes to time series:

-Moved map inset on time series to lower left corner so that it doesn't hide the time series
-Changed units GT to Gt for melt flux
-Masked out ice-shelf cavities for calculating regional profiles and tasks depending on those, like Hovmoller. The reason for that is coordinate distortion in the cavities which can be an issue for interpreting layer averaged quantities.

Mpas-analysis for melt rate timeseries:

https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.vankova/analysis/Sv2p1/diff_melt/SSP3-ENS/clim_2015-2100_ts_2015-2100/html/ocean/index.html

for Hovmoller:

This is with changes:
https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.vankova/analysis/Sv2p1/hov12/SSP3-ENS/clim_2015-2100_ts_2015-2100/html/ocean/index.html#ocnreghovs_antarcticregions&gid=9&pid=4
This is prior to changes:
https://web.lcrc.anl.gov/public/e3sm/diagnostic_output/ac.dcomeau/E3SMv2_1/v2_1.SORRM.ssp370_ensmean/yrs2081-2100_bt/ocean/index.html#ocnreghovs_antarcticregions&gid=135&pid=4




<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [ ] User's Guide has been updated
* [ ] If this PR adds a new analysis task, it has also been added to the user's guide
* [ ] Developer's Guide has been updated
* [ ] API documentation in the Developer's Guide (`api.rst`) has any new or modified class, method and/or functions listed
* [ ] Documentation has been [built locally](https://mpas-dev.github.io/MPAS-Analysis/develop/users_guide/quick_start.html#generating-documentation) and changes look as expected
* [ ] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

