### PR TITLE
Update unified suite to use python 3.13

### DIFF
--- a/suite/run_e3sm_unified_suite.bash
+++ b/suite/run_e3sm_unified_suite.bash
@@ -6,7 +6,7 @@ set -e
 branch=test_e3sm_unified
 
 # test building the docs
-py=3.10
+py=3.13
 machine=${E3SMU_MACHINE}
 
 ./suite/setup.py -p ${py} -r main_py${py} -b ${branch} --clean


### PR DESCRIPTION
This is just in the name of the `main` run and has no actual bearing on the python version used to deploy Unified. But for clarity, it would be better if it is correct.