### PR TITLE
Fix updating z coord of remapped transects

### DIFF
--- a/mpas_analysis/ocean/sose_transects.py
+++ b/mpas_analysis/ocean/sose_transects.py
@@ -379,7 +379,7 @@ class SoseTransectsObservations(TransectsObservations):
 
         # make a copy of the top set of data at z=0
         dsObs = xr.concat((dsObs.isel(z=0), dsObs), dim='z')
-        z = dsObs.z.values
+        z = dsObs.z.values.copy()
         z[0] = 0.
         dsObs['z'] = ('z', z)
         write_netcdf_with_fill(dsObs, combinedFileName)


### PR DESCRIPTION
We were trying to modify a read-only view of the transect's z array, but we need to make a copy.

<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

