### PR TITLE
Several fixes to global plots

### DIFF
--- a/mpas_analysis/ocean/climatology_map_fluxes.py
+++ b/mpas_analysis/ocean/climatology_map_fluxes.py
@@ -142,7 +142,7 @@ class ClimatologyMapFluxes(AnalysisTask):
                         unitsLabel = r'W m$^{-2}$'
                     else:
                         groupSubtitle = 'Mass fluxes'
-                        unitsLabel = r'kg m$^{-2}$ s^${-1}$'
+                        unitsLabel = r'kg m$^{-2}$ s$^{-1}$'
 
                     subtask.set_plot_info(
                         outFileLabel=outFileName,

--- a/mpas_analysis/shared/plot/climatology_map.py
+++ b/mpas_analysis/shared/plot/climatology_map.py
@@ -800,12 +800,12 @@ def _add_stats(modelArray, refArray, diffArray, Lats, axes):
 
 def _add_stats_text(names, values, ax, loc):
     if loc == 'upper':
-        text_ax = inset_axes(ax, width='17%', height='20%', loc='upper right',
-                             bbox_to_anchor=(0.2, 0.1, 1., 1.),
+        text_ax = inset_axes(ax, width='19%', height='20%', loc='upper right',
+                             bbox_to_anchor=(0.22, 0.1, 1., 1.),
                              bbox_transform=ax.transAxes, borderpad=0)
     else:
-        text_ax = inset_axes(ax, width='17%', height='20%', loc='lower right',
-                             bbox_to_anchor=(0.2, 0.03, 1., 1.),
+        text_ax = inset_axes(ax, width='19%', height='20%', loc='lower right',
+                             bbox_to_anchor=(0.22, 0.03, 1., 1.),
                              bbox_transform=ax.transAxes, borderpad=0)
 
     text = '\n'.join(names)

--- a/mpas_analysis/shared/plot/climatology_map.py
+++ b/mpas_analysis/shared/plot/climatology_map.py
@@ -414,6 +414,9 @@ def plot_global_comparison(
     plottitle_font = {'size': config.get('plot',
                                          'threePanelPlotTitleFontSize')}
 
+    multi_line_ref_title = (
+        refArray is not None and refTitle is not None and '\n' in refTitle)
+
     if refArray is None:
         subplots = [111]
     else:
@@ -427,20 +430,42 @@ def plot_global_comparison(
     dictDiff = setup_colormap(config, colorMapSectionName, suffix='Difference')
 
     axes = []
-    ax = plt.subplot(subplots[0], projection=projection)
-    _plot_panel(ax, modelTitle, modelArray, **dictModelRef)
-    axes.append(ax)
+    if refArray is not None and multi_line_ref_title:
+        # Use a GridSpec with unequal gaps but equal-sized panels
+        gs = fig.add_gridspec(
+            nrows=5,
+            ncols=1,
+            height_ratios=[1.0, 0.18, 1.0, 0.08, 1.0])
 
-    if refArray is not None:
-        ax = plt.subplot(subplots[1], projection=projection)
+        ax = fig.add_subplot(gs[0, 0], projection=projection)
+        _plot_panel(ax, modelTitle, modelArray, **dictModelRef)
+        axes.append(ax)
+
+        ax = fig.add_subplot(gs[2, 0], projection=projection)
         _plot_panel(ax, refTitle, refArray, **dictModelRef)
         axes.append(ax)
 
-        ax = plt.subplot(subplots[2], projection=projection)
+        ax = fig.add_subplot(gs[4, 0], projection=projection)
         _plot_panel(ax, diffTitle, diffArray, **dictDiff)
         axes.append(ax)
+    else:
+        ax = plt.subplot(subplots[0], projection=projection)
+        _plot_panel(ax, modelTitle, modelArray, **dictModelRef)
+        axes.append(ax)
+
+        if refArray is not None:
+            ax = plt.subplot(subplots[1], projection=projection)
+            _plot_panel(ax, refTitle, refArray, **dictModelRef)
+            axes.append(ax)
+
+            ax = plt.subplot(subplots[2], projection=projection)
+            _plot_panel(ax, diffTitle, diffArray, **dictDiff)
+            axes.append(ax)
 
     _add_stats(modelArray, refArray, diffArray, Lats, axes)
+
+    # Note: in the multi-line reference-title case, uneven spacing is handled
+    # via GridSpec so all three panels keep identical sizes.
 
     if fileout is not None:
         savefig(fileout, config, pad_inches=0.2)

--- a/suite/main_vs_ctrl.cfg
+++ b/suite/main_vs_ctrl.cfg
@@ -7,10 +7,3 @@
 # control run is desired.
 controlRunConfigFile = ../ctrl.cfg
 
-# config file for a main run on which the analysis was already run to
-# completion.  The relevant MPAS climatologies already exist and have been
-# remapped to the comparison grid and time series have been extracted.
-# Leave this option commented out if the analysis for the main run should be
-# performed.
-mainRunConfigFile = ../main.cfg
-

--- a/suite/run_dev_suite.bash
+++ b/suite/run_dev_suite.bash
@@ -25,7 +25,6 @@ py=$(python -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}"
 ./suite/setup.py -p ${py} -r wc_defaults -b ${branch} --no_polar_regions -e ${env_name}
 ./suite/setup.py -p ${py} -r moc_am -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r no_ncclimo -b ${branch} -e ${env_name}
-./suite/setup.py -p ${py} -r main -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r ctrl -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r main_vs_ctrl -b ${branch} -e ${env_name}
 ./suite/setup.py -p ${py} -r no_polar_regions -b ${branch} --no_polar_regions -e ${env_name}

--- a/suite/run_e3sm_unified_suite.bash
+++ b/suite/run_e3sm_unified_suite.bash
@@ -13,7 +13,6 @@ machine=${E3SMU_MACHINE}
 ./suite/setup.py -p ${py} -r wc_defaults -b ${branch} --no_polar_regions
 ./suite/setup.py -p ${py} -r moc_am -b ${branch}
 ./suite/setup.py -p ${py} -r no_ncclimo -b ${branch}
-./suite/setup.py -p ${py} -r main -b ${branch}
 ./suite/setup.py -p ${py} -r ctrl -b ${branch}
 ./suite/setup.py -p ${py} -r main_vs_ctrl -b ${branch}
 ./suite/setup.py -p ${py} -r no_polar_regions -b ${branch} --no_polar_regions

--- a/suite/run_suite.bash
+++ b/suite/run_suite.bash
@@ -59,7 +59,6 @@ conda deactivate
 
 py=${alt_py}
 conda activate test_mpas_analysis_py${py}
-./suite/setup.py -p ${py} -r main -b ${branch}
 ./suite/setup.py -p ${py} -r main_py${py} -b ${branch}
 conda deactivate
 

--- a/suite/setup.py
+++ b/suite/setup.py
@@ -91,8 +91,9 @@ def main():
         shutil.copytree(os.path.join('docs', '_build', 'html'), docs_path)
 
     if mesh == 'oQU240wLI':
-        generate = "['all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke', " \
-                   "'no_waves']"
+        generate = [
+            'all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke', 'no_waves'
+        ]
         end_year = '10'
         ctrl_end_year = '8'
     else:
@@ -103,6 +104,9 @@ def main():
 
     if args.run == 'main_vs_ctrl':
         end_year = ctrl_end_year
+        generate.append('no_hovmoller')
+
+    generate_string = f"['" + "', '".join(generate) + "']"
 
     sbatch = list()
     if account is not None:
@@ -140,7 +144,7 @@ def main():
         use_e3sm_unified=use_e3sm_unified, run_name=args.run,
         input_base=input_base, simulation=simulation, mesh=mesh,
         output_base=output_base, html_base=html_base, out_subdir=out_subdir,
-        generate=generate, end_year=end_year)
+        generate=generate_string, end_year=end_year)
     with open(config, 'w') as config_file:
         config_file.write(config_text)
 

--- a/suite/setup.py
+++ b/suite/setup.py
@@ -94,11 +94,15 @@ def main():
         generate = "['all', 'no_BGC', 'no_icebergs', 'no_index', 'no_eke', " \
                    "'no_waves']"
         end_year = '10'
+        ctrl_end_year = '8'
     else:
         raise ValueError(f'Unexpected mesh: {mesh}')
 
     if args.run == 'mesh_rename':
         mesh = f'new_{mesh}'
+
+    if args.run == 'main_vs_ctrl':
+        end_year = ctrl_end_year
 
     sbatch = list()
     if account is not None:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This merge fixes:
* the spacing for the two-line control title in global main vs. control plots
* the spacing of stats (min, max, mean, corr, etc.) for numbers in exponential notation
* the format of units for mass fluxes

To better test these fixes, the suites have been updated so the "main" run in the `main_vs_ctrl` test use year 8 as the end year, rather than 10 in the "control" run.  Since Hovmoller plots don't work with different time bounds, these have been disabled in the `main_vs_ctrl` test.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

Fixes #1135 