### PR TITLE
Drop python 3.14 support for now

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -27,7 +27,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     steps:
       - id: skip_check

--- a/.github/workflows/docs_workflow.yml
+++ b/.github/workflows/docs_workflow.yml
@@ -10,7 +10,7 @@ on:
     types: [published]
 
 env:
-  PYTHON_VERSION: "3.14"
+  PYTHON_VERSION: "3.13"
 
 jobs:
   publish-docs:

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pip
     - setuptools >=60
   run:
-    - python >={{ python_min }},<3.13
+    - python >={{ python_min }},<3.14
     - cartopy >=0.18.0
     - cartopy_offlinedata
     - cmocean

--- a/dev-spec.txt
+++ b/dev-spec.txt
@@ -2,7 +2,7 @@
 # $ conda create --name <env> --file <this file>
 
 # Base
-python >=3.10
+python >=3.10,<3.14
 cartopy >=0.18.0
 cartopy_offlinedata
 cmocean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
 
 
     "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ description = """\
     """
 license = { file = "LICENSE" }
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.14"
 classifiers = [
     # these are only for searching/browsing projects on PyPI
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
We are seeing issues with networkx that need to be resolved by a new python 3.14 release

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

