### PR TITLE
Fix test suite for e3sm-unified

### DIFF
--- a/suite/setup.py
+++ b/suite/setup.py
@@ -36,9 +36,9 @@ def main():
     account, partition, configuration, qos = \
         machine_info.get_account_defaults()
 
-    use_e3sm_unified = 'E3SMU_SCRIPT' in os.environ
+    use_e3sm_unified = 'E3SM_UNIFIED_LOAD_SCRIPT' in os.environ
     if use_e3sm_unified:
-        e3sm_unified_script = os.environ['E3SMU_SCRIPT']
+        e3sm_unified_script = os.environ['E3SM_UNIFIED_LOAD_SCRIPT']
         args.branch = \
             os.path.splitext(os.path.basename(e3sm_unified_script))[0]
     else:

--- a/suite/templates/job_script.bash
+++ b/suite/templates/job_script.bash
@@ -8,38 +8,33 @@
 
 set -e
 
-{% if use_e3sm_unified %}
+{% if use_e3sm_unified -%}
 source {{ e3sm_unified_script }}
 
 echo E3SM-Unified: {{ e3sm_unified_script }}
-{% elif pixi_env %}
+{% elif pixi_env -%}
 export HDF5_USE_FILE_LOCKING=FALSE
 export E3SMU_MACHINE={{ machine }}
 
-run_mpas_analysis() {
-    pixi run --manifest-path ../../pixi.toml -e {{ pixi_env }} mpas_analysis "$@"
-}
+eval "$(pixi shell-hook --manifest-path ../../pixi.toml -e {{ pixi_env }})"
 
 echo pixi env: {{ pixi_env }}
-{% else %}
+{% else -%}
 source {{ conda_base }}/etc/profile.d/conda.sh
 conda activate {{ conda_env }}
 export HDF5_USE_FILE_LOCKING=FALSE
 export E3SMU_MACHINE={{ machine }}
 
-run_mpas_analysis() {
-    mpas_analysis "$@"
-}
 
 echo env: {{ conda_env }}
-{% endif %}
+{% endif -%}
 echo configs: {{ flags }} {{ config }}
 
-run_mpas_analysis --list
-run_mpas_analysis --plot_colormaps
-run_mpas_analysis --setup_only {{ flags }} {{ config }}
-run_mpas_analysis --purge {{ flags }} {{ config }} --verbose
-run_mpas_analysis --html_only {{ flags }} {{ config }}
+mpas_analysis --list
+mpas_analysis --plot_colormaps
+mpas_analysis --setup_only {{ flags }} {{ config }}
+mpas_analysis --purge {{ flags }} {{ config }} --verbose
+mpas_analysis --html_only {{ flags }} {{ config }}
 
 chmod ugo+rx {{ html_base }}/{{ out_common_dir }}
 chmod -R ugo+rX {{ html_base }}/{{ out_subdir }}


### PR DESCRIPTION
<!--
Thank you for your pull request.
Please add a description of what is accomplished in the PR here at the top:
-->

This PR gets rid of the unneeded `run_mpas_analysis` command and just activating the pixi shell hooks.

It also uses the newer `E3SM_UNIFIED_LOAD_SCRIPT` environment variable since `E3SMU_SCRIPT` was wrong (since fixed).

I also clean up the blank lines that were being left by the jinja2 if/elif/endif lines.

<!--
Below are a few things we ask you or your reviewers to kindly check.
***Remove checks that are not relevant by deleting the line(s) below.***
-->
Checklist
* [x] `Testing` comment in the PR documents testing used to verify the changes

<!--
Please note any issues this fixes using closing keywords: https://help.github.com/articles/closing-issues-using-keywords
-->

