### PR TITLE
Fix sea ice time series cache masking bug

### DIFF
--- a/mpas_analysis/sea_ice/time_series.py
+++ b/mpas_analysis/sea_ice/time_series.py
@@ -695,8 +695,8 @@ class TimeSeriesSeaIce(AnalysisTask):
                                       ds.iceThick <= maxAllowedSeaIceThickness)
             if os.path.exists(outFileNames[hemisphere]):
                 dsCache = xr.open_dataset(outFileNames[hemisphere])
-                timeMask = ds.startTime > dsCache.startTime.isel(Time=-1)
-                ds = ds.isel(Time=timeMask)
+                timeMask = np.argwhere(ds.startTime.values > dsCache.startTime.isel(Time=-1).values)
+                ds = ds.isel(Time=timeMask[:,0])
 
             dsAreaSum = (ds.where(mask) * dsMesh.areaCell).sum('nCells')
             dsAreaSum = dsAreaSum.rename(


### PR DESCRIPTION
There seem to be cases where a boolean mask to xarray.Dataset's isel is an issue. This PR changes the boolean mask to a list of time integers.